### PR TITLE
Use the clear buffer on fail option. Not using it is now deprecated.

### DIFF
--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -117,7 +117,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         synchronized (tableLock) {
             _hTable = new HTable(config, table);
             //2 suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
-            _hTable.setAutoFlush(false);
+            _hTable.setAutoFlush(false, true);
             _hTable.setWriteBufferSize(1024*1024*12);
             //return hTable;
         }


### PR DESCRIPTION
Reasons are detailed in https://issues.apache.org/jira/browse/HBASE-9521
This makes errors simpler to understand: without this setting, the failed insertions are retried when we close the connection to HBase.
