### PR TITLE
Client-Server mode benchmark support for infinispan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output*
 .project
 .classpath
 .settings
+.checkstyle

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ output*
 .classpath
 .settings
 .checkstyle
+
+.DS_Store

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -34,6 +34,7 @@ DATABASES = {
     "gemfire"      : "com.yahoo.ycsb.db.GemFireClient",
     "hbase"        : "com.yahoo.ycsb.db.HBaseClient",
     "hypertable"   : "com.yahoo.ycsb.db.HypertableClient",
+    "infinispan-cs": "com.yahoo.ycsb.db.InfinispanRemoteClient",
     "infinispan"   : "com.yahoo.ycsb.db.InfinispanClient",
     "jdbc"         : "com.yahoo.ycsb.db.JdbcDBClient",
     "mapkeeper"    : "com.yahoo.ycsb.db.MapKeeperClient",

--- a/infinispan/README.md
+++ b/infinispan/README.md
@@ -1,0 +1,41 @@
+## Quick Start
+
+This section describes how to run YCSB on infinispan. 
+
+### 1. Install Java and Maven
+
+### 2. Set Up YCSB
+1. Git clone YCSB and compile:
+  ```
+git clone http://github.com/brianfrankcooper/YCSB.git
+cd YCSB
+mvn clean package
+  ```
+
+2. Copy and untar YCSB distribution in distribution/target/ycsb-x.x.x.tar.gz to target machine
+
+### 4. Load data and run tests
+####4.1 embedded mode with cluster or not
+Load the data:
+```
+./bin/ycsb load infinispan -P workloads/workloada -p infinispan.clustered=<true or false>
+```
+Run the workload test:
+```
+./bin/ycsb run infinispan -s -P workloads/workloada -p infinispan.clustered=<true or false>
+```
+####4.2 client-server mode
+    
+1. start infinispan server
+
+2. read [RemoteCacheManager](http://docs.jboss.org/infinispan/7.2/apidocs/org/infinispan/client/hotrod/RemoteCacheManager.html) doc and customize hotrod client properties in infinispan-bindinf/conf/remote-cache.properties
+
+3. Load the data with specified cache:
+  ```
+./bin/ycsb load infinispan-cs -s -P workloads/workloada -P infinispan-binding/conf/remote-cache.properties -p cache=<cache name>
+  ```
+
+4. Run the workload test with specified cache:
+  ```
+./bin/ycsb run infinispan-cs -s -P workloads/workloada -P infinispan-binding/conf/remote-cache.properties -p cache=<cache name>
+  ```

--- a/infinispan/README.md
+++ b/infinispan/README.md
@@ -28,7 +28,7 @@ Run the workload test:
     
 1. start infinispan server
 
-2. read [RemoteCacheManager](http://docs.jboss.org/infinispan/7.2/apidocs/org/infinispan/client/hotrod/RemoteCacheManager.html) doc and customize hotrod client properties in infinispan-bindinf/conf/remote-cache.properties
+2. read [RemoteCacheManager](http://docs.jboss.org/infinispan/7.2/apidocs/org/infinispan/client/hotrod/RemoteCacheManager.html) doc and customize hotrod client properties in infinispan-binding/conf/remote-cache.properties
 
 3. Load the data with specified cache:
   ```

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -51,5 +51,4 @@
       </plugin>
     </plugins>
   </build>
-	
 </project>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -13,8 +13,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.as</groupId>
-      <artifactId>jboss-as-clustering-infinispan</artifactId>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+      <version>${infinispan.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-core</artifactId>
       <version>${infinispan.version}</version>
     </dependency>
     <dependency>
@@ -23,7 +28,6 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
- 
   <build>
     <plugins>
      <plugin>

--- a/infinispan/src/main/conf/remote-cache.properties
+++ b/infinispan/src/main/conf/remote-cache.properties
@@ -1,0 +1,9 @@
+infinispan.client.hotrod.server_list=192.168.101.17:11222
+infinispan.client.hotrod.force_return_values=false
+
+maxActive=-1
+maxIdle=-1
+minIdle=1
+maxTotal=-1
+
+whenExhaustedAction=1

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
@@ -1,0 +1,128 @@
+package com.yahoo.ycsb.db;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.util.logging.Log;
+import org.infinispan.util.logging.LogFactory;
+
+import com.yahoo.ycsb.ByteIterator;
+import com.yahoo.ycsb.DB;
+import com.yahoo.ycsb.DBException;
+import com.yahoo.ycsb.StringByteIterator;
+
+/**
+ * This is a client implementation for Infinispan 5.x in client-server mode.
+ * 
+ * @author mylesjao
+ *
+ */
+public class InfinispanRemoteClient extends DB {
+
+   private RemoteCacheManager remoteIspnManager;
+   
+   private String cacheName = null;
+
+   private static final Log logger = LogFactory.getLog(InfinispanRemoteClient.class);
+
+   public InfinispanRemoteClient() {
+      
+   }
+   
+   @Override
+   public void init() throws DBException {
+	  remoteIspnManager = RemoteCacheManagerHolder.getInstance(getProperties());
+	  cacheName = getProperties().getProperty("cache");
+   }
+   
+   @Override
+   public void cleanup() {
+      remoteIspnManager.stop();
+      remoteIspnManager = null;
+   }
+   
+   @Override
+   public int insert(String table, String recordKey, HashMap<String, ByteIterator> values) {
+	   String compositKey = createKey(table, recordKey);
+	   Map<String, String> stringValues = new HashMap<String,String>();
+	   StringByteIterator.putAllAsStrings(stringValues, values);
+	   try {
+    	  cache().put(compositKey, stringValues);
+         return Status.OK;
+      } catch (Exception e) {
+         return Status.ERROR;
+      }
+   }
+   
+   @Override
+   public int read(String table, String recordKey, Set<String> fields, HashMap<String, ByteIterator> result) {
+	   String compositKey = createKey(table, recordKey);
+	   try {	  
+    	  Map<String, String> values = cache().get(compositKey);
+    	  
+    	  if(values == null || values.isEmpty()){
+    		  return Status.NOT_FOUND;
+    	  }
+    	  
+    	  if(fields == null){ //get all field/value pairs
+    		  StringByteIterator.putAllAsByteIterators(result, values);
+    	  }else{
+    		  for(String field: fields){
+    			  String value = values.get(field);
+    			  if(value != null){
+    				  result.put(field, new StringByteIterator(value) );
+    			  }
+    		  }
+    	  }
+    	  
+    	  return Status.OK;
+      } catch (Exception e) {
+         return Status.ERROR;
+      }
+   }
+   
+   @Override
+   public int scan(String table, String startkey, int recordcount, Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+      logger.warn("Infinispan does not support scan semantics");
+      return Status.NOT_SUPPORT;
+   }
+   
+   @Override
+   public int update(String table, String recordKey, HashMap<String, ByteIterator> values) {
+	   String compositKey = createKey(table, recordKey);
+      try {
+    	  Map<String, String> stringValues = new HashMap<String, String>();
+    	  StringByteIterator.putAllAsStrings(stringValues, values);
+    	  cache().put(compositKey, stringValues);
+         return Status.OK;
+      } catch (Exception e) {
+         return Status.ERROR;
+      }
+   }
+   @Override
+   public int delete(String table, String recordKey) {
+	   String compositKey = createKey(table, recordKey);
+      try {
+    	  cache().remove(compositKey);
+    	  return Status.OK;
+      } catch (Exception e) {
+         return Status.ERROR;
+      }
+   }
+   
+   private RemoteCache<String, Map<String,String>> cache(){
+	   if(this.cacheName != null){
+		   return remoteIspnManager.getCache(cacheName);
+	   }else{
+		   return remoteIspnManager.getCache();
+	   }
+   }
+   
+   private String createKey(String table, String recordKey){
+	   return table + "-" + recordKey;
+   }
+}

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/RemoteCacheManagerHolder.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/RemoteCacheManagerHolder.java
@@ -1,0 +1,21 @@
+package com.yahoo.ycsb.db;
+
+import java.util.Properties;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+
+public class RemoteCacheManagerHolder {
+	
+	private static RemoteCacheManager cacheManager = null;
+	
+	private RemoteCacheManagerHolder() {}
+	
+	public static RemoteCacheManager getInstance(Properties props){
+		if(cacheManager == null){
+			synchronized (RemoteCacheManager.class) {
+				cacheManager = new RemoteCacheManager(props);
+			}
+		}
+		return cacheManager;
+	}
+}

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/Status.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/Status.java
@@ -1,0 +1,9 @@
+package com.yahoo.ycsb.db;
+
+public class Status {
+	public static final int OK = 0;
+	public static final int ERROR = 1;
+	public static final int NOT_FOUND = 2;
+	public static final int CONFLICT = 3;
+	public static final int NOT_SUPPORT = 4;
+}	

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <cassandra.version>0.7.0</cassandra.version>
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
-    <mapkeeper.version>1.0</mapkeeper.version>
+    <!-- <mapkeeper.version>1.0</mapkeeper.version> -->
     <mongodb.version>2.11.2</mongodb.version>
     <orientdb.version>1.0.1</orientdb.version>
     <redis.version>2.0.0</redis.version>
@@ -71,7 +71,7 @@
     <!--<module>gemfire</module>-->
     <module>infinispan</module>
     <module>jdbc</module>
-    <module>mapkeeper</module>
+    <!-- <module>mapkeeper</module> -->
     <module>mongodb</module>
     <module>orientdb</module>
     <!--module>nosqldb</module-->

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
     <hbase.version>0.92.1</hbase.version>
     <accumulo.version>1.6.0</accumulo.version>
     <cassandra.version>0.7.0</cassandra.version>
-    <infinispan.version>5.1.6.FINAL</infinispan.version>
+    <!-- <infinispan.version>5.1.6.FINAL</infinispan.version> -->
+    <infinispan.version>7.2.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!-- <mapkeeper.version>1.0</mapkeeper.version> -->
     <mongodb.version>2.11.2</mongodb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <hbase.version>0.92.1</hbase.version>
     <accumulo.version>1.6.0</accumulo.version>
     <cassandra.version>0.7.0</cassandra.version>
-    <infinispan.version>7.1.0.CR1</infinispan.version>
+    <infinispan.version>5.1.6.FINAL</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!-- <mapkeeper.version>1.0</mapkeeper.version> -->
     <mongodb.version>2.11.2</mongodb.version>


### PR DESCRIPTION
The Following is modification and new support in this PR:

* add new infinispan db client with hotrod client to support benchmark for default or specified cache in remote standalone infinispan cluster server. 

* add README for infinispan-binding.