### PR TITLE
Switch unordered key generation from FNV32 to FNV64

### DIFF
--- a/src/com/yahoo/ycsb/Utils.java
+++ b/src/com/yahoo/ycsb/Utils.java
@@ -48,9 +48,9 @@ public class Utils
       /**
        * Hash an integer value.
        */
-      public static int hash(int val)
+      public static long hash(long val)
       {
-	 return FNVhash32(val);
+	 return FNVhash64(val);
       }
 	
       public static final int FNV_offset_basis_32=0x811c9dc5;

--- a/src/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/src/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -411,7 +411,7 @@ public class CoreWorkload extends Workload
 		}
 	}
 
-	public String buildKeyName(int keynum) {
+	public String buildKeyName(long keynum) {
  		if (!orderedinserts)
  		{
  			keynum=Utils.hash(keynum);


### PR DESCRIPTION
This includes a code cleanup and bug fix.

I was seeing collisions on unordered workloads.  As a workaround, I switched from FNV32 to FNV64, and the problem went away.
