### PR TITLE
Minor fix so the classpath path separator is OS independent

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -107,7 +107,7 @@ database = sys.argv[2]
 db_classname = DATABASES[database]
 options = sys.argv[3:]
 
-ycsb_command = ["java", "-cp", ":".join(find_jars(ycsb_home, database)), \
+ycsb_command = ["java", "-cp", os.pathsep.join(find_jars(ycsb_home, database)), \
                 COMMANDS[sys.argv[1]]["main"], "-db", db_classname] + options
 if command:
     ycsb_command.append(command)


### PR DESCRIPTION
When running from Windows (I known, but it's what I have) the classpath path separator should be ";" and not ":"

This minor fix allows to use the underlying OS separator.
