### PR TITLE
Remove hard-coded property key strings in favour of string constants

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -378,8 +378,6 @@ public class Client
      */
     public static final String TARGET_PROPERTY="target";
 
-    public static final String MEASUREMENT_TYPE_PROPERTY="measurementtype";
-
     /**
    * The maximum amount of time (in seconds) for which the benchmark will be run.
    */
@@ -775,7 +773,7 @@ public class Client
 		if (status)
 		{
 			boolean standardstatus=false;
-			if (props.getProperty(MEASUREMENT_TYPE_PROPERTY,"").compareTo("timeseries")==0)
+			if (props.getProperty(Measurements.MEASUREMENT_TYPE_PROPERTY,"").compareTo("timeseries")==0)
 			{
 				standardstatus=true;
 			}	

--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -329,12 +329,43 @@ class ClientThread extends Thread
 public class Client
 {
 
+    /**
+     * The target number of operations to perform.
+     */
 	public static final String OPERATION_COUNT_PROPERTY="operationcount";
 
+    /**
+     * The number of records to load into the database initially.
+     */
 	public static final String RECORD_COUNT_PROPERTY="recordcount";
 
+    /**
+     * The workload class to be loaded.
+     */
 	public static final String WORKLOAD_PROPERTY="workload";
 	
+	/**
+     * The database class to be used.
+     */
+    public static final String DB_PROPERTY="db";
+
+    /**
+     * The exporter class to be used. The default is
+     * com.yahoo.ycsb.measurements.exporter.TextMeasurementsExporter.
+     */
+    public static final String EXPORTER_PROPERTY="exporter";
+
+    /**
+     * If set to the path of a file, YCSB will write all output to this file
+     * instead of STDOUT.
+     */
+    public static final String EXPORT_FILE_PROPERTY="exportfile";
+
+    /**
+     * The number of YCSB client threads to run.
+     */
+    public static final String THREAD_COUNT_PROPERTY="threadcount";
+
 	/**
 	 * Indicates how many inserts to do, if less than recordcount. Useful for partitioning
 	 * the load among multiple servers, if the client is the bottleneck. Additionally, workloads
@@ -343,6 +374,13 @@ public class Client
 	public static final String INSERT_COUNT_PROPERTY="insertcount";
 	
 	/**
+     * Target number of operations per second
+     */
+    public static final String TARGET_PROPERTY="target";
+
+    public static final String MEASUREMENT_TYPE_PROPERTY="measurementtype";
+
+    /**
    * The maximum amount of time (in seconds) for which the benchmark will be run.
    */
   public static final String MAX_EXECUTION_TIME = "maxexecutiontime";
@@ -400,7 +438,7 @@ public class Client
 		{
 			// if no destination file is provided the results will be written to stdout
 			OutputStream out;
-			String exportFile = props.getProperty("exportfile");
+			String exportFile = props.getProperty(EXPORT_FILE_PROPERTY);
 			if (exportFile == null)
 			{
 				out = System.out;
@@ -410,7 +448,7 @@ public class Client
 			}
 
 			// if no exporter is provided the default text one will be used
-			String exporterStr = props.getProperty("exporter", "com.yahoo.ycsb.measurements.exporter.TextMeasurementsExporter");
+			String exporterStr = props.getProperty(EXPORTER_PROPERTY, "com.yahoo.ycsb.measurements.exporter.TextMeasurementsExporter");
 			try
 			{
 				exporter = (MeasurementsExporter) Class.forName(exporterStr).getConstructor(OutputStream.class).newInstance(out);
@@ -468,7 +506,7 @@ public class Client
 					System.exit(0);
 				}
 				int tcount=Integer.parseInt(args[argindex]);
-				props.setProperty("threadcount", tcount+"");
+				props.setProperty(THREAD_COUNT_PROPERTY, tcount+"");
 				argindex++;
 			}
 			else if (args[argindex].compareTo("-target")==0)
@@ -480,7 +518,7 @@ public class Client
 					System.exit(0);
 				}
 				int ttarget=Integer.parseInt(args[argindex]);
-				props.setProperty("target", ttarget+"");
+				props.setProperty(TARGET_PROPERTY, ttarget+"");
 				argindex++;
 			}
 			else if (args[argindex].compareTo("-load")==0)
@@ -506,7 +544,7 @@ public class Client
 					usageMessage();
 					System.exit(0);
 				}
