### PR TITLE
MongoDB readPreference and writeConcern improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+- Added mongodb.readPreference property (thumbtack)
+- Upgraded MongoDB client to v.2.10.1 (thumbtack)
+
 - gh-95 Bump MongoDB version to 2.9.0 (allanbank)
 - gh-67 Use checkstyle (m1ch1)
 - gh-76 Implemented OrientDB client (lvca)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+- Added mongodb.writeConcern.X properties (thumbtack)
 - Added mongodb.readPreference property (thumbtack)
 - Upgraded MongoDB client to v.2.10.1 (thumbtack)
 

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -474,13 +474,15 @@ public class CoreWorkload extends Workload
 		int keynum=keysequence.nextInt();
 		String dbkey = buildKeyName(keynum);
 		HashMap<String, ByteIterator> values = buildValues();
+        int result = db.insert(table, dbkey, values);
         if (ignoreinserterrors) {
             return true;
         }
-		if (db.insert(table,dbkey,values) == 0)
+        if (result == 0) {
 			return true;
-		else
+        } else {
 			return false;
+        }
 	}
 
 	/**

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -58,6 +58,7 @@ import java.util.Vector;
  * <LI><b>maxscanlength</b>: for scans, what is the maximum number of records to scan (default: 1000)
  * <LI><b>scanlengthdistribution</b>: for scans, what distribution should be used to choose the number of records to scan, for each scan, between 1 and maxscanlength (default: uniform)
  * <LI><b>insertorder</b>: should records be inserted in order by key ("ordered"), or in hashed order ("hashed") (default: hashed)
+ * <LI><b>ignoreinserterrors</b>: if set to true the insert operations are continues ever when one of the operations failed (default: false)
  * </ul> 
  */
 public class CoreWorkload extends Workload
@@ -257,6 +258,17 @@ public class CoreWorkload extends Workload
    * Default value of the percentage operations accessing the hot set.
    */
   public static final String HOTSPOT_OPN_FRACTION_DEFAULT = "0.8";
+
+  /**
+   * Ignore insert errors.
+   */
+  public static final String IGNORE_INSERT_ERRORS = "ignoreinserterrors";
+
+   /**
+    * Default value of the ignore insert errors.
+    */
+  public static final String IGNORE_INSERT_ERRORS_DEFAULT = "false";
+
 	
 	IntegerGenerator keysequence;
 
@@ -273,6 +285,8 @@ public class CoreWorkload extends Workload
 	boolean orderedinserts;
 
 	int recordcount;
+
+    boolean ignoreinserterrors;
 	
 	protected static IntegerGenerator getFieldLengthGenerator(Properties p) throws WorkloadException{
 		IntegerGenerator fieldlengthgenerator;
@@ -322,6 +336,8 @@ public class CoreWorkload extends Workload
 		
 		readallfields=Boolean.parseBoolean(p.getProperty(READ_ALL_FIELDS_PROPERTY,READ_ALL_FIELDS_PROPERTY_DEFAULT));
 		writeallfields=Boolean.parseBoolean(p.getProperty(WRITE_ALL_FIELDS_PROPERTY,WRITE_ALL_FIELDS_PROPERTY_DEFAULT));
+
+        ignoreinserterrors = Boolean.parseBoolean(p.getProperty(IGNORE_INSERT_ERRORS, IGNORE_INSERT_ERRORS_DEFAULT));
 		
 		if (p.getProperty(INSERT_ORDER_PROPERTY,INSERT_ORDER_PROPERTY_DEFAULT).compareTo("hashed")==0)
 		{
@@ -458,6 +474,9 @@ public class CoreWorkload extends Workload
 		int keynum=keysequence.nextInt();
 		String dbkey = buildKeyName(keynum);
 		HashMap<String, ByteIterator> values = buildValues();
+        if (ignoreinserterrors) {
+            return true;
+        }
 		if (db.insert(table,dbkey,values) == 0)
 			return true;
 		else

--- a/doc/coreproperties.html
+++ b/doc/coreproperties.html
@@ -22,7 +22,7 @@ The property files used with the core workload generator can specify values for 
 <LI><b>requestdistribution</b>: what distribution should be used to select the records to operate on - uniform, zipfian or latest (default: uniform) 
 <LI><b>maxscanlength</b>: for scans, what is the maximum number of records to scan (default: 1000) 
 <LI><b>scanlengthdistribution</b>: for scans, what distribution should be used to choose the number of records to scan, for each scan, between 1 and maxscanlength (default: uniform) 
-<LI><b>insertorder</b>: should records be inserted in order by key ("ordered"), or in hashed order ("hashed") (default: hashed) 
+<LI><b>ignoreinserterrors</b>: if set to true the insert operations are continues ever when one of the operations failed (default: false)
 </UL>
 <HR>
 YCSB - Yahoo! Research - Contact cooperb@yahoo-inc.com.

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -41,6 +41,16 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ### `mongodb.writeConcern` (default `safe`)
 
+### `mongodb.writeConcern.w` (default `1`)
+
+### `mongodb.writeConcern.wtimeout` (default `0`)
+
+### `mongodb.writeConcern.fsync` (default `false`)
+
+### `mongodb.writeConcern.j` (default `false`)
+
+### `mongodb.writeConcern.continueOnInsertError` (default `false`)
+
 ### `mongodb.readPreference` (default `primary`)
 
 ### `mongodb.maxconnections` (default `10`)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -41,4 +41,6 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ### `mongodb.writeConcern` (default `safe`)
 
+### `mongodb.readPreference` (default `primary`)
+
 ### `mongodb.maxconnections` (default `10`)

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -22,6 +22,12 @@
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.10</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
  
   <build>

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -104,13 +104,13 @@ public class MongoDbClient extends DB {
             if ("primary".equals(readPreferenceType)) {
                 readPreference = ReadPreference.primary();
             }
-            else if ("primaryPreferred".equals(readPreferenceType)) {
+            else if ("primarypreferred".equals(readPreferenceType)) {
                 readPreference = ReadPreference.primaryPreferred();
             }
             else if ("secondary".equals(readPreferenceType)) {
                 readPreference = ReadPreference.secondary();
             }
-            else if ("secondaryPreferred".equals(readPreferenceType)) {
+            else if ("secondarypreferred".equals(readPreferenceType)) {
                 readPreference = ReadPreference.secondaryPreferred();
             }
             else if ("nearest".equals(readPreferenceType)) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -225,7 +225,13 @@ public class MongoDbClient extends DB {
                 r.put(k, values.get(k).toArray());
             }
             WriteResult res = collection.insert(r, writeConcern);
-            return res.getError() == null ? 0 : 1;
+            String error = res.getError();
+            if (error == null) {
+                return 0;
+            } else {
+                System.err.println(error);
+                return 1;
+            }
         }
         catch (Exception e) {
             e.printStackTrace();
@@ -320,6 +326,10 @@ public class MongoDbClient extends DB {
             u.put("$set", fieldsToSet);
             WriteResult res = collection.update(q, u, false, false,
                     writeConcern);
+            String error = res.getError();
+            if (error != null) {
+                System.err.println(error);
+            }
             return res.getN() == 1 ? 0 : 1;
         }
         catch (Exception e) {

--- a/mongodb/test/main/java/com/yahoo/ycsb/db/MongoDbClientTest.java
+++ b/mongodb/test/main/java/com/yahoo/ycsb/db/MongoDbClientTest.java
@@ -1,0 +1,86 @@
+package com.yahoo.ycsb.db;
+
+import com.mongodb.WriteConcern;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class MongoDbClientTest {
+
+    MongoDbClient client;
+    Properties props;
+
+    @Before
+    public void setUp() {
+        client = new MongoDbClient();
+        props = new Properties();
+    }
+
+    @Test
+    public void testInitWriteConcernDefault() throws Exception {
+        client.init();
+        assertEquals(WriteConcern.SAFE, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernNormal() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        client.setProperties(props);
+        client.init();
+        assertEquals(WriteConcern.NORMAL, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernW() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        props.setProperty("mongodb.writeConcern.w", "2");
+        client.setProperties(props);
+        client.init();
+        WriteConcern concern = new WriteConcern(2, 0, false, false, false);
+        assertEquals(concern, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernWtimeout() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        props.setProperty("mongodb.writeConcern.wtimeout", "500");
+        client.setProperties(props);
+        client.init();
+        WriteConcern concern = new WriteConcern(0, 500, false, false, false);
+        assertEquals(concern, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernFsync() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        props.setProperty("mongodb.writeConcern.fsync", "true");
+        client.setProperties(props);
+        client.init();
+        WriteConcern concern = new WriteConcern(0, 0, true, false, false);
+        assertEquals(concern, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernJ() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        props.setProperty("mongodb.writeConcern.j", "true");
+        client.setProperties(props);
+        client.init();
+        WriteConcern concern = new WriteConcern(0, 0, false, true, false);
+        assertEquals(concern, client.writeConcern);
+    }
+
+    @Test
+    public void testInitWriteConcernContinue() throws Exception {
+        props.setProperty("mongodb.writeConcern", "normal");
+        props.setProperty("mongodb.writeConcern.continueOnErrorForInsert", "true");
+        client.setProperties(props);
+        client.init();
+        WriteConcern concern = new WriteConcern(0, 0, false, false, true);
+        assertEquals(concern, client.writeConcern);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <mapkeeper.version>1.0</mapkeeper.version>
-    <mongodb.version>2.9.0</mongodb.version>
+    <mongodb.version>2.10.1</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>


### PR DESCRIPTION
Added ability to set readPreference for read operations.
Added ability to set more detailed writeConcern, which is supported by the latest Mongo driver.
Added ability to ignore insert operation errors, which can be useful to reload incomplete data into MongoDB.