### PR TITLE
Remove unnecessary configurations in hbase-site.xml

### DIFF
--- a/hbase/src/main/conf/hbase-site.xml
+++ b/hbase/src/main/conf/hbase-site.xml
@@ -23,19 +23,7 @@
 -->
 <configuration>
   <property>
-    <name>hbase.rootdir</name>
-    <value>hdfs://<HBASE_MASTER_SERVER>:20001/hbase</value>
-    <description>The directory shared by region servers.
-    </description>
-  </property>
-  <property>
-    <name>hbase.master</name>
-    <value><HBASE_MASTER_SERVER>:60000</value>
-    <description>The host and port that the HBase master runs at.
-    </description>
-  </property>
-  <property>
     <name>hbase.zookeeper.quorum</name>
-    <value><HBASE_MASTER_SERVER></value>
+    <value><HBASE_ZOOKEEPER_QUORUM></value>
   </property>
 </configuration>


### PR DESCRIPTION
hbase.rootdir and hbase.master are unnecessary for hbase client.