### PR TITLE
Synchronize Measurements.getSummary() method to prevent ConcurrentModificationExceptions

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -154,7 +154,7 @@ public class Measurements
       /**
        * Return a one line summary of the measurements.
        */
-	public String getSummary()
+	public synchronized String getSummary()
 	{
 		String ret="";
 		for (OneMeasurement m : data.values())


### PR DESCRIPTION
Previously the method `Measurements.getSummary()` wasn't set to synchronized, which was occasionally resulting in `java.util.ConcurrentModificationException` being raised when running YCSB with multiple threads. This commit fixes the issue by simply adding the `synchronized` keyword to `Measurements.getSummary()`.

Let me know if you can think of any potential issues with making this change. I'm unsure if `getSummary()` was deliberately left unsynchronized for a reason?