### PR TITLE
Fix hbase client's write bug in debug mode.

### DIFF
--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -316,11 +316,12 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         Put p = new Put(Bytes.toBytes(key));
         for (Map.Entry<String, ByteIterator> entry : values.entrySet())
         {
+            byte[] value = entry.getValue().toArray();
             if (_debug) {
                 System.out.println("Adding field/value " + entry.getKey() + "/"+
-                  entry.getValue() + " to put request");
+                  Bytes.toStringBinary(value) + " to put request");
             }
-            p.add(_columnFamilyBytes,Bytes.toBytes(entry.getKey()),entry.getValue().toArray());
+            p.add(_columnFamilyBytes,Bytes.toBytes(entry.getKey()), value);
         }
 
         try

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -372,11 +372,12 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
         p.setDurability(_durability);
         for (Map.Entry<String, ByteIterator> entry : values.entrySet())
         {
+            byte[] value = entry.getValue().toArray();
             if (_debug) {
                 System.out.println("Adding field/value " + entry.getKey() + "/"+
-                        entry.getValue() + " to put request");
+                        Bytes.toStringBinary(value) + " to put request");
             }
-            p.add(_columnFamilyBytes,Bytes.toBytes(entry.getKey()),entry.getValue().toArray());
+            p.add(_columnFamilyBytes,Bytes.toBytes(entry.getKey()), value);
         }
 
         try


### PR DESCRIPTION
Hbase client has a bug to write all values as empty byte arrays in debug mode. It is caused by an illegal use of ByteIterator. Values returned from toString() or toArray() should be cached if they are needed later.