### PR TITLE
Use the new MongoClient constructor

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -35,10 +35,4 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ## MongoDB Configuration Parameters
 
-### `mongodb.url` (default: `mongodb://localhost:27017`)
-
-### `mongodb.database` (default: `ycsb`)
-
-### `mongodb.writeConcern` (default `safe`)
-
-### `mongodb.maxconnections` (default `10`)
+### `mongodb.url` (default: `mongodb://localhost:27017/ycsb`)

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <mapkeeper.version>1.0</mapkeeper.version>
-    <mongodb.version>2.9.0</mongodb.version>
+    <mongodb.version>2.10.1</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>


### PR DESCRIPTION
* Upgrade to MongoClient constructor used in 2.10+ of the MongoDB java client.
* Use the URL for most properties instead fo having multiple configuration options that aren't needed: http://docs.mongodb.org/manual/reference/connection-string/