### PR TITLE
Patch for YCSB Cassandra Client version 1.0.6

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -122,8 +122,8 @@ public class CassandraClient10 extends DB
     String password = getProperties().getProperty(PASSWORD_PROPERTY);
 
     readConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(READ_CONSISTENCY_LEVEL_PROPERTY, READ_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
-    writeConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(WRITE_CONSISTENCY_LEVEL_PROPERTY, SCAN_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
-    scanConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(SCAN_CONSISTENCY_LEVEL_PROPERTY, WRITE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
+    writeConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(WRITE_CONSISTENCY_LEVEL_PROPERTY, WRITE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
+    scanConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(SCAN_CONSISTENCY_LEVEL_PROPERTY, SCAN_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
     deleteConsistencyLevel = ConsistencyLevel.valueOf(getProperties().getProperty(DELETE_CONSISTENCY_LEVEL_PROPERTY, DELETE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
 
 


### PR DESCRIPTION
We have a patch for YCSB cassandra client version 1.0.6.This allows users to choose the consistency model at runtime.Consistency level can be ONE or QUORUM or ALL (as applicable)and can be set via properties.The default value being ONE.The patch supports all 4 operations - read,write,scan and delete.The corresponding properties to be set will be cassandra.readconsistencylevel, cassandra.writeconsistencylevel, cassandra.scanconsistencylevel and cassandra.deleteconsistencylevel.
For example,to set write consistency to quorum,users can use the following property.

cassandra.writeconsistencylevel=QUORUM

Patch is applicable for current YCSB framework version 1.0.4
