### PR TITLE
Fixed bug in CoreWorkload

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -570,15 +570,15 @@ public class CoreWorkload extends Workload
 
 		//do the transaction
 		
-		long st=System.currentTimeMillis();
+		long st=System.nanoTime();
 
 		db.read(table,keyname,fields,new HashMap<String,ByteIterator>());
 		
 		db.update(table,keyname,values);
 
-		long en=System.currentTimeMillis();
+		long en=System.nanoTime();
 		
-		Measurements.getMeasurements().measure("READ-MODIFY-WRITE", (int)(en-st));
+		Measurements.getMeasurements().measure("READ-MODIFY-WRITE", (int)((en-st)/1000));
 	}
 	
 	public void doTransactionScan(DB db)


### PR DESCRIPTION
Fixed bug in CoreWorkload. Read-Modify-Write Average Latency should be reported in microseconds, not milliseconds.

This affects reporting when ycsb is run using the -s parameter.

E.g. (correct output):

... [UPDATE AverageLatency(us)=441.68] [READ-MODIFY-WRITE AverageLatency(us)=801.57] [READ AverageLatency(us)=316.32] ...

Thanks!