-				props.setProperty("db",args[argindex]);
+				props.setProperty(DB_PROPERTY,args[argindex]);
 				argindex++;
 			}
 			else if (args[argindex].compareTo("-l")==0)
@@ -614,9 +652,9 @@ public class Client
 		long maxExecutionTime = Integer.parseInt(props.getProperty(MAX_EXECUTION_TIME, "0"));
 
 		//get number of threads, target and db
-		threadcount=Integer.parseInt(props.getProperty("threadcount","1"));
-		dbname=props.getProperty("db","com.yahoo.ycsb.BasicDB");
-		target=Integer.parseInt(props.getProperty("target","0"));
+		threadcount=Integer.parseInt(props.getProperty(THREAD_COUNT_PROPERTY,"1"));
+		dbname=props.getProperty(DB_PROPERTY,"com.yahoo.ycsb.BasicDB");
+		target=Integer.parseInt(props.getProperty(TARGET_PROPERTY,"0"));
 		
 		//compute the target throughput
 		double targetperthreadperms=-1;
@@ -737,7 +775,7 @@ public class Client
 		if (status)
 		{
 			boolean standardstatus=false;
-			if (props.getProperty("measurementtype","").compareTo("timeseries")==0) 
+			if (props.getProperty(MEASUREMENT_TYPE_PROPERTY,"").compareTo("timeseries")==0)
 			{
 				standardstatus=true;
 			}	

--- a/core/src/main/java/com/yahoo/ycsb/CommandLine.java
+++ b/core/src/main/java/com/yahoo/ycsb/CommandLine.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.HashSet;
 import java.util.Vector;
 
+import com.yahoo.ycsb.Client;
 import com.yahoo.ycsb.workloads.*;
 
 /**
@@ -89,7 +90,7 @@ public class CommandLine
 		  usageMessage();
 		  System.exit(0);
 	       }
-	       props.setProperty("db",args[argindex]);
+	       props.setProperty(Client.DB_PROPERTY, args[argindex]);
 	       argindex++;
 	    }
 	    else if (args[argindex].compareTo("-P")==0)

--- a/core/src/main/java/com/yahoo/ycsb/CommandLine.java
+++ b/core/src/main/java/com/yahoo/ycsb/CommandLine.java
@@ -188,7 +188,7 @@ public class CommandLine
 	 System.out.println("Start with \"-help\" for usage info");
 
 	 //create a DB
-	 String dbname=props.getProperty("db",DEFAULT_DB);
+	 String dbname=props.getProperty(Client.DB_PROPERTY, DEFAULT_DB);
 
 	 ClassLoader classLoader = CommandLine.class.getClassLoader();
 

--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -31,7 +31,7 @@ import com.yahoo.ycsb.measurements.exporter.MeasurementsExporter;
  */
 public class Measurements
 {
-	private static final String MEASUREMENT_TYPE_PROPERTY = "measurementtype";
+	public static final String MEASUREMENT_TYPE_PROPERTY = "measurementtype";
 
 	private static final String MEASUREMENT_TYPE_PROPERTY_DEFAULT = "histogram";
 

--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -31,9 +31,9 @@ import com.yahoo.ycsb.measurements.exporter.MeasurementsExporter;
  */
 public class Measurements
 {
-	private static final String MEASUREMENT_TYPE = "measurementtype";
+	private static final String MEASUREMENT_TYPE_PROPERTY = "measurementtype";
 
-	private static final String MEASUREMENT_TYPE_DEFAULT = "histogram";
+	private static final String MEASUREMENT_TYPE_PROPERTY_DEFAULT = "histogram";
 
 	static Measurements singleton=null;
 	
@@ -70,7 +70,7 @@ public class Measurements
 		
 		_props=props;
 		
-		if (_props.getProperty(MEASUREMENT_TYPE, MEASUREMENT_TYPE_DEFAULT).compareTo("histogram")==0)
+		if (_props.getProperty(MEASUREMENT_TYPE_PROPERTY, MEASUREMENT_TYPE_PROPERTY_DEFAULT).compareTo("histogram")==0)
 		{
 			histogram=true;
 		}


### PR DESCRIPTION
Previously the YCSB core code contained some hard-coded property keys, with others defined as constants. This pull request removes the remaining hard-coded strings in favour of string constants defined in `core/src/main/java/com/yahoo/ycsb/Client.java` and `core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java`.