### PR TITLE
Added support of testing MongoDB replica set with automatic failover.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <mapkeeper.version>1.0</mapkeeper.version>
-    <mongodb.version>2.9.0</mongodb.version>
+    <mongodb.version>2.11.2</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>


### PR DESCRIPTION
1) MongoDB driver upgraded to the latest version 2.11.2
2) Use mongodb.host and mongodb.port properties instead of mongodb.url
3) Added mongodb.readPreference property which can be secondary or primary (default)