### PR TITLE
Add autoflush property to HBaseClient

### DIFF
--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -60,7 +60,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public HTable _hTable=null;
     public String _columnFamily="";
     public byte _columnFamilyBytes[];
-    public boolean _clientSideBuffering = true;
+    public boolean _clientSideBuffering = false;
 
     public static final int Ok=0;
     public static final int ServerError=-1;

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -61,6 +61,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public HTable _hTable=null;
     public String _columnFamily="";
     public byte _columnFamilyBytes[];
+    public boolean _autoflush = false;
 
     public static final int Ok=0;
     public static final int ServerError=-1;
@@ -79,6 +80,11 @@ public class HBaseClient extends com.yahoo.ycsb.DB
                 (getProperties().getProperty("debug").compareTo("true")==0) )
         {
             _debug=true;
+        }
+
+        if (getProperties().containsKey("autoflush"))
+        {
+            _autoflush = Boolean.parseBoolean(getProperties().getProperty("autoflush"));
         }
 
         _columnFamily = getProperties().getProperty("columnfamily");
@@ -117,7 +123,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         synchronized (tableLock) {
             _hTable = new HTable(config, table);
             //2 suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
-            _hTable.setAutoFlush(false, true);
+            _hTable.setAutoFlush(_autoflush, true);
             _hTable.setWriteBufferSize(1024*1024*12);
             //return hTable;
         }

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -21,7 +21,6 @@ package com.yahoo.ycsb.db;
 import com.yahoo.ycsb.DBException;
 import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.ByteArrayByteIterator;
-import com.yahoo.ycsb.StringByteIterator;
 
 import java.io.IOException;
 import java.util.*;
@@ -61,7 +60,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public HTable _hTable=null;
     public String _columnFamily="";
     public byte _columnFamilyBytes[];
-    public boolean _autoflush = false;
+    public boolean _clientSideBuffering = true;
 
     public static final int Ok=0;
     public static final int ServerError=-1;
@@ -82,9 +81,9 @@ public class HBaseClient extends com.yahoo.ycsb.DB
             _debug=true;
         }
 
-        if (getProperties().containsKey("autoflush"))
+        if (getProperties().containsKey("clientbuffering"))
         {
-            _autoflush = Boolean.parseBoolean(getProperties().getProperty("autoflush"));
+            _clientSideBuffering = Boolean.parseBoolean(getProperties().getProperty("clientbuffering"));
         }
 
         _columnFamily = getProperties().getProperty("columnfamily");
@@ -123,7 +122,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         synchronized (tableLock) {
             _hTable = new HTable(config, table);
             //2 suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
-            _hTable.setAutoFlush(_autoflush, true);
+            _hTable.setAutoFlush(!_clientSideBuffering, true);
             _hTable.setWriteBufferSize(1024*1024*12);
             //return hTable;
         }

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -88,7 +88,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
      * This is the default behavior for HBaseClient. For measuring
      * insert/update/delete latencies, client side buffering should be disabled.
      */
-    public boolean _clientSideBuffering = true;
+    public boolean _clientSideBuffering = false;
 
     public static final int Ok=0;
     public static final int ServerError=-1;
@@ -102,8 +102,8 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
     @Override
     public void init() throws DBException
     {
-        if ("false".equals(getProperties().getProperty("clientbuffering", "true"))) {
-            this._clientSideBuffering = false;
+        if ("true".equals(getProperties().getProperty("clientbuffering", "false"))) {
+            this._clientSideBuffering = true;
         }
 
         if (getProperties().getProperty("durability") != null) {


### PR DESCRIPTION
Add `autoflush` property to HBaseClient. It enables to turn on or off auto flush flag of HTable.