### PR TITLE
Fix NullPointException when execute "ycsb run gemfire ..."

### DIFF
--- a/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
+++ b/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
@@ -133,7 +133,7 @@ public class GemFireClient extends DB {
     if (val != null) {
       if (fields == null) {
         for (String k : val.keySet()) {
-          result.put(key, new ByteArrayByteIterator(val.get(key)));
+          result.put(k, new ByteArrayByteIterator(val.get(k)));
         }
       } else {
         for (String field : fields) {


### PR DESCRIPTION
The GemFire binding has a bug when read data by region, it try getting non-exist key from it which result in NullPointException. 
