### PR TITLE
Support to stop benchmark after a maximum specified elapsed time.

### DIFF
--- a/src/com/yahoo/ycsb/Client.java
+++ b/src/com/yahoo/ycsb/Client.java
@@ -220,9 +220,7 @@ class ClientThread extends Thread
 		}
 		catch (InterruptedException e)
 		{
-		  // Changed from doing nothing to returning to support interruption
-      // of the client threads.
-		  return;
+		  // do nothing.
 		}
 		
 		try
@@ -231,7 +229,7 @@ class ClientThread extends Thread
 			{
 				long st=System.currentTimeMillis();
 
-				while ( (_opcount==0) || (_opsdone<_opcount) )
+				while (((_opcount == 0) || (_opsdone < _opcount)) && !_workload.isStopRequested())
 				{
 
 					if (!_workload.doTransaction(_db,_workloadstate))
@@ -256,9 +254,7 @@ class ClientThread extends Thread
 							}
 							catch (InterruptedException e)
 							{
-							  // Changed from doing nothing to returning to support interruption
-                // of the client threads.
-								return;
+							  // do nothing.
 							}
 
 						}
@@ -269,7 +265,7 @@ class ClientThread extends Thread
 			{
 				long st=System.currentTimeMillis();
 
-				while ( (_opcount==0) || (_opsdone<_opcount) )
+				while (((_opcount == 0) || (_opsdone < _opcount)) && !_workload.isStopRequested())
 				{
 
 					if (!_workload.doInsert(_db,_workloadstate))
@@ -294,9 +290,7 @@ class ClientThread extends Thread
 							}
 							catch (InterruptedException e)
 							{
-							  // Changed from doing nothing to returning to support interruption
-							  // of the client threads.
-								return;
+							  // do nothing.
 							}
 						}
 					}
@@ -755,7 +749,7 @@ public class Client
     Thread terminator = null;
     
     if (maxExecutionTime > 0) {
-      terminator = new TerminatorThread(maxExecutionTime, threads);
+      terminator = new TerminatorThread(maxExecutionTime, threads, workload);
       terminator.start();
     }
     

--- a/src/com/yahoo/ycsb/TerminatorThread.java
+++ b/src/com/yahoo/ycsb/TerminatorThread.java
@@ -31,10 +31,15 @@ public class TerminatorThread extends Thread {
   
   private Vector<Thread> threads;
   private long maxExecutionTime;
+  private Workload workload;
+  private long waitTimeOutInMS;
   
-  public TerminatorThread(long maxExecutionTime, Vector<Thread> threads) {
+  public TerminatorThread(long maxExecutionTime, Vector<Thread> threads, 
+      Workload workload) {
     this.maxExecutionTime = maxExecutionTime;
     this.threads = threads;
+    this.workload = workload;
+    waitTimeOutInMS = 2000;
     System.err.println("Maximum execution time specified as: " + maxExecutionTime + " secs");
   }
   
@@ -42,17 +47,23 @@ public class TerminatorThread extends Thread {
     try {
       Thread.sleep(maxExecutionTime * 1000);
     } catch (InterruptedException e) {
-      System.err.println("Could not wait until max specified time, thread interrupted.");
+      System.err.println("Could not wait until max specified time, TerminatorThread interrupted.");
       return;
     }
-    System.err.println("Maximum time elapsed. Interrupting the benchmark threads.");
+    System.err.println("Maximum time elapsed. Requesting stop for the workload.");
+    workload.requestStop();
+    System.err.println("Stop requested for workload. Now Joining!");
     for (Thread t : threads) {
-      if (!t.isInterrupted()) {
-        t.interrupt();
-      }
-      try {
-        t.join();
-      } catch (InterruptedException e) {
+      while (t.isAlive()) {
+        try {
+          t.join(waitTimeOutInMS);
+          if (t.isAlive()) {
+            System.err.println("Still waiting for thread " + t.getName() + " to complete. " +
+                "Workload status: " + workload.isStopRequested());
+          }
+        } catch (InterruptedException e) {
+          // Do nothing. Don't know why I was interrupted.
+        }
       }
     }
   }

--- a/src/com/yahoo/ycsb/Workload.java
+++ b/src/com/yahoo/ycsb/Workload.java
@@ -18,6 +18,7 @@
 package com.yahoo.ycsb;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * One experiment scenario. One object of this type will
@@ -38,6 +39,8 @@ public abstract class Workload
 	public static final String INSERT_START_PROPERTY="insertstart";
 	
 	public static final String INSERT_START_PROPERTY_DEFAULT="0";
+	
+	private volatile AtomicBoolean stopRequested = new AtomicBoolean(false);
 	
       /**
        * Initialize the scenario. Create any generators and other shared objects here.
@@ -90,4 +93,20 @@ public abstract class Workload
        * @return false if the workload knows it is done for this thread. Client will terminate the thread. Return true otherwise. Return true for workloads that rely on operationcount. For workloads that read traces from a file, return true when there are more to do, false when you are done.
        */
       public abstract boolean doTransaction(DB db, Object threadstate);
+      
+      /**
+       * Allows scheduling a request to stop the workload.
+       */
+      public void requestStop() {
+        stopRequested.set(true);
+      }
+      
+      /**
+       * Check the status of the stop request flag.
+       * @return true if stop was requested, false otherwise.
+       */
+      public boolean isStopRequested() {
+        if (stopRequested.get() == true) return true;
+        else return false;
+      }
 }


### PR DESCRIPTION
Hi Brian,

I adding support to stop the benchmark after a user specified maximum time (in seconds), expressed by the property maxexecutiontime, has passed.

The user needs to pass -p maxexecutiontime=<time_in_secs> at the command prompt or in the workload properties file. The benchmark runs until either the operation count has exhausted or the maximum specified time has elapsed, whichever is earlier.

Best,
Sudipto
