### PR TITLE
Use more recent monogdb bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <mapkeeper.version>1.0</mapkeeper.version>
-    <mongodb.version>2.11.2</mongodb.version>
+    <mongodb.version>2.13.0</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
     <voldemort.version>0.81</voldemort.version>


### PR DESCRIPTION
Versions >= 2.12 use the new bulk API. So there might be a big performance difference. 