### PR TITLE
Async mongodb driver

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -39,6 +39,7 @@ DATABASES = {
     "jdbc"         : "com.yahoo.ycsb.db.JdbcDBClient",
     "mapkeeper"    : "com.yahoo.ycsb.db.MapKeeperClient",
     "mongodb"      : "com.yahoo.ycsb.db.MongoDbClient",
+    "mongodb-async": "com.yahoo.ycsb.db.AsyncMongoDbClient",
     "nosqldb"      : "com.yahoo.ycsb.db.NoSqlDbClient",
     "orientdb"     : "com.yahoo.ycsb.db.OrientDBClient",
     "redis"        : "com.yahoo.ycsb.db.RedisClient", 

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -109,9 +109,15 @@ command = COMMANDS[sys.argv[1]]["command"]
 database = sys.argv[2]
 db_classname = DATABASES[database]
 options = sys.argv[3:]
+java_home = os.environ["JAVA_HOME"]
 
-ycsb_command = ["java", "-cp", os.pathsep.join(find_jars(ycsb_home, database)), \
+if java_home: 
+    ycsb_command = [java_home + "/bin/java", "-cp", os.pathsep.join(find_jars(ycsb_home, database)), \
                 COMMANDS[sys.argv[1]]["main"], "-db", db_classname] + options
+else: 
+    ycsb_command = ["java", "-cp", os.pathsep.join(find_jars(ycsb_home, database)), \
+                COMMANDS[sys.argv[1]]["main"], "-db", db_classname] + options
+
 if command:
     ycsb_command.append(command)
 print " ".join(ycsb_command)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -56,15 +56,23 @@ Download the YCSB zip file and compile:
     mvn -pl com.yahoo.ycsb:core,com.yahoo.ycsb:mongodb-binding clean package
 
 ### 4. Run YCSB
+
+Now you are ready to run! First, use the asynchronous driver to load the data:
+
+    ./bin/ycsb load mongodb-async -s -P workloads/workloada > outputLoad.txt
+
+Then, run the workload:
+
+    ./bin/ycsb run mongodb-async -s -P workloads/workloada > outputRun.txt
     
-Now you are ready to run! First, load the data:
+Similarly, to use the synchronous driver from MongoDB Inc. we load the data: 
 
     ./bin/ycsb load mongodb -s -P workloads/workloada > outputLoad.txt
 
 Then, run the workload:
 
     ./bin/ycsb run mongodb -s -P workloads/workloada > outputRun.txt
-
+    
 See the next section for the list of configuration parameters for MongoDB.
 
 ## MongoDB Configuration Parameters
@@ -95,5 +103,8 @@ See the next section for the list of configuration parameters for MongoDB.
 
 For example:
 
-    ./bin/ycsb load mongodb -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged
+    ./bin/ycsb load mongodb-async -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged
 
+To run with the synchronous driver from MongoDB Inc.:
+
+    ./bin/ycsb load mongodb -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged    

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -21,6 +21,10 @@ and get the url to download the rpm into your server. For example:
 
     wget http://download.oracle.com/otn-pub/java/jdk/7u40-b43/jdk-7u40-linux-x64.rpm?AuthParam=11232426132 -o jdk-7u40-linux-x64.rpm
     rpm -Uvh jdk-7u40-linux-x64.rpm
+    
+Or install via yum/apt-get
+
+    sudo yum install java-devel
 
 Download MVN from http://maven.apache.org/download.cgi
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -29,6 +29,14 @@ Download MVN from http://maven.apache.org/download.cgi
     cd /usr/local
     sudo ln -s apache-maven-* maven
     sudo vi /etc/profile.d/maven.sh
+
+Add the following to `maven.sh`
+
+    export M2_HOME=/usr/local/maven
+    export PATH=${M2_HOME}/bin:${PATH}
+
+Reload bash and test mvn
+
     bash
     mvn -version
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -42,3 +42,5 @@ See the next section for the list of configuration parameters for MongoDB.
 ### `mongodb.writeConcern` (default `safe`)
 
 ### `mongodb.maxconnections` (default `10`)
+
+### `mongodb.threadsAllowedToBlockForConnectionMultiplier` (default `5`)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,6 +1,6 @@
 ## Quick Start
 
-This section describes how to run YCSB on MongoDB running locally. 
+This section describes how to run YCSB on MongoDB. 
 
 ### 1. Start MongoDB
 
@@ -13,7 +13,10 @@ on x86-64 Linux box:
     cd mongodb-linux-x86_64-*
     ./bin/mongod --dbpath /tmp/mongodb
 
-### 2. Install Maven and Java
+Replace x.x.x above with the latest stable release version for MongoDB.
+See http://docs.mongodb.org/manual/installation/ for installation steps for various operating systems.
+
+### 2. Install Java and Maven
 
 Go to http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
@@ -46,21 +49,22 @@ Reload bash and test mvn
 
 ### 3. Set Up YCSB
 
-Clone the YCSB git repository and compile:
+Download the YCSB zip file and compile:
 
-    git clone git://github.com/brianfrankcooper/YCSB.git
-    cd YCSB
-    mvn clean package
+    wget https://github.com/achille/YCSB/archive/master.zip
+    unzip master
+    cd YCSB-master
+    mvn -pl com.yahoo.ycsb:core,com.yahoo.ycsb:mongodb-binding clean package
 
 ### 4. Run YCSB
     
 Now you are ready to run! First, load the data:
 
-    ./bin/ycsb load mongodb -s -P workloads/workloada
+    ./bin/ycsb load mongodb -s -P workloads/workloada > outputLoad.txt
 
 Then, run the workload:
 
-    ./bin/ycsb run mongodb -s -P workloads/workloada
+    ./bin/ycsb run mongodb -s -P workloads/workloada > outputRun.txt
 
 See the next section for the list of configuration parameters for MongoDB.
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -78,6 +78,14 @@ See the next section for the list of configuration parameters for MongoDB.
   - `journaled`
   - `replica_acknowledged`
 
+- `mongodb.readPreference` default `primary`
+ - options are :
+  - `primary`
+  - `primary_preferred`
+  - `secondary`
+  - `secondary_preferred`
+  - `nearest`
+
 - `mongodb.maxconnections` (default `100`)
 
 - `mongodb.threadsAllowedToBlockForConnectionMultiplier` (default `5`)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -77,34 +77,19 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ## MongoDB Configuration Parameters
 
-- `mongodb.url` default: `mongodb://localhost:27017`
+- `mongodb.url` default: `mongodb://localhost:27017/ycsb?w=1`
+  - This should be a MongoDB URI or connection string. 
+    - See http://docs.mongodb.org/manual/reference/connection-string/ for the standard options.
+    - For the complete set of options for the asynchronous driver see: 
+      - http://www.allanbank.com/mongodb-async-driver/apidocs/index.html?com/allanbank/mongodb/MongoDbUri.html
+    - For the complete set of options for the synchronous driver see:
+      - http://api.mongodb.org/java/current/index.html?com/mongodb/MongoClientURI.html
 
-- `mongodb.database` default: `ycsb`
-
-- `mongodb.writeConcern` default `acknowledged`
-  - options are :
-    - `errors_ignored`
-    - `unacknowledged`
-    - `acknowledged`
-    - `journaled`
-    - `replica_acknowledged`
-
-- `mongodb.readPreference` default `primary`
-  - options are :
-    - `primary`
-    - `primary_preferred`
-    - `secondary`
-    - `secondary_preferred`
-    - `nearest`
-
-- `mongodb.maxconnections` (default `100`)
-
-- `mongodb.threadsAllowedToBlockForConnectionMultiplier` (default `5`)
 
 For example:
 
-    ./bin/ycsb load mongodb-async -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged
+    ./bin/ycsb load mongodb-async -s -P workloads/workloada -p mongodb.url=mongodb://localhost:27017/ycsb?w=0
 
 To run with the synchronous driver from MongoDB Inc.:
 
-    ./bin/ycsb load mongodb -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged    
+    ./bin/ycsb load mongodb -s -P workloads/workloada -p mongodb.url=mongodb://localhost:27017/ycsb?w=0

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -77,14 +77,47 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ## MongoDB Configuration Parameters
 
-- `mongodb.url` default: `mongodb://localhost:27017/ycsb?w=1`
+- `mongodb.url`
   - This should be a MongoDB URI or connection string. 
     - See http://docs.mongodb.org/manual/reference/connection-string/ for the standard options.
     - For the complete set of options for the asynchronous driver see: 
       - http://www.allanbank.com/mongodb-async-driver/apidocs/index.html?com/allanbank/mongodb/MongoDbUri.html
     - For the complete set of options for the synchronous driver see:
       - http://api.mongodb.org/java/current/index.html?com/mongodb/MongoClientURI.html
+  - Default value is `mongodb://localhost:27017/ycsb?w=1`
 
+- `mongodb.batchsize`
+  - Useful for the insert workload as it will submit the inserts in batches inproving throughput.
+  - Default value is `1`.
+
+- `mongodb.writeConcern`
+  - **Deprecated** - Use the `w` and `journal` options on the MongoDB URI provided by the `mongodb.uri`.
+  - Allowed values are :
+    - `errors_ignored`
+    - `unacknowledged`
+    - `acknowledged`
+    - `journaled`
+    - `replica_acknowledged`
+    - `majority`
+  - Default value is `acknowledged`.
+ 
+- `mongodb.readPreference`
+  - **Deprecated** - Use the `readPreference` options on the MongoDB URI provided by the `mongodb.uri`.
+  - Allowed values are :
+    - `primary`
+    - `primary_preferred`
+    - `secondary`
+    - `secondary_preferred`
+    - `nearest`
+  - Default value is `primary`.
+ 
+- `mongodb.maxconnections`
+  - **Deprecated** - Use the `maxPoolSize` options on the MongoDB URI provided by the `mongodb.uri`.
+  - Default value is `100`.
+
+- `mongodb.threadsAllowedToBlockForConnectionMultiplier`
+  - **Deprecated** - Use the `waitQueueMultiple` options on the MongoDB URI provided by the `mongodb.uri`.
+  - Default value is `5`.
 
 For example:
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -51,9 +51,8 @@ Reload bash and test mvn
 
 Download the YCSB zip file and compile:
 
-    wget https://github.com/achille/YCSB/archive/master.zip
-    unzip master
-    cd YCSB-master
+    git clone git://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
     mvn -pl com.yahoo.ycsb:core,com.yahoo.ycsb:mongodb-binding clean package
 
 ### 4. Run YCSB

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -7,13 +7,32 @@ This section describes how to run YCSB on MongoDB running locally.
 First, download MongoDB and start `mongod`. For example, to start MongoDB
 on x86-64 Linux box:
 
-    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-1.8.3.tgz
-    tar xfvz mongodb-linux-x86_64-1.8.3.tgz
+    wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-x.x.x.tgz
+    tar xfvz mongodb-linux-x86_64-*.tgz
     mkdir /tmp/mongodb
-    cd mongodb-linux-x86_64-1.8.3
+    cd mongodb-linux-x86_64-*
     ./bin/mongod --dbpath /tmp/mongodb
 
-### 2. Set Up YCSB
+### 2. Install Maven and Java
+
+Go to http://www.oracle.com/technetwork/java/javase/downloads/index.html
+
+and get the url to download the rpm into your server. For example:
+
+    wget http://download.oracle.com/otn-pub/java/jdk/7u40-b43/jdk-7u40-linux-x64.rpm?AuthParam=11232426132 -o jdk-7u40-linux-x64.rpm
+    rpm -Uvh jdk-7u40-linux-x64.rpm
+
+Download MVN from http://maven.apache.org/download.cgi
+
+    wget http://ftp.heanet.ie/mirrors/www.apache.org/dist/maven/maven-3/3.1.1/binaries/apache-maven-3.1.1-bin.tar.gz
+    sudo tar xzf apache-maven-*-bin.tar.gz -C /usr/local
+    cd /usr/local
+    sudo ln -s apache-maven-* maven
+    sudo vi /etc/profile.d/maven.sh
+    bash
+    mvn -version
+
+### 3. Set Up YCSB
 
 Clone the YCSB git repository and compile:
 
@@ -21,7 +40,7 @@ Clone the YCSB git repository and compile:
     cd YCSB
     mvn clean package
 
-### 3. Run YCSB
+### 4. Run YCSB
     
 Now you are ready to run! First, load the data:
 
@@ -35,12 +54,23 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ## MongoDB Configuration Parameters
 
-### `mongodb.url` (default: `mongodb://localhost:27017`)
+- `mongodb.url` default: `mongodb://localhost:27017`
 
-### `mongodb.database` (default: `ycsb`)
+- `mongodb.database` default: `ycsb`
 
-### `mongodb.writeConcern` (default `acknowledged`, options are `errors_ignored`, `unacknowledged`, `acknowledged`, `journaled`, `replica_acknowledged`)
+- `mongodb.writeConcern` default `acknowledged`
+ - options are :
+  - `errors_ignored`
+  - `unacknowledged`
+  - `acknowledged`
+  - `journaled`
+  - `replica_acknowledged`
 
-### `mongodb.maxconnections` (default `10`)
+- `mongodb.maxconnections` (default `100`)
 
-### `mongodb.threadsAllowedToBlockForConnectionMultiplier` (default `5`)
+- `mongodb.threadsAllowedToBlockForConnectionMultiplier` (default `5`)
+
+For example:
+
+    ./bin/ycsb load mongodb -s -P workloads/workloada -p mongodb.writeConcern=unacknowledged
+

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -74,20 +74,20 @@ See the next section for the list of configuration parameters for MongoDB.
 - `mongodb.database` default: `ycsb`
 
 - `mongodb.writeConcern` default `acknowledged`
- - options are :
-  - `errors_ignored`
-  - `unacknowledged`
-  - `acknowledged`
-  - `journaled`
-  - `replica_acknowledged`
+  - options are :
+    - `errors_ignored`
+    - `unacknowledged`
+    - `acknowledged`
+    - `journaled`
+    - `replica_acknowledged`
 
 - `mongodb.readPreference` default `primary`
- - options are :
-  - `primary`
-  - `primary_preferred`
-  - `secondary`
-  - `secondary_preferred`
-  - `nearest`
+  - options are :
+    - `primary`
+    - `primary_preferred`
+    - `secondary`
+    - `secondary_preferred`
+    - `nearest`
 
 - `mongodb.maxconnections` (default `100`)
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -39,7 +39,7 @@ See the next section for the list of configuration parameters for MongoDB.
 
 ### `mongodb.database` (default: `ycsb`)
 
-### `mongodb.writeConcern` (default `safe`)
+### `mongodb.writeConcern` (default `acknowledged`, options are `errors_ignored`, `unacknowledged`, `acknowledged`, `journaled`, `replica_acknowledged`)
 
 ### `mongodb.maxconnections` (default `10`)
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -1,74 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.yahoo.ycsb</groupId>
-    <artifactId>root</artifactId>
-    <version>0.1.4</version>
-  </parent>
-  
-  <artifactId>mongodb-binding</artifactId>
-  <name>Mongo DB Binding</name>
-  <packaging>jar</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.yahoo.ycsb</groupId>
+		<artifactId>root</artifactId>
+		<version>0.1.4</version>
+	</parent>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongo-java-driver</artifactId>
-      <version>${mongodb.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.allanbank</groupId>
-      <artifactId>mongodb-async-driver</artifactId>
-      <version>${mongodb.async.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
-      <artifactId>core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-  </dependencies>
- 
-  <build>
-    <plugins>
-     <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>${maven.assembly.version}</version>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <appendAssemblyId>false</appendAssemblyId>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-	
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-        <checksumPolicy>warn</checksumPolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
-        <checksumPolicy>fail</checksumPolicy>
-      </snapshots>
-      <id>allanbank</id>
-      <name>Allanbank Releases</name>
-      <url>http://www.allanbank.com/repo/</url>
-      <layout>default</layout>
-    </repository>
-  </repositories>
+	<artifactId>mongodb-binding</artifactId>
+	<name>Mongo DB Binding</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongo-java-driver</artifactId>
+			<version>${mongodb.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.allanbank</groupId>
+			<artifactId>mongodb-async-driver</artifactId>
+			<version>${mongodb.async.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.yahoo.ycsb</groupId>
+			<artifactId>core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.1.2</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>${maven.assembly.version}</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<appendAssemblyId>false</appendAssemblyId>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+				<checksumPolicy>warn</checksumPolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+				<updatePolicy>never</updatePolicy>
+				<checksumPolicy>fail</checksumPolicy>
+			</snapshots>
+			<id>allanbank</id>
+			<name>Allanbank Releases</name>
+			<url>http://www.allanbank.com/repo/</url>
+			<layout>default</layout>
+		</repository>
+	</repositories>
 </project>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -18,6 +18,11 @@
       <version>${mongodb.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.allanbank</groupId>
+      <artifactId>mongodb-async-driver</artifactId>
+      <version>${mongodb.async.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
@@ -48,4 +53,22 @@
     </plugins>
   </build>
 	
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>warn</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+      <id>allanbank</id>
+      <name>Allanbank Releases</name>
+      <url>http://www.allanbank.com/repo/</url>
+      <layout>default</layout>
+    </repository>
+  </repositories>
 </project>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>mongodb-binding</artifactId>
-	<name>Mongo DB Binding</name>
+	<name>MongoDB Binding</name>
 	<packaging>jar</packaging>
 
 	<dependencies>
@@ -32,6 +32,13 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>1.1.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -1,0 +1,384 @@
+/**
+ * MongoDB client binding for YCSB using the Asynchronous Java Driver.
+ *
+ * Submitted by Rob Moore.
+ */
+
+package com.yahoo.ycsb.db;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.allanbank.mongodb.MongoIterator;
+import com.allanbank.mongodb.Durability;
+import com.allanbank.mongodb.LockType;
+import com.allanbank.mongodb.Mongo;
+import com.allanbank.mongodb.MongoCollection;
+import com.allanbank.mongodb.MongoDatabase;
+import com.allanbank.mongodb.MongoDbUri;
+import com.allanbank.mongodb.MongoFactory;
+import com.allanbank.mongodb.bson.Document;
+import com.allanbank.mongodb.bson.Element;
+import com.allanbank.mongodb.bson.builder.BuilderFactory;
+import com.allanbank.mongodb.bson.builder.DocumentBuilder;
+import com.allanbank.mongodb.bson.element.BinaryElement;
+import com.allanbank.mongodb.builder.Find;
+import com.allanbank.mongodb.builder.QueryBuilder;
+import com.yahoo.ycsb.ByteArrayByteIterator;
+import com.yahoo.ycsb.ByteIterator;
+import com.yahoo.ycsb.DB;
+import com.yahoo.ycsb.DBException;
+
+/**
+ * MongoDB asynchronous client for YCSB framework.
+ * 
+ * Properties to set:
+ * 
+ * mongodb.url=mongodb://localhost:27017 mongodb.database=ycsb
+ * mongodb.writeConcern=normal
+ * 
+ * @author rjm
+ * 
+ */
+public class AsyncMongoDbClient extends DB {
+
+    /** The database to use. */
+    private static String database;
+
+    /** The connection to MongoDB. */
+    private static Mongo mongo;
+
+    /** The database to MongoDB. */
+    private MongoDatabase db;
+
+    /** The write concern for the requests. */
+    private static Durability writeConcern;
+
+    /** The write concern for the requests. */
+    private static final AtomicInteger initCount = new AtomicInteger(0);
+
+    /**
+     * Cleanup any state for this DB. Called once per DB instance; there is one
+     * DB instance per client thread.
+     */
+    @Override
+    public final void cleanup() throws DBException {
+        if (initCount.decrementAndGet() <= 0) {
+            try {
+                mongo.close();
+            }
+            catch (final Exception e1) {
+                System.err.println("Could not close MongoDB connection pool: "
+                        + e1.toString());
+                e1.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Delete a record from the database.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to delete.
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
+     */
+    @Override
+    public final int delete(final String table, final String key) {
+        try {
+            final MongoCollection collection = db.getCollection(table);
+            final Document q = BuilderFactory.start().add("_id", key).build();
+            final long res = collection.delete(q, writeConcern);
+            return res == 1 ? 0 : 1;
+        }
+        catch (final Exception e) {
+            System.err.println(e.toString());
+            return 1;
+        }
+    }
+
+    /**
+     * Initialize any state for this DB. Called once per DB instance; there is
+     * one DB instance per client thread.
+     */
+    @Override
+    public final void init() throws DBException {
+        initCount.incrementAndGet();
+        synchronized (AsyncMongoDbClient.class) {
+            if (mongo != null) {
+                db = mongo.getDatabase(database);
+                return;
+            }
+
+            // initialize MongoDb driver
+            final Properties props = getProperties();
+            String url = props.getProperty("mongodb.url",
+                    "mongodb://localhost:27017");
+            database = props.getProperty("mongodb.database", "ycsb");
+            final String writeConcernType = props.getProperty(
+                    "mongodb.writeConcern",
+                    props.getProperty("mongodb.durability", "safe"))
+                    .toLowerCase();
+            final String maxConnections = props.getProperty(
+                    "mongodb.maxconnections", "10");
+
+            if ("none".equals(writeConcernType)) {
+                writeConcern = Durability.NONE;
+            }
+            else if ("safe".equals(writeConcernType)) {
+                writeConcern = Durability.ACK;
+            }
+            else if ("normal".equals(writeConcernType)) {
+                writeConcern = Durability.ACK;
+            }
+            else if ("fsync_safe".equals(writeConcernType)) {
+                writeConcern = Durability.fsyncDurable(10000);
+            }
+            else if ("replicas_safe".equals(writeConcernType)) {
+                writeConcern = Durability.replicaDurable(10000);
+            }
+            else {
+                System.err
+                        .println("ERROR: Invalid durability: '"
+                                + writeConcernType
+                                + "'. "
+                                + "Must be [ none | safe | normal | fsync_safe | replicas_safe ]");
+                System.exit(1);
+            }
+
+            try {
+                // need to append db to url.
+                url += "/" + database;
+                System.out.println("new database url = " + url);
+                mongo = MongoFactory.create(new MongoDbUri(url));
+                mongo.getConfig().setMaxConnectionCount(
+                        Integer.parseInt(maxConnections));
+                mongo.getConfig().setLockType(LockType.LOW_LATENCY_SPIN);
+                db = mongo.getDatabase(database);
+
+                System.out.println("mongo connection created with " + url);
+            }
+            catch (final Exception e1) {
+                System.err
+                        .println("Could not initialize MongoDB connection pool for Loader: "
+                                + e1.toString());
+                e1.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Insert a record in the database. Any field/value pairs in the specified
+     * values HashMap will be written into the record with the specified record
+     * key.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to insert.
+     * @param values
+     *            A HashMap of field/value pairs to insert in the record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
+     */
+    @Override
+    public final int insert(final String table, final String key,
+            final HashMap<String, ByteIterator> values) {
+        try {
+            final MongoCollection collection = db.getCollection(table);
+            final DocumentBuilder r = BuilderFactory.start().add("_id", key);
+            for (final Map.Entry<String, ByteIterator> entry : values
+                    .entrySet()) {
+                r.add(entry.getKey(), entry.getValue().toArray());
+            }
+            collection.insert(writeConcern, r);
+            return 0;
+        }
+        catch (final Exception e) {
+            e.printStackTrace();
+            return 1;
+        }
+    }
+
+    /**
+     * Read a record from the database. Each field/value pair from the result
+     * will be stored in a HashMap.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to read.
+     * @param fields
+     *            The list of fields to read, or null for all of them
+     * @param result
+     *            A HashMap of field/value pairs for the result
+     * @return Zero on success, a non-zero error code on error or "not found".
+     */
+    @Override
+    public final int read(final String table, final String key,
+            final Set<String> fields, final HashMap<String, ByteIterator> result) {
+        try {
+            final MongoCollection collection = db.getCollection(table);
+            final Document q = BuilderFactory.start().add("_id", key).build();
+            final DocumentBuilder fieldsToReturn = BuilderFactory.start();
+
+            Document queryResult = null;
+            if (fields != null) {
+                final Iterator<String> iter = fields.iterator();
+                while (iter.hasNext()) {
+                    fieldsToReturn.add(iter.next(), 1);
+                }
+
+                final Find.Builder fb = new Find.Builder(q);
+                fb.setReturnFields(fieldsToReturn);
+                fb.setLimit(1);
+                fb.setBatchSize(1);
+
+                final MongoIterator<Document> ci = collection.find(fb
+                        .build());
+                if (ci.hasNext()) {
+                    queryResult = ci.next();
+                    ci.close();
+                }
+            }
+            else {
+                queryResult = collection.findOne(q);
+            }
+
+            if (queryResult != null) {
+                fillMap(result, queryResult);
+            }
+            return queryResult != null ? 0 : 1;
+        }
+        catch (final Exception e) {
+            System.err.println(e.toString());
+            return 1;
+        }
+
+    }
+
+    /**
+     * Perform a range scan for a set of records in the database. Each
+     * field/value pair from the result will be stored in a HashMap.
+     * 
+     * @param table
+     *            The name of the table
+     * @param startkey
+     *            The record key of the first record to read.
+     * @param recordcount
+     *            The number of records to read
+     * @param fields
+     *            The list of fields to read, or null for all of them
+     * @param result
+     *            A Vector of HashMaps, where each HashMap is a set field/value
+     *            pairs for one record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
+     */
+    @Override
+    public final int scan(final String table, final String startkey,
+            final int recordcount, final Set<String> fields,
+            final Vector<HashMap<String, ByteIterator>> result) {
+        try {
+            final MongoCollection collection = db.getCollection(table);
+
+            // { "_id":{"$gte":startKey, "$lte":{"appId":key+"\uFFFF"}} }
+            final Find.Builder fb = new Find.Builder();
+            fb.setQuery(QueryBuilder.where("_id")
+                    .greaterThanOrEqualTo(startkey));
+            fb.setLimit(recordcount);
+            fb.setBatchSize(recordcount);
+            if (fields != null) {
+                DocumentBuilder fieldsDoc = BuilderFactory.start();
+                for (String field : fields) {
+                    fieldsDoc.add(field, 1);
+                }
+
+                fb.setReturnFields(fieldsDoc);
+            }
+
+            result.ensureCapacity(recordcount);
+            final MongoIterator<Document> cursor = collection.find(fb
+                    .build());
+            while (cursor.hasNext()) {
+                // toMap() returns a Map but result.add() expects a
+                // Map<String,String>. Hence, the suppress warnings.
+                final Document doc = cursor.next();
+                final HashMap<String, ByteIterator> docAsMap = new HashMap<String, ByteIterator>();
+
+                fillMap(docAsMap, doc);
+
+                result.add(docAsMap);
+            }
+
+            return 0;
+        }
+        catch (final Exception e) {
+            System.err.println(e.toString());
+            return 1;
+        }
+    }
+
+    /**
+     * Update a record in the database. Any field/value pairs in the specified
+     * values HashMap will be written into the record with the specified record
+     * key, overwriting any existing values with the same field name.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to write.
+     * @param values
+     *            A HashMap of field/value pairs to update in the record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
+     */
+    @Override
+    public final int update(final String table, final String key,
+            final HashMap<String, ByteIterator> values) {
+        try {
+            final MongoCollection collection = db.getCollection(table);
+            final Document q = BuilderFactory.start().add("_id", key).build();
+            final DocumentBuilder u = BuilderFactory.start();
+            final DocumentBuilder fieldsToSet = u.push("$set");
+            for (final Map.Entry<String, ByteIterator> entry : values
+                    .entrySet()) {
+                fieldsToSet.add(entry.getKey(), entry.getValue().toArray());
+            }
+            final long res = collection
+                    .update(q, u, false, false, writeConcern);
+            return res == 1 ? 0 : 1;
+        }
+        catch (final Exception e) {
+            System.err.println(e.toString());
+            return 1;
+        }
+    }
+
+    /**
+     * Fills the map with the ByteIterators from the document.
+     * 
+     * @param result
+     *            The map to fill.
+     * @param queryResult
+     *            The document to fill from.
+     */
+    protected final void fillMap(final HashMap<String, ByteIterator> result,
+            final Document queryResult) {
+        for (final Element be : queryResult) {
+            if (be instanceof BinaryElement) {
+                result.put(be.getName(), new ByteArrayByteIterator(
+                        ((BinaryElement) be).getValue()));
+            }
+        }
+    }
+}

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -245,11 +245,16 @@ public class AsyncMongoDbClient extends DB {
             final MongoCollection collection = db.getCollection(table);
             final DocumentBuilder r = DOCUMENT_BUILDER.get().reset()
                     .add("_id", key);
+            final Document q = r.build();
             for (final Map.Entry<String, ByteIterator> entry : values
                     .entrySet()) {
                 r.add(entry.getKey(), entry.getValue().toArray());
             }
             collection.insert(writeConcern, r);
+
+            collection.update(q, r, /* multi= */false, /* upsert= */true,
+                    writeConcern);
+
             return 0;
         }
         catch (final Exception e) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -1,9 +1,19 @@
-/**
- * MongoDB client binding for YCSB using the Asynchronous Java Driver.
- *
- * Submitted by Rob Moore.
+/**                                                                                                                                                                                
+ * Copyright (c) 2013-2014, Allanbank Consulting, Inc. All rights reserved.                                                                                                                             
+ *                                                                                                                                                                                 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+ * may not use this file except in compliance with the License. You                                                                                                                
+ * may obtain a copy of the License at                                                                                                                                             
+ *                                                                                                                                                                                 
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+ *                                                                                                                                                                                 
+ * Unless required by applicable law or agreed to in writing, software                                                                                                             
+ * distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+ * implied. See the License for the specific language governing                                                                                                                    
+ * permissions and limitations under the License. See accompanying                                                                                                                 
+ * LICENSE file.                                                                                                                                                                   
  */
-
 package com.yahoo.ycsb.db;
 
 import static com.allanbank.mongodb.builder.QueryBuilder.where;
@@ -46,7 +56,7 @@ import com.yahoo.ycsb.DBException;
  * mongodb.writeConcern=normal
  * 
  * @author rjm
- * 
+ * @copyright 2013-2014, Allanbank Consulting, Inc., All Rights Reserved
  */
 public class AsyncMongoDbClient extends DB {
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -124,7 +124,7 @@ public class AsyncMongoDbClient extends DB {
 
         final Properties props = getProperties();
         final String maxConnections = props.getProperty(
-                "mongodb.maxconnections", "10");
+                "mongodb.maxconnections", "100");
         final int connections = Integer.parseInt(maxConnections);
 
         synchronized (AsyncMongoDbClient.class) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -145,32 +145,31 @@ public class AsyncMongoDbClient extends DB {
             String url = props.getProperty("mongodb.url",
                     "mongodb://localhost:27017");
             database = props.getProperty("mongodb.database", "ycsb");
-            final String writeConcernType = props.getProperty(
-                    "mongodb.writeConcern",
-                    props.getProperty("mongodb.durability", "safe"))
+            String writeConcernType = props.getProperty("mongodb.writeConcern",
+                    props.getProperty("mongodb.durability", "acknowledged"))
                     .toLowerCase();
 
-            if ("none".equals(writeConcernType)) {
+            if ("errors_ignored".equals(writeConcernType)) {
                 writeConcern = Durability.NONE;
             }
-            else if ("safe".equals(writeConcernType)) {
+            else if ("unacknowledged".equals(writeConcernType)) {
+                writeConcern = Durability.NONE;
+            }
+            else if ("acknowledged".equals(writeConcernType)) {
                 writeConcern = Durability.ACK;
             }
-            else if ("normal".equals(writeConcernType)) {
-                writeConcern = Durability.ACK;
+            else if ("journaled".equals(writeConcernType)) {
+                writeConcern = Durability.journalDurable(0);
             }
-            else if ("fsync_safe".equals(writeConcernType)) {
-                writeConcern = Durability.fsyncDurable(10000);
-            }
-            else if ("replicas_safe".equals(writeConcernType)) {
-                writeConcern = Durability.replicaDurable(10000);
+            else if ("replica_acknowledged".equals(writeConcernType)) {
+                writeConcern = Durability.replicaDurable(2, 0);
             }
             else {
                 System.err
-                        .println("ERROR: Invalid durability: '"
+                        .println("ERROR: Invalid writeConcern: '"
                                 + writeConcernType
                                 + "'. "
-                                + "Must be [ none | safe | normal | fsync_safe | replicas_safe ]");
+                                + "Must be [ errors_ignored | unacknowledged | acknowledged | journaled | replica_acknowledged ]");
                 System.exit(1);
             }
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -1,5 +1,5 @@
 /**                                                                                                                                                                                
- * Copyright (c) 2013-2014, Allanbank Consulting, Inc. All rights reserved.                                                                                                                             
+ * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.                                                                                                                             
  *                                                                                                                                                                                 
  * Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
  * may not use this file except in compliance with the License. You                                                                                                                
@@ -56,7 +56,6 @@ import com.yahoo.ycsb.DBException;
  * mongodb.writeConcern=normal
  * 
  * @author rjm
- * @copyright 2013-2014, Allanbank Consulting, Inc., All Rights Reserved
  */
 public class AsyncMongoDbClient extends DB {
 
@@ -417,8 +416,6 @@ public class AsyncMongoDbClient extends DB {
     /**
      * BinaryByteArrayIterator provides an adapter from a {@link BinaryElement}
      * to a {@link ByteIterator}.
-     * 
-     * @copyright 2013, Allanbank Consulting, Inc., All Rights Reserved
      */
     private final static class BinaryByteArrayIterator extends ByteIterator {
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -9,14 +9,29 @@
 
 package com.yahoo.ycsb.db;
 
-import com.mongodb.*;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBAddress;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 import com.yahoo.ycsb.ByteArrayByteIterator;
 import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.DB;
 import com.yahoo.ycsb.DBException;
 
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * MongoDB client for YCSB framework.
@@ -34,7 +49,7 @@ public class MongoDbClient extends DB {
     protected static final Integer INCLUDE = Integer.valueOf(1);
 
     /** A singleton Mongo instance. */
-    private static Mongo mongo;
+    private static MongoClient mongo;
 
     /** The default write concern for the test. */
     private static WriteConcern writeConcern;
@@ -42,12 +57,15 @@ public class MongoDbClient extends DB {
     /** The database to access. */
     private static String database;
 
-    /** Count the number of times initialized to teardown on the last {@link #cleanup()}. */
+    /**
+     * Count the number of times initialized to teardown on the last
+     * {@link #cleanup()}.
+     */
     private static final AtomicInteger initCount = new AtomicInteger(0);
 
     /**
-     * Initialize any state for this DB.
-     * Called once per DB instance; there is one DB instance per client thread.
+     * Initialize any state for this DB. Called once per DB instance; there is
+     * one DB instance per client thread.
      */
     @Override
     public void init() throws DBException {
@@ -75,6 +93,10 @@ public class MongoDbClient extends DB {
                     "safe").toLowerCase();
             final String maxConnections = props.getProperty(
                     "mongodb.maxconnections", "10");
+            final String threadsAllowedToBlockForConnectionMultiplier = props
+                    .getProperty(
+                            "mongodb.threadsAllowedToBlockForConnectionMultiplier",
+                            "5");
 
             if ("none".equals(writeConcernType)) {
                 writeConcern = WriteConcern.NONE;
@@ -111,9 +133,13 @@ public class MongoDbClient extends DB {
                 // need to append db to url.
                 url += "/" + database;
                 System.out.println("new database url = " + url);
-                MongoOptions options = new MongoOptions();
-                options.connectionsPerHost = Integer.parseInt(maxConnections);
-                mongo = new Mongo(new DBAddress(url), options);
+                MongoClientOptions options = MongoClientOptions
+                        .builder()
+                        .connectionsPerHost(Integer.parseInt(maxConnections))
+                        .threadsAllowedToBlockForConnectionMultiplier(
+                                Integer.parseInt(threadsAllowedToBlockForConnectionMultiplier))
+                        .build();
+                mongo = new MongoClient(new DBAddress(url), options);
 
                 System.out.println("mongo connection created with " + url);
             }
@@ -128,8 +154,8 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Cleanup any state for this DB.
-     * Called once per DB instance; there is one DB instance per client thread.
+     * Cleanup any state for this DB. Called once per DB instance; there is one
+     * DB instance per client thread.
      */
     @Override
     public void cleanup() throws DBException {
@@ -148,10 +174,13 @@ public class MongoDbClient extends DB {
 
     /**
      * Delete a record from the database.
-     *
-     * @param table The name of the table
-     * @param key The record key of the record to delete.
-     * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to delete.
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
      */
     @Override
     public int delete(String table, String key) {
@@ -176,13 +205,18 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Insert a record in the database. Any field/value pairs in the specified values HashMap will be written into the record with the specified
-     * record key.
-     *
-     * @param table The name of the table
-     * @param key The record key of the record to insert.
-     * @param values A HashMap of field/value pairs to insert in the record
-     * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+     * Insert a record in the database. Any field/value pairs in the specified
+     * values HashMap will be written into the record with the specified record
+     * key.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to insert.
+     * @param values
+     *            A HashMap of field/value pairs to insert in the record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
      */
     @Override
     public int insert(String table, String key,
@@ -195,8 +229,8 @@ public class MongoDbClient extends DB {
 
             DBCollection collection = db.getCollection(table);
             DBObject r = new BasicDBObject().append("_id", key);
-            for (String k : values.keySet()) {
-                r.put(k, values.get(k).toArray());
+            for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
+                r.put(entry.getKey(), entry.getValue().toArray());
             }
             WriteResult res = collection.insert(r, writeConcern);
             return res.getError() == null ? 0 : 1;
@@ -213,12 +247,17 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Read a record from the database. Each field/value pair from the result will be stored in a HashMap.
-     *
-     * @param table The name of the table
-     * @param key The record key of the record to read.
-     * @param fields The list of fields to read, or null for all of them
-     * @param result A HashMap of field/value pairs for the result
+     * Read a record from the database. Each field/value pair from the result
+     * will be stored in a HashMap.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to read.
+     * @param fields
+     *            The list of fields to read, or null for all of them
+     * @param result
+     *            A HashMap of field/value pairs for the result
      * @return Zero on success, a non-zero error code on error or "not found".
      */
     @Override
@@ -264,13 +303,18 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Update a record in the database. Any field/value pairs in the specified values HashMap will be written into the record with the specified
-     * record key, overwriting any existing values with the same field name.
-     *
-     * @param table The name of the table
-     * @param key The record key of the record to write.
-     * @param values A HashMap of field/value pairs to update in the record
-     * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+     * Update a record in the database. Any field/value pairs in the specified
+     * values HashMap will be written into the record with the specified record
+     * key, overwriting any existing values with the same field name.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to write.
+     * @param values
+     *            A HashMap of field/value pairs to update in the record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
      */
     @Override
     public int update(String table, String key,
@@ -308,14 +352,22 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Perform a range scan for a set of records in the database. Each field/value pair from the result will be stored in a HashMap.
-     *
-     * @param table The name of the table
-     * @param startkey The record key of the first record to read.
-     * @param recordcount The number of records to read
-     * @param fields The list of fields to read, or null for all of them
-     * @param result A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
-     * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+     * Perform a range scan for a set of records in the database. Each
+     * field/value pair from the result will be stored in a HashMap.
+     * 
+     * @param table
+     *            The name of the table
+     * @param startkey
+     *            The record key of the first record to read.
+     * @param recordcount
+     *            The number of records to read
+     * @param fields
+     *            The list of fields to read, or null for all of them
+     * @param result
+     *            A Vector of HashMaps, where each HashMap is a set field/value
+     *            pairs for one record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
      */
     @Override
     public int scan(String table, String startkey, int recordcount,
@@ -355,10 +407,12 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * TODO - Finish
+     * Fills the map with the values from the DBObject.
      * 
      * @param resultMap
+     *            The map to fill/
      * @param obj
+     *            The object to copy values from.
      */
     @SuppressWarnings("unchecked")
     protected void fillMap(HashMap<String, ByteIterator> resultMap, DBObject obj) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -19,19 +19,17 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.DBAddress;
 import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.yahoo.ycsb.ByteArrayByteIterator;
 import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.DB;
 import com.yahoo.ycsb.DBException;
-
 
 /**
  * MongoDB client for YCSB framework.
@@ -48,15 +46,6 @@ public class MongoDbClient extends DB {
     /** Used to include a field in a response. */
     protected static final Integer INCLUDE = Integer.valueOf(1);
 
-    /** A singleton Mongo instance. */
-    private static MongoClient mongo;
-
-    /** The default write concern for the test. */
-    private static WriteConcern writeConcern;
-
-    /** The default read preference for the test */
-    private static ReadPreference readPreference;
-
     /** The database to access. */
     private static String database;
 
@@ -66,125 +55,14 @@ public class MongoDbClient extends DB {
      */
     private static final AtomicInteger initCount = new AtomicInteger(0);
 
-    /**
-     * Initialize any state for this DB. Called once per DB instance; there is
-     * one DB instance per client thread.
-     */
-    @Override
-    public void init() throws DBException {
-        initCount.incrementAndGet();
-        synchronized (INCLUDE) {
-            if (mongo != null) {
-                return;
-            }
+    /** A singleton Mongo instance. */
+    private static MongoClient mongo;
 
-            // initialize MongoDb driver
-            Properties props = getProperties();
-            String url = props.getProperty("mongodb.url",
-                    "mongodb://localhost:27017");
+    /** The default read preference for the test */
+    private static ReadPreference readPreference;
 
-            if (url.contains(",")) {
-                //pick one and random
-                String[] urls = url.split(",");
-                int index = new Random().nextInt(urls.length);
-                url = urls[index];
-                System.out.printf("Using Mongo URL: %s\n", url);
-            }
-
-            database = props.getProperty("mongodb.database", "ycsb");
-
-            final String maxConnections = props.getProperty(
-                    "mongodb.maxconnections", "100");
-            final String threadsAllowedToBlockForConnectionMultiplier = props
-                    .getProperty(
-                            "mongodb.threadsAllowedToBlockForConnectionMultiplier",
-                            "5");
-
-            // write concern
-            String writeConcernType = props.getProperty("mongodb.writeConcern",
-                    "acknowledged").toLowerCase();
-            if ("errors_ignored".equals(writeConcernType)) {
-                writeConcern = WriteConcern.ERRORS_IGNORED;
-            }
-            else if ("unacknowledged".equals(writeConcernType)) {
-                writeConcern = WriteConcern.UNACKNOWLEDGED;
-            }
-            else if ("acknowledged".equals(writeConcernType)) {
-                writeConcern = WriteConcern.ACKNOWLEDGED;
-            }
-            else if ("journaled".equals(writeConcernType)) {
-                writeConcern = WriteConcern.JOURNALED;
-            }
-            else if ("replica_acknowledged".equals(writeConcernType)) {
-                writeConcern = WriteConcern.REPLICA_ACKNOWLEDGED;
-            }
-            else {
-                System.err
-                        .println("ERROR: Invalid writeConcern: '"
-                                + writeConcernType
-                                + "'. "
-                                + "Must be [ errors_ignored | unacknowledged | acknowledged | journaled | replica_acknowledged ]");
-                System.exit(1);
-            }
-
-            // readPreference
-            String readPreferenceType = props.getProperty(
-                    "mongodb.readPreference", "primary").toLowerCase();
-            if ("primary".equals(readPreferenceType)) {
-                readPreference = ReadPreference.primary();
-            }
-            else if ("primary_preferred".equals(readPreferenceType)) {
-                readPreference = ReadPreference.primaryPreferred();
-            }
-            else if ("secondary".equals(readPreferenceType)) {
-                readPreference = ReadPreference.secondary();
-            }
-            else if ("secondary_preferred".equals(readPreferenceType)) {
-                readPreference = ReadPreference.secondaryPreferred();
-            }
-            else if ("nearest".equals(readPreferenceType)) {
-                readPreference = ReadPreference.nearest();
-            }
-            else {
-                System.err
-                        .println("ERROR: Invalid readPreference: '"
-                                + readPreferenceType
-                                + "'. Must be [ primary | primary_preferred | secondary | secondary_preferred | nearest ]");
-                System.exit(1);
-            }
-
-            try {
-                // strip out prefix since Java driver doesn't currently support
-                // standard connection format URL yet
-                // http://www.mongodb.org/display/DOCS/Connections
-                if (url.startsWith("mongodb://")) {
-                    url = url.substring(10);
-
-                }
-
-                // need to append db to url.
-                url += "/" + database;
-                System.out.println("new database url = " + url);
-                MongoClientOptions options = MongoClientOptions
-                        .builder()
-                        .cursorFinalizerEnabled(false)
-                        .connectionsPerHost(Integer.parseInt(maxConnections))
-                        .threadsAllowedToBlockForConnectionMultiplier(
-                                Integer.parseInt(threadsAllowedToBlockForConnectionMultiplier))
-                        .build();
-                mongo = new MongoClient(new DBAddress(url), options);
-
-                System.out.println("mongo connection created with " + url);
-            }
-            catch (Exception e1) {
-                System.err
-                        .println("Could not initialize MongoDB connection pool for Loader: "
-                                + e1.toString());
-                e1.printStackTrace();
-                return;
-            }
-        }
-    }
+    /** The default write concern for the test. */
+    private static WriteConcern writeConcern;
 
     /**
      * Cleanup any state for this DB. Called once per DB instance; there is one
@@ -233,6 +111,80 @@ public class MongoDbClient extends DB {
         finally {
             if (db != null) {
                 db.requestDone();
+            }
+        }
+    }
+
+    /**
+     * Initialize any state for this DB. Called once per DB instance; there is
+     * one DB instance per client thread.
+     */
+    @Override
+    public void init() throws DBException {
+        initCount.incrementAndGet();
+        synchronized (INCLUDE) {
+            if (mongo != null) {
+                return;
+            }
+
+            // Just use the standard connection format URL
+            // http://docs.mongodb.org/manual/reference/connection-string/
+            //
+            // Support legacy options by updating the URL as appropriate.
+            Properties props = getProperties();
+            String url = props.getProperty("mongodb.url", null);
+            boolean defaultedUrl = false;
+            if (url == null) {
+                defaultedUrl = true;
+                url = "mongodb://localhost:27017/ycsb?w=1";
+            }
+
+            url = OptionsSupport.updateUrl(url, props);
+
+            if (!url.startsWith("mongodb://")) {
+                System.err
+                        .println("ERROR: Invalid URL: '"
+                                + url
+                                + "'. Must be of the form "
+                                + "'mongodb://<host1>:<port1>,<host2>:<port2>/database?options'. "
+                                + "See http://docs.mongodb.org/manual/reference/connection-string/.");
+                System.exit(1);
+            }
+
+            try {
+                MongoClientURI uri = new MongoClientURI(url);
+
+                String uriDb = uri.getDatabase();
+                if (!defaultedUrl && (uriDb != null) && !uriDb.isEmpty()
+                        && !"admin".equals(uriDb)) {
+                    database = uriDb;
+                }
+                else {
+                    database = props.getProperty("mongodb.database", "ycsb");
+                }
+
+                if ((database == null) || database.isEmpty()) {
+                    System.err
+                            .println("ERROR: Invalid URL: '"
+                                    + url
+                                    + "'. Must provide a database name with the URI. "
+                                    + "'mongodb://<host1>:<port1>,<host2>:<port2>/database");
+                    System.exit(1);
+                }
+
+                readPreference = uri.getOptions().getReadPreference();
+                writeConcern = uri.getOptions().getWriteConcern();
+
+                mongo = new MongoClient(uri);
+
+                System.out.println("mongo connection created with " + url);
+            }
+            catch (Exception e1) {
+                System.err
+                        .println("Could not initialize MongoDB connection pool for Loader: "
+                                + e1.toString());
+                e1.printStackTrace();
+                return;
             }
         }
     }
@@ -341,54 +293,6 @@ public class MongoDbClient extends DB {
     }
 
     /**
-     * Update a record in the database. Any field/value pairs in the specified
-     * values HashMap will be written into the record with the specified record
-     * key, overwriting any existing values with the same field name.
-     * 
-     * @param table
-     *            The name of the table
-     * @param key
-     *            The record key of the record to write.
-     * @param values
-     *            A HashMap of field/value pairs to update in the record
-     * @return Zero on success, a non-zero error code on error. See this class's
-     *         description for a discussion of error codes.
-     */
-    @Override
-    public int update(String table, String key,
-            HashMap<String, ByteIterator> values) {
-        com.mongodb.DB db = null;
-        try {
-            db = mongo.getDB(database);
-
-            db.requestStart();
-
-            DBCollection collection = db.getCollection(table);
-            DBObject q = new BasicDBObject().append("_id", key);
-            DBObject u = new BasicDBObject();
-            DBObject fieldsToSet = new BasicDBObject();
-            Iterator<String> keys = values.keySet().iterator();
-            while (keys.hasNext()) {
-                String tmpKey = keys.next();
-                fieldsToSet.put(tmpKey, values.get(tmpKey).toArray());
-
-            }
-            u.put("$set", fieldsToSet);
-            collection.update(q, u, false, false, writeConcern);
-            return 0;
-        }
-        catch (Exception e) {
-            System.err.println(e.toString());
-            return 1;
-        }
-        finally {
-            if (db != null) {
-                db.requestDone();
-            }
-        }
-    }
-
-    /**
      * Perform a range scan for a set of records in the database. Each
      * field/value pair from the result will be stored in a HashMap.
      * 
@@ -446,6 +350,54 @@ public class MongoDbClient extends DB {
             }
         }
 
+    }
+
+    /**
+     * Update a record in the database. Any field/value pairs in the specified
+     * values HashMap will be written into the record with the specified record
+     * key, overwriting any existing values with the same field name.
+     * 
+     * @param table
+     *            The name of the table
+     * @param key
+     *            The record key of the record to write.
+     * @param values
+     *            A HashMap of field/value pairs to update in the record
+     * @return Zero on success, a non-zero error code on error. See this class's
+     *         description for a discussion of error codes.
+     */
+    @Override
+    public int update(String table, String key,
+            HashMap<String, ByteIterator> values) {
+        com.mongodb.DB db = null;
+        try {
+            db = mongo.getDB(database);
+
+            db.requestStart();
+
+            DBCollection collection = db.getCollection(table);
+            DBObject q = new BasicDBObject().append("_id", key);
+            DBObject u = new BasicDBObject();
+            DBObject fieldsToSet = new BasicDBObject();
+            Iterator<String> keys = values.keySet().iterator();
+            while (keys.hasNext()) {
+                String tmpKey = keys.next();
+                fieldsToSet.put(tmpKey, values.get(tmpKey).toArray());
+
+            }
+            u.put("$set", fieldsToSet);
+            collection.update(q, u, false, false, writeConcern);
+            return 0;
+        }
+        catch (Exception e) {
+            System.err.println(e.toString());
+            return 1;
+        }
+        finally {
+            if (db != null) {
+                db.requestDone();
+            }
+        }
     }
 
     /**

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -39,7 +39,7 @@ import com.yahoo.ycsb.DBException;
  * Properties to set:
  * 
  * mongodb.url=mongodb://localhost:27017 mongodb.database=ycsb
- * mongodb.writeConcern=normal
+ * mongodb.writeConcern=acknowledged
  * 
  * @author ypai
  */
@@ -90,7 +90,9 @@ public class MongoDbClient extends DB {
 
             database = props.getProperty("mongodb.database", "ycsb");
             String writeConcernType = props.getProperty("mongodb.writeConcern",
-                    "safe").toLowerCase();
+                    "acknowledged").toLowerCase();
+
+            // Set connectionpool to size of ycsb thread pool
             final String maxConnections = props.getProperty(
                     "mongodb.maxconnections", "10");
             final String threadsAllowedToBlockForConnectionMultiplier = props
@@ -98,27 +100,27 @@ public class MongoDbClient extends DB {
                             "mongodb.threadsAllowedToBlockForConnectionMultiplier",
                             "5");
 
-            if ("none".equals(writeConcernType)) {
-                writeConcern = WriteConcern.NONE;
+            if ("errors_ignored".equals(writeConcernType)) {
+                writeConcern = WriteConcern.ERRORS_IGNORED;
             }
-            else if ("safe".equals(writeConcernType)) {
-                writeConcern = WriteConcern.SAFE;
+            else if ("unacknowledged".equals(writeConcernType)) {
+                writeConcern = WriteConcern.UNACKNOWLEDGED;
             }
-            else if ("normal".equals(writeConcernType)) {
-                writeConcern = WriteConcern.NORMAL;
+            else if ("acknowledged".equals(writeConcernType)) {
+                writeConcern = WriteConcern.ACKNOWLEDGED;
             }
-            else if ("fsync_safe".equals(writeConcernType)) {
-                writeConcern = WriteConcern.FSYNC_SAFE;
+            else if ("journaled".equals(writeConcernType)) {
+                writeConcern = WriteConcern.JOURNALED;
             }
-            else if ("replicas_safe".equals(writeConcernType)) {
-                writeConcern = WriteConcern.REPLICAS_SAFE;
+            else if ("replica_acknowledged".equals(writeConcernType)) {
+                writeConcern = WriteConcern.REPLICA_ACKNOWLEDGED;
             }
             else {
                 System.err
                         .println("ERROR: Invalid writeConcern: '"
                                 + writeConcernType
                                 + "'. "
-                                + "Must be [ none | safe | normal | fsync_safe | replicas_safe ]");
+                                + "Must be [ errors_ignored | unacknowledged | acknowledged | journaled | replica_acknowledged ]");
                 System.exit(1);
             }
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -261,11 +261,15 @@ public class MongoDbClient extends DB {
             db.requestStart();
 
             DBCollection collection = db.getCollection(table);
-            DBObject r = new BasicDBObject().append("_id", key);
+            DBObject criteria = new BasicDBObject().append("_id", key);
+            DBObject toInsert = new BasicDBObject().append("_id", key);
+
             for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
-                r.put(entry.getKey(), entry.getValue().toArray());
+                toInsert.put(entry.getKey(), entry.getValue().toArray());
             }
-            collection.insert(r, writeConcern);
+
+            collection.update(criteria, toInsert, true, false, writeConcern);
+
             return 0;
         }
         catch (Exception e) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -194,7 +194,7 @@ public class MongoDbClient extends DB {
             DBCollection collection = db.getCollection(table);
             DBObject q = new BasicDBObject().append("_id", key);
             WriteResult res = collection.remove(q, writeConcern);
-            return res.getN() == 1 ? 0 : 1;
+            return 0;
         }
         catch (Exception e) {
             System.err.println(e.toString());
@@ -236,7 +236,7 @@ public class MongoDbClient extends DB {
                 r.put(entry.getKey(), entry.getValue().toArray());
             }
             WriteResult res = collection.insert(r, writeConcern);
-            return res.getError() == null ? 0 : 1;
+            return 0;
         }
         catch (Exception e) {
             e.printStackTrace();
@@ -341,7 +341,7 @@ public class MongoDbClient extends DB {
             u.put("$set", fieldsToSet);
             WriteResult res = collection.update(q, u, false, false,
                     writeConcern);
-            return res.getN() == 1 ? 0 : 1;
+            return 0;
         }
         catch (Exception e) {
             System.err.println(e.toString());

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -26,7 +26,6 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.WriteConcern;
-import com.mongodb.WriteResult;
 import com.yahoo.ycsb.ByteArrayByteIterator;
 import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.DB;
@@ -94,7 +93,7 @@ public class MongoDbClient extends DB {
 
             // Set connectionpool to size of ycsb thread pool
             final String maxConnections = props.getProperty(
-                    "mongodb.maxconnections", "10");
+                    "mongodb.maxconnections", "100");
             final String threadsAllowedToBlockForConnectionMultiplier = props
                     .getProperty(
                             "mongodb.threadsAllowedToBlockForConnectionMultiplier",
@@ -193,7 +192,7 @@ public class MongoDbClient extends DB {
             db.requestStart();
             DBCollection collection = db.getCollection(table);
             DBObject q = new BasicDBObject().append("_id", key);
-            WriteResult res = collection.remove(q, writeConcern);
+            collection.remove(q, writeConcern);
             return 0;
         }
         catch (Exception e) {
@@ -235,7 +234,7 @@ public class MongoDbClient extends DB {
             for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
                 r.put(entry.getKey(), entry.getValue().toArray());
             }
-            WriteResult res = collection.insert(r, writeConcern);
+            collection.insert(r, writeConcern);
             return 0;
         }
         catch (Exception e) {
@@ -339,8 +338,7 @@ public class MongoDbClient extends DB {
 
             }
             u.put("$set", fieldsToSet);
-            WriteResult res = collection.update(q, u, false, false,
-                    writeConcern);
+            collection.update(q, u, false, false, writeConcern);
             return 0;
         }
         catch (Exception e) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -24,8 +24,13 @@ import java.util.Properties;
 
 /**
  * OptionsSupport provides methods for handling legacy options.
+ * 
+ * @author rjm
  */
 public final class OptionsSupport {
+
+    /** Value for an unavailable property. */
+    protected static final String UNAVAILABLE = "n/a";
 
     /**
      * Updates the URL with the appropriate attributes if legacy properties are
@@ -42,8 +47,8 @@ public final class OptionsSupport {
 
         // max connections.
         final String maxConnections = props.getProperty(
-                "mongodb.maxconnections", "N/A");
-        if (!"N/A".equals(maxConnections)) {
+                "mongodb.maxconnections", UNAVAILABLE).toLowerCase();
+        if (!UNAVAILABLE.equals(maxConnections)) {
             result = addUrlOption(result, "maxPoolSize", maxConnections);
         }
 
@@ -51,16 +56,16 @@ public final class OptionsSupport {
         final String threadsAllowedToBlockForConnectionMultiplier = props
                 .getProperty(
                         "mongodb.threadsAllowedToBlockForConnectionMultiplier",
-                        "N/A");
-        if (!"N/A".equals(threadsAllowedToBlockForConnectionMultiplier)) {
+                        UNAVAILABLE).toLowerCase();
+        if (!UNAVAILABLE.equals(threadsAllowedToBlockForConnectionMultiplier)) {
             result = addUrlOption(result, "waitQueueMultiple",
                     threadsAllowedToBlockForConnectionMultiplier);
         }
 
         // write concern
         String writeConcernType = props.getProperty("mongodb.writeConcern",
-                "N/A").toLowerCase();
-        if (!"N/A".equals(writeConcernType)) {
+                UNAVAILABLE).toLowerCase();
+        if (!UNAVAILABLE.equals(writeConcernType)) {
             if ("errors_ignored".equals(writeConcernType)) {
                 result = addUrlOption(result, "w", "0");
             }
@@ -83,9 +88,9 @@ public final class OptionsSupport {
         }
 
         // read preference
-        String readPreferenceType = props.getProperty("mongodb.writeConcern",
-                "N/A").toLowerCase();
-        if (!"N/A".equals(readPreferenceType)) {
+        String readPreferenceType = props.getProperty("mongodb.readPreference",
+                UNAVAILABLE).toLowerCase();
+        if (!UNAVAILABLE.equals(readPreferenceType)) {
             if ("primary".equals(readPreferenceType)) {
                 result = addUrlOption(result, "readPreference", "primary");
             }

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -81,9 +81,14 @@ public final class OptionsSupport {
             else if ("replica_acknowledged".equals(writeConcernType)) {
                 result = addUrlOption(result, "w", "2");
             }
+            else if ("majority".equals(writeConcernType)) {
+                result = addUrlOption(result, "w", "majority");
+            }
             else {
                 System.err.println("WARNING: Invalid writeConcern: '"
-                        + writeConcernType + "' will be ignored.");
+                        + writeConcernType + "' will be ignored. "
+                        + "Must be one of [ unacknowledged | acknowledged | "
+                        + "journaled | replica_acknowledged | majority ]");
             }
         }
 
@@ -110,7 +115,9 @@ public final class OptionsSupport {
             }
             else {
                 System.err.println("WARNING: Invalid readPreference: '"
-                        + readPreferenceType + "' will be ignored.");
+                        + readPreferenceType + "' will be ignored. "
+                        + "Must be one of [ primary | primary_preferred | "
+                        + "secondary | secondary_preferred | nearest ]");
             }
         }
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -27,6 +27,16 @@ import java.util.Properties;
  */
 public final class OptionsSupport {
 
+    /**
+     * Updates the URL with the appropriate attributes if legacy properties are
+     * set and the URL does not have the property already set.
+     * 
+     * @param url
+     *            The URL to update.
+     * @param props
+     *            The legacy properties.
+     * @return The updated URL.
+     */
     public static String updateUrl(String url, Properties props) {
         String result = url;
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * OptionsSupport.java - mongodb-binding - Yahoo!, Inc.
+ * %%
+ * Copyright (C) 2015 Yahoo!, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.yahoo.ycsb.db;
+
+import java.util.Properties;
+
+/**
+ * OptionsSupport provides methods for handling legacy options.
+ */
+public final class OptionsSupport {
+
+    public static String updateUrl(String url, Properties props) {
+        String result = url;
+
+        // max connections.
+        final String maxConnections = props.getProperty(
+                "mongodb.maxconnections", "N/A");
+        if (!"N/A".equals(maxConnections)) {
+            result = addUrlOption(result, "maxPoolSize", maxConnections);
+        }
+
+        // Blocked thread multiplier.
+        final String threadsAllowedToBlockForConnectionMultiplier = props
+                .getProperty(
+                        "mongodb.threadsAllowedToBlockForConnectionMultiplier",
+                        "N/A");
+        if (!"N/A".equals(threadsAllowedToBlockForConnectionMultiplier)) {
+            result = addUrlOption(result, "waitQueueMultiple",
+                    threadsAllowedToBlockForConnectionMultiplier);
+        }
+
+        // write concern
+        String writeConcernType = props.getProperty("mongodb.writeConcern",
+                "N/A").toLowerCase();
+        if (!"N/A".equals(writeConcernType)) {
+            if ("errors_ignored".equals(writeConcernType)) {
+                result = addUrlOption(result, "w", "0");
+            }
+            else if ("unacknowledged".equals(writeConcernType)) {
+                result = addUrlOption(result, "w", "0");
+            }
+            else if ("acknowledged".equals(writeConcernType)) {
+                result = addUrlOption(result, "w", "1");
+            }
+            else if ("journaled".equals(writeConcernType)) {
+                result = addUrlOption(result, "journal", "true");
+            }
+            else if ("replica_acknowledged".equals(writeConcernType)) {
+                result = addUrlOption(result, "w", "2");
+            }
+            else {
+                System.err.println("WARNING: Invalid writeConcern: '"
+                        + writeConcernType + "' will be ignored.");
+            }
+        }
+
+        // read preference
+        String readPreferenceType = props.getProperty("mongodb.writeConcern",
+                "N/A").toLowerCase();
+        if (!"N/A".equals(readPreferenceType)) {
+            if ("primary".equals(readPreferenceType)) {
+                result = addUrlOption(result, "readPreference", "primary");
+            }
+            else if ("primary_preferred".equals(readPreferenceType)) {
+                result = addUrlOption(result, "readPreference",
+                        "primaryPreferred");
+            }
+            else if ("secondary".equals(readPreferenceType)) {
+                result = addUrlOption(result, "readPreference", "secondary");
+            }
+            else if ("secondary_preferred".equals(readPreferenceType)) {
+                result = addUrlOption(result, "readPreference",
+                        "secondaryPreferred");
+            }
+            else if ("nearest".equals(readPreferenceType)) {
+                result = addUrlOption(result, "readPreference", "nearest");
+            }
+            else {
+                System.err.println("WARNING: Invalid readPreference: '"
+                        + readPreferenceType + "' will be ignored.");
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Adds an option to the url if it does not already contain the option.
+     * 
+     * @param url
+     *            The URL to append the options to.
+     * @param name
+     *            The name of the option.
+     * @param value
+     *            The value for the option.
+     * @return The updated URL.
+     */
+    private static String addUrlOption(String url, String name, String value) {
+        String fullName = name + "=";
+        if (!url.contains(fullName)) {
+            if (url.contains("?")) {
+                return url + "&" + fullName + value;
+            }
+            return url + "?" + fullName + value;
+        }
+        return url;
+    }
+}

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
@@ -115,6 +115,10 @@ public class OptionsSupportTest {
                 updateUrl("mongodb://locahost:27017/?foo=bar",
                         props("mongodb.writeConcern", "replica_acknowledged")),
                 is("mongodb://locahost:27017/?foo=bar&w=2"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.writeConcern", "majority")),
+                is("mongodb://locahost:27017/?foo=bar&w=majority"));
 
         // w already exists.
         assertThat(

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
@@ -1,0 +1,189 @@
+/*
+ * #%L
+ * OptionsSupport.java - mongodb-binding - Yahoo!, Inc.
+ * %%
+ * Copyright (C) 2015 Yahoo!, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.yahoo.ycsb.db;
+
+import static com.yahoo.ycsb.db.OptionsSupport.updateUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+/**
+ * OptionsSupportTest provides tests for the OptionsSupport class.
+ * 
+ * @author rjm
+ */
+public class OptionsSupportTest {
+
+    /**
+     * Test method for {@link OptionsSupport#updateUrl(String, Properties)} for
+     * {@code mongodb.maxconnections}.
+     */
+    @Test
+    public void testUpdateUrlMaxConnections() {
+        assertThat(
+                updateUrl("mongodb://locahost:27017/",
+                        props("mongodb.maxconnections", "1234")),
+                is("mongodb://locahost:27017/?maxPoolSize=1234"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.maxconnections", "1234")),
+                is("mongodb://locahost:27017/?foo=bar&maxPoolSize=1234"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?maxPoolSize=1",
+                        props("mongodb.maxconnections", "1234")),
+                is("mongodb://locahost:27017/?maxPoolSize=1"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("foo", "1234")),
+                is("mongodb://locahost:27017/?foo=bar"));
+    }
+
+    /**
+     * Test method for {@link OptionsSupport#updateUrl(String, Properties)} for
+     * {@code mongodb.threadsAllowedToBlockForConnectionMultiplier}.
+     */
+    @Test
+    public void testUpdateUrlWaitQueueMultiple() {
+        assertThat(
+                updateUrl(
+                        "mongodb://locahost:27017/",
+                        props("mongodb.threadsAllowedToBlockForConnectionMultiplier",
+                                "1234")),
+                is("mongodb://locahost:27017/?waitQueueMultiple=1234"));
+        assertThat(
+                updateUrl(
+                        "mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.threadsAllowedToBlockForConnectionMultiplier",
+                                "1234")),
+                is("mongodb://locahost:27017/?foo=bar&waitQueueMultiple=1234"));
+        assertThat(
+                updateUrl(
+                        "mongodb://locahost:27017/?waitQueueMultiple=1",
+                        props("mongodb.threadsAllowedToBlockForConnectionMultiplier",
+                                "1234")),
+                is("mongodb://locahost:27017/?waitQueueMultiple=1"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("foo", "1234")),
+                is("mongodb://locahost:27017/?foo=bar"));
+    }
+
+    /**
+     * Test method for {@link OptionsSupport#updateUrl(String, Properties)} for
+     * {@code mongodb.threadsAllowedToBlockForConnectionMultiplier}.
+     */
+    @Test
+    public void testUpdateUrlWriteConcern() {
+        assertThat(
+                updateUrl("mongodb://locahost:27017/",
+                        props("mongodb.writeConcern", "errors_ignored")),
+                is("mongodb://locahost:27017/?w=0"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.writeConcern", "unacknowledged")),
+                is("mongodb://locahost:27017/?foo=bar&w=0"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.writeConcern", "acknowledged")),
+                is("mongodb://locahost:27017/?foo=bar&w=1"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.writeConcern", "journaled")),
+                is("mongodb://locahost:27017/?foo=bar&journal=true"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.writeConcern", "replica_acknowledged")),
+                is("mongodb://locahost:27017/?foo=bar&w=2"));
+
+        // w already exists.
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?w=1",
+                        props("mongodb.writeConcern", "acknowledged")),
+                is("mongodb://locahost:27017/?w=1"));
+
+        // Unknown options
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("foo", "1234")),
+                is("mongodb://locahost:27017/?foo=bar"));
+    }
+
+    /**
+     * Test method for {@link OptionsSupport#updateUrl(String, Properties)} for
+     * {@code mongodb.threadsAllowedToBlockForConnectionMultiplier}.
+     */
+    @Test
+    public void testUpdateUrlReadPreference() {
+        assertThat(
+                updateUrl("mongodb://locahost:27017/",
+                        props("mongodb.readPreference", "primary")),
+                is("mongodb://locahost:27017/?readPreference=primary"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.readPreference", "primary_preferred")),
+                is("mongodb://locahost:27017/?foo=bar&readPreference=primaryPreferred"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.readPreference", "secondary")),
+                is("mongodb://locahost:27017/?foo=bar&readPreference=secondary"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.readPreference", "secondary_preferred")),
+                is("mongodb://locahost:27017/?foo=bar&readPreference=secondaryPreferred"));
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("mongodb.readPreference", "nearest")),
+                is("mongodb://locahost:27017/?foo=bar&readPreference=nearest"));
+
+        // readPreference already exists.
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?readPreference=primary",
+                        props("mongodb.readPreference", "secondary")),
+                is("mongodb://locahost:27017/?readPreference=primary"));
+
+        // Unknown options
+        assertThat(
+                updateUrl("mongodb://locahost:27017/?foo=bar",
+                        props("foo", "1234")),
+                is("mongodb://locahost:27017/?foo=bar"));
+    }
+
+    /**
+     * Factory method for a {@link Properties} object.
+     * 
+     * @param key
+     *            The key for the property to set.
+     * @param value
+     *            The value for the property to set.
+     * @return The {@link Properties} with the property added.
+     */
+    private Properties props(String key, String value) {
+        Properties props = new Properties();
+
+        props.setProperty(key, value);
+
+        return props;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>2.13.1</mongodb.version>
-    <mongodb.async.version>1.2.3</mongodb.async.version>
+    <mongodb.async.version>2.0.0-SNAPSHOT</mongodb.async.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>
@@ -111,5 +111,38 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>
+    									org.apache.maven.plugins
+    								</groupId>
+    								<artifactId>
+    									maven-checkstyle-plugin
+    								</artifactId>
+    								<versionRange>[2.6,)</versionRange>
+    								<goals>
+    									<goal>checkstyle</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>2.13.1</mongodb.version>
+    <mongodb.async.version>1.2.3</mongodb.async.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,38 +111,5 @@
         </executions>
       </plugin>
     </plugins>
-    <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>
-    									org.apache.maven.plugins
-    								</groupId>
-    								<artifactId>
-    									maven-checkstyle-plugin
-    								</artifactId>
-    								<versionRange>[2.6,)</versionRange>
-    								<goals>
-    									<goal>checkstyle</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
-    	</plugins>
-    </pluginManagement>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
-    <mongodb.version>2.13.1</mongodb.version>
-    <mongodb.async.version>2.0.0-SNAPSHOT</mongodb.async.version>
+    <mongodb.version>3.0.1</mongodb.version>
+    <mongodb.async.version>2.0.1</mongodb.async.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>


### PR DESCRIPTION
This pull request contains a new driver for MongoDB based on the [asynchronous driver](http://github.com/allanbank/mongodb-async-driver). The bulk of the changes are adding the required logic to the startup scripts to support the second driver. I have used this branch to run a series of [benchmarks](http://www.allanbank.com/mongodb-async-driver/performance/ycsb.html).

There are also a number of community contributed updates to the old MongoDB Driver. These include:

* Updated README with specific instructions for running a MongoDB suite.
* Updates to the configuration to now be strictly based on a [MongoDB Connection String URI](http://docs.mongodb.org/manual/reference/connection-string/) which is standardized across drivers.
* Other small fixes and performance enhancements.

This pull request will supersede the following pull requests:

* [PR-112](https://github.com/brianfrankcooper/YCSB/pull/112) - Integrates the MongoDB Connection String URI for both drivers.
* [PR-115](https://github.com/brianfrankcooper/YCSB/pull/115) - The writeConcern and readPreference are expressed via the standardized  MongoDB Connection String URI.
* [PR-131](https://github.com/brianfrankcooper/YCSB/pull/131) - Read preferences are passed via the MongoDB Connection String and replica sets are automatically detected for the asynchronous driver and will be enabled with the MongoDB Inc. driver by passing multiple servers in the URI.

I know this is a large volume of changes but they are all focused on the MongoDB driver and thought it would be easier to provide them in one batch than a bunch of pull requests. If you would prefer a bunch of smaller changes I will need guidance on the desired granularity. 