### PR TITLE
Remove mapkeeper so that build passes

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/TerminatorThread.java
+++ b/core/src/main/java/com/yahoo/ycsb/TerminatorThread.java
@@ -58,7 +58,7 @@ public class TerminatorThread extends Thread {
         try {
           t.join(waitTimeOutInMS);
           if (t.isAlive()) {
-            System.err.println("Still waiting for thread " + t.getName() + " to complete. " +
+            System.out.println("Still waiting for thread " + t.getName() + " to complete. " +
                 "Workload status: " + workload.isStopRequested());
           }
         } catch (InterruptedException e) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -9,27 +9,14 @@
 
 package com.yahoo.ycsb.db;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import com.mongodb.BasicDBObject;
-import com.mongodb.DBAddress;
-import com.mongodb.DBCollection;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import com.mongodb.Mongo;
-import com.mongodb.MongoOptions;
-import com.mongodb.WriteConcern;
-import com.mongodb.WriteResult;
+import com.mongodb.*;
 import com.yahoo.ycsb.ByteArrayByteIterator;
 import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.DB;
 import com.yahoo.ycsb.DBException;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * MongoDB client for YCSB framework.
@@ -74,6 +61,15 @@ public class MongoDbClient extends DB {
             Properties props = getProperties();
             String url = props.getProperty("mongodb.url",
                     "mongodb://localhost:27017");
+
+            if (url.contains(",")) {
+                //pick one and random
+                String[] urls = url.split(",");
+                int index = new Random().nextInt(urls.length);
+                url = urls[index];
+                System.out.printf("Using Mongo URL: %s\n", url);
+            }
+
             database = props.getProperty("mongodb.database", "ycsb");
             String writeConcernType = props.getProperty("mongodb.writeConcern",
                     "safe").toLowerCase();

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <cassandra.version>0.7.0</cassandra.version>
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
-    <mapkeeper.version>1.0</mapkeeper.version>
+    <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>2.11.2</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
@@ -68,10 +68,9 @@
     <module>accumulo</module>
     <module>dynamodb</module>
     <module>elasticsearch</module>
-    <!--<module>gemfire</module>-->
     <module>infinispan</module>
     <module>jdbc</module>
-    <module>mapkeeper</module>
+    <!--<module>mapkeeper</module>-->
     <module>mongodb</module>
     <module>orientdb</module>
     <!--module>nosqldb</module-->

--- a/pom.xml
+++ b/pom.xml
@@ -68,16 +68,16 @@
     <module>accumulo</module>
     <module>dynamodb</module>
     <module>elasticsearch</module>
-    <!--<module>gemfire</module>-->
     <module>infinispan</module>
     <module>jdbc</module>
-    <!--<module>mapkeeper</module>-->
     <module>mongodb</module>
     <module>orientdb</module>
-    <!--module>nosqldb</module-->
     <module>redis</module>
     <module>voldemort</module>
     <module>distribution</module>
+    <!--<module>mapkeeper</module>-->
+    <!--module>nosqldb</module-->
+    <!--<module>gemfire</module>-->
   </modules>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <version>1.6.4</version>
     </dependency>
   </dependencies>
- 
+
   <!-- Properties Management -->
   <properties>
     <maven.assembly.version>2.2.1</maven.assembly.version>
@@ -68,6 +68,7 @@
     <module>accumulo</module>
     <module>dynamodb</module>
     <module>elasticsearch</module>
+    <!--<module>gemfire</module>-->
     <module>infinispan</module>
     <module>jdbc</module>
     <!--<module>mapkeeper</module>-->


### PR DESCRIPTION
Looks like MapKeeper has been failing for some time due the jar not being available. Lets remove the dependency for now so commits can run the build. 