### PR TITLE
Support multiple versions of HBase, including 0.94 and 0.96 (modularized)

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -12,16 +12,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase</artifactId>
-      <version>${hbase.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-core</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
@@ -51,5 +41,53 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- This profile is intended for HBase up to 0.94.x included.
+    For 0.94:
+    mvn clean package -Dhbase.version=0.94.12 -Dhadoop.version=1.0.4 -Dslf4j-api.version=1.4.3 -DskipTests
+    or, to use the default settings (0.92, hadoop 1.0.0)
+    mvn clean package
+    -->
+    <profile>
+      <id>hbase-single-module</id>
+      <activation>
+        <property>
+          <name>!hbase-client</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase</artifactId>
+          <version>${hbase.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-core</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <!-- This profile is intended for HBase since version 0.95
+           mvn clean package -Dhbase-client -Dhbase.version=0.95.2-hadoop2
+       -->
+      <id>hbase-client</id>
+      <activation>
+        <property>
+          <name>hbase-client</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-client</artifactId>
+          <version>${hbase.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 
 </project>

--- a/hbase/src/main/conf/hbase-site.xml
+++ b/hbase/src/main/conf/hbase-site.xml
@@ -23,19 +23,7 @@
 -->
 <configuration>
   <property>
-    <name>hbase.rootdir</name>
-    <value>hdfs://<HBASE_MASTER_SERVER>:20001/hbase</value>
-    <description>The directory shared by region servers.
-    </description>
-  </property>
-  <property>
-    <name>hbase.master</name>
-    <value><HBASE_MASTER_SERVER>:60000</value>
-    <description>The host and port that the HBase master runs at.
-    </description>
-  </property>
-  <property>
     <name>hbase.zookeeper.quorum</name>
-    <value><HBASE_MASTER_SERVER></value>
+    <value><ZOOKEEPER_SERVER></value>
   </property>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.4</version>
+      <version>${slf4j-api.version}</version>
     </dependency>
   </dependencies>
  
@@ -45,6 +45,8 @@
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
     <hbase.version>0.92.1</hbase.version>
+    <hadoop.version>1.0.0</hadoop.version>
+    <slf4j-api.version>1.6.4</slf4j-api.version>
     <cassandra.version>0.7.0</cassandra.version>
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>


### PR DESCRIPTION
HBase 0.96 changed the names of the maven modules. The default is not change, but there is now a profile to run 0.95+:
 mvn clean package -Dhbase-client -Dhbase.version=0.95.2-hadoop2 

HBase 0.94 with hadoop 1 depends on slf4j v1.4.3, so I made it configurable:
mvn clean package -Dhbase.version=0.94.12 -Dhadoop.version=1.0.4 -Dslf4j-api.version=1.4.3 -DskipTests

hbase.master does not need to be configured since HBase 0.90
hbase.rootdir is a server side config.

All the defaults remain unchanged.
I've tested the settings for 0.94.12 and HBase 0.96.RC5
