### PR TITLE
ignore all target folder contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/elasticsearch/target/
+target


### PR DESCRIPTION
This effectively ensures that contributors must override git if they wish to commit contents of target folders.
