### PR TITLE
added truncate functionality to DB class, pushed it through to all implementors

### DIFF
--- a/db/cassandra-0.5/src/com/yahoo/ycsb/db/CassandraClient5.java
+++ b/db/cassandra-0.5/src/com/yahoo/ycsb/db/CassandraClient5.java
@@ -409,6 +409,12 @@ public class CassandraClient5 extends DB
 	}
 
 
+	@Override
+	public int truncate(String table) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
 	public static void main(String[] args)
 	{
 		CassandraClient5 cli=new CassandraClient5();

--- a/db/cassandra-0.6/src/com/yahoo/ycsb/db/CassandraClient6.java
+++ b/db/cassandra-0.6/src/com/yahoo/ycsb/db/CassandraClient6.java
@@ -422,6 +422,12 @@ public class CassandraClient6 extends DB
 	}
 
 
+	@Override
+	public int truncate(String table) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
 	public static void main(String[] args)
 	{
 		CassandraClient6 cli=new CassandraClient6();

--- a/db/cassandra-0.7/src/com/yahoo/ycsb/db/CassandraClient7.java
+++ b/db/cassandra-0.7/src/com/yahoo/ycsb/db/CassandraClient7.java
@@ -511,7 +511,50 @@ public class CassandraClient7 extends DB
     return Error;
   }
 
-  public static void main(String[] args)
+  @Override
+public int truncate(String table) {
+	  Exception errorexception = null;
+
+    try
+    {
+      client.set_keyspace(table);
+    } catch (Exception e)
+    {
+      e.printStackTrace();
+      e.printStackTrace(System.out);
+      return Error;
+    }
+
+    for (int i = 0; i < OperationRetries; i++)
+    {
+      try
+      {
+      	client.truncate(column_family);
+        
+        if (_debug)
+        {
+          System.out.println("TRUNCATE");
+        }
+
+        return Ok;
+      } catch (Exception e)
+      {
+        errorexception = e;
+      }
+      try
+      {
+        Thread.sleep(500);
+      } catch (InterruptedException e)
+      {
+      }
+    }
+    errorexception.printStackTrace();
+    errorexception.printStackTrace(System.out);
+    return Error;
+
+}
+
+public static void main(String[] args)
   {
     CassandraClient7 cli = new CassandraClient7();
 

--- a/db/hbase/src/com/yahoo/ycsb/db/HBaseClient.java
+++ b/db/hbase/src/com/yahoo/ycsb/db/HBaseClient.java
@@ -391,7 +391,13 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         return Ok;
     }
 
-    public static void main(String[] args)
+    @Override
+	public int truncate(String table) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	public static void main(String[] args)
     {
         if (args.length!=3)
         {

--- a/db/mongodb/src/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/db/mongodb/src/com/yahoo/ycsb/db/MongoDbClient.java
@@ -313,6 +313,31 @@ public class MongoDbClient extends DB {
 	
     }
 
+	@Override
+	public int truncate(String table) {
+		com.mongodb.DB db = null;
+        try {
+            db = mongo.getDB(database);
+
+            db.requestStart();
+
+            DBCollection collection = db.getCollection(table);
+            collection.drop();
+                        
+          
+            return 0;
+        } catch (Exception e) {
+        	System.out.println(e.toString());
+            logger.error(e + "", e);
+            return 1;
+        } finally {
+	   if (db!=null)
+	   {
+	      db.requestDone();
+	   }
+        }
+	}
+
 	
 
 }

--- a/db/voldemort/src/com/yahoo/ycsb/db/VoldemortClient.java
+++ b/db/voldemort/src/com/yahoo/ycsb/db/VoldemortClient.java
@@ -129,6 +129,12 @@ public class VoldemortClient extends DB {
 		return OK;
 	}
 	
+	@Override
+	public int truncate(String table) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
 	private int checkStore(String table) {
 		if ( table.compareTo(storeName) != 0) {
 			try {

--- a/src/com/yahoo/ycsb/BasicDB.java
+++ b/src/com/yahoo/ycsb/BasicDB.java
@@ -237,6 +237,17 @@ public class BasicDB extends DB
 		return 0;
 	}
 
+
+	@Override
+  public int truncate(String table) {
+	  if (verbose) 
+	  {
+	  	System.out.println("TRUNCATE "+table);
+	  }
+	  
+	  return 0;
+  }
+
 	/**
 	 * Short test of BasicDB
 	 */

--- a/src/com/yahoo/ycsb/DB.java
+++ b/src/com/yahoo/ycsb/DB.java
@@ -80,6 +80,13 @@ public abstract class DB
 	public void cleanup() throws DBException
 	{
 	}
+	
+	/**
+	 * removes all data from the specified table. 
+	 * @param table
+	 * @return
+	 */
+	public abstract int truncate(String table);
 
 	/**
 	 * Read a record from the database. Each field/value pair from the result will be stored in a HashMap.

--- a/src/com/yahoo/ycsb/DBWrapper.java
+++ b/src/com/yahoo/ycsb/DBWrapper.java
@@ -165,4 +165,17 @@ public class DBWrapper extends DB
 		_measurements.reportReturnCode("DELETE",res);
 		return res;
 	}
+
+	/**
+	 * truncate the specified table. NOTE that actual
+	 * truncation method is specific to the underlying datastore. 
+	 */
+  public int truncate(String table) {
+		long st=System.currentTimeMillis();
+		int res=_db.truncate(table);
+		long en=System.currentTimeMillis();
+		_measurements.measure("DELETE",(int)(en-st));
+		_measurements.reportReturnCode("DELETE",res);
+		return res;
+  }
 }

--- a/src/com/yahoo/ycsb/Workload.java
+++ b/src/com/yahoo/ycsb/Workload.java
@@ -90,4 +90,12 @@ public abstract class Workload
        * @return false if the workload knows it is done for this thread. Client will terminate the thread. Return true otherwise. Return true for workloads that rely on operationcount. For workloads that read traces from a file, return true when there are more to do, false when you are done.
        */
       public abstract boolean doTransaction(DB db, Object threadstate);
+      
+      /**
+       * do one truncation operation. This op is not called from a thread, because it is a single op to clean out a table. 
+       * This op does not have to be threadsafe, it is called from the main thread.
+       * @param db
+       * @return false if truncation fails, else true. 
+       */
+      public abstract boolean doTruncation(DB db);
 }

--- a/src/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/src/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -572,4 +572,10 @@ public class CoreWorkload extends Workload
 		}
 		db.insert(table,dbkey,values);
 	}
+
+	@Override
+  public boolean doTruncation(DB db) {
+	  int res = db.truncate(table);
+		return res == 0 ? true : false;
+  }
 }


### PR DESCRIPTION
However some of them (Mongo 5,6, HBase, Voldemort) are empty implementations. I primarily did this for Mongo b/c I would have to clean it out in order to re-insert data. I assume there will be other doc stores that have the same problem. 
