### PR TITLE
Added fieldnameprefix property

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -252,11 +252,22 @@ public class CoreWorkload extends Workload
    * Percentage operations that access the hot set.
    */
   public static final String HOTSPOT_OPN_FRACTION = "hotspotopnfraction";
-  
+
   /**
    * Default value of the percentage operations accessing the hot set.
    */
   public static final String HOTSPOT_OPN_FRACTION_DEFAULT = "0.8";
+
+    /**
+     * Field name prefix.
+     */
+    public static final String FIELD_NAME_PREFIX = "fieldnameprefix";
+
+    /**
+     * Default value of the field name prefix.
+     */
+    public static final String FIELD_NAME_PREFIX_DEFAULT = "field";
+
 	
 	IntegerGenerator keysequence;
 
@@ -273,6 +284,8 @@ public class CoreWorkload extends Workload
 	boolean orderedinserts;
 
 	int recordcount;
+
+    String fieldnameprefix;
 	
 	protected static IntegerGenerator getFieldLengthGenerator(Properties p) throws WorkloadException{
 		IntegerGenerator fieldlengthgenerator;
@@ -307,6 +320,8 @@ public class CoreWorkload extends Workload
 		
 		fieldcount=Integer.parseInt(p.getProperty(FIELD_COUNT_PROPERTY,FIELD_COUNT_PROPERTY_DEFAULT));
 		fieldlengthgenerator = CoreWorkload.getFieldLengthGenerator(p);
+
+        fieldnameprefix = p.getProperty(FIELD_NAME_PREFIX, FIELD_NAME_PREFIX_DEFAULT);
 		
 		double readproportion=Double.parseDouble(p.getProperty(READ_PROPORTION_PROPERTY,READ_PROPORTION_PROPERTY_DEFAULT));
 		double updateproportion=Double.parseDouble(p.getProperty(UPDATE_PROPORTION_PROPERTY,UPDATE_PROPORTION_PROPERTY_DEFAULT));
@@ -432,16 +447,16 @@ public class CoreWorkload extends Workload
 
  		for (int i=0; i<fieldcount; i++)
  		{
- 			String fieldkey="field"+i;
- 			ByteIterator data= new RandomByteIterator(fieldlengthgenerator.nextInt());
+ 			String fieldkey = fieldnameprefix + i;
+ 			ByteIterator data = new RandomByteIterator(fieldlengthgenerator.nextInt());
  			values.put(fieldkey,data);
  		}
 		return values;
 	}
 	HashMap<String, ByteIterator> buildUpdate() {
 		//update a random field
-		HashMap<String, ByteIterator> values=new HashMap<String,ByteIterator>();
-		String fieldname="field"+fieldchooser.nextString();
+		HashMap<String, ByteIterator> values = new HashMap<String,ByteIterator>();
+		String fieldname = fieldnameprefix + fieldchooser.nextString();
 		ByteIterator data = new RandomByteIterator(fieldlengthgenerator.nextInt());
 		values.put(fieldname,data);
 		return values;
@@ -528,9 +543,9 @@ public class CoreWorkload extends Workload
 		if (!readallfields)
 		{
 			//read a random field  
-			String fieldname="field"+fieldchooser.nextString();
+			String fieldname = fieldnameprefix + fieldchooser.nextString();
 
-			fields=new HashSet<String>();
+			fields = new HashSet<String>();
 			fields.add(fieldname);
 		}
 
@@ -549,9 +564,9 @@ public class CoreWorkload extends Workload
 		if (!readallfields)
 		{
 			//read a random field  
-			String fieldname="field"+fieldchooser.nextString();
+			String fieldname = fieldnameprefix + fieldchooser.nextString();
 
-			fields=new HashSet<String>();
+			fields = new HashSet<String>();
 			fields.add(fieldname);
 		}
 		
@@ -596,7 +611,7 @@ public class CoreWorkload extends Workload
 		if (!readallfields)
 		{
 			//read a random field  
-			String fieldname="field"+fieldchooser.nextString();
+			String fieldname = fieldnameprefix + fieldchooser.nextString();
 
 			fields=new HashSet<String>();
 			fields.add(fieldname);

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -58,6 +58,7 @@ import java.util.Vector;
  * <LI><b>maxscanlength</b>: for scans, what is the maximum number of records to scan (default: 1000)
  * <LI><b>scanlengthdistribution</b>: for scans, what distribution should be used to choose the number of records to scan, for each scan, between 1 and maxscanlength (default: uniform)
  * <LI><b>insertorder</b>: should records be inserted in order by key ("ordered"), or in hashed order ("hashed") (default: hashed)
+ * <LI><b>fieldnameprefix</b>: what should be a prefix for field names, the shorter may decrease the required storage size (default: "field")
  * </ul> 
  */
 public class CoreWorkload extends Workload

--- a/doc/coreproperties.html
+++ b/doc/coreproperties.html
@@ -1,4 +1,4 @@
-<HTML>
+<HTML xmlns="http://www.w3.org/1999/html">
 <HEAD>
 <TITLE>YCSB - Core workload package properties</TITLE>
 </HEAD>
@@ -22,7 +22,8 @@ The property files used with the core workload generator can specify values for 
 <LI><b>requestdistribution</b>: what distribution should be used to select the records to operate on - uniform, zipfian or latest (default: uniform) 
 <LI><b>maxscanlength</b>: for scans, what is the maximum number of records to scan (default: 1000) 
 <LI><b>scanlengthdistribution</b>: for scans, what distribution should be used to choose the number of records to scan, for each scan, between 1 and maxscanlength (default: uniform) 
-<LI><b>insertorder</b>: should records be inserted in order by key ("ordered"), or in hashed order ("hashed") (default: hashed) 
+<LI><b>insertorder</b>: should records be inserted in order by key ("ordered"), or in hashed order ("hashed") (default: hashed)
+<LI><b>fieldnameprefix</b>: string prefix for the field name (default: “field”)
 </UL>
 <HR>
 YCSB - Yahoo! Research - Contact cooperb@yahoo-inc.com.

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -464,7 +464,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
                             rescode=cli.read("table1", key, s, result);
                             */
                             HashSet<String> scanFields = new HashSet<String>();
-                            scanFields.add("field1");
+                            scanFields.add("field1");   //TODO: remove hardcoded field prefix
                             scanFields.add("field3");
                             Vector<HashMap<String,ByteIterator>> scanResults = new Vector<HashMap<String,ByteIterator>>();
                             rescode = cli.scan("table1","user2",20,null,scanResults);


### PR DESCRIPTION
By default YCSB names the database record fields as “field” + a number.
The new configuration option allows to replace the “field” prefix with
something shorter which affects the data storage size for schema-less databases.
