### PR TITLE
[version] update to 0.2.0-SNAPSHOT.

### DIFF
--- a/accumulo/pom.xml
+++ b/accumulo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>accumulo-binding</artifactId>
   <name>Accumulo DB Binding</name>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -4,7 +4,7 @@
   <parent>
      <groupId>com.yahoo.ycsb</groupId>
      <artifactId>root</artifactId>
-     <version>0.1.4</version>
+     <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>cassandra-binding</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>core</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ycsb</artifactId>

--- a/dynamodb/pom.xml
+++ b/dynamodb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dynamodb-binding</artifactId>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.yahoo.ycsb</groupId>
         <artifactId>root</artifactId>
-        <version>0.1.4</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>elasticsearch-binding</artifactId>

--- a/gemfire/pom.xml
+++ b/gemfire/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>gemfire-binding</artifactId>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>hbase-binding</artifactId>

--- a/hypertable/pom.xml
+++ b/hypertable/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>hypertable-binding</artifactId>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>infinispan-binding</artifactId>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>jdbc-binding</artifactId>

--- a/mapkeeper/pom.xml
+++ b/mapkeeper/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>mapkeeper-binding</artifactId>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.yahoo.ycsb</groupId>
 		<artifactId>root</artifactId>
-		<version>0.1.4</version>
+		<version>0.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>mongodb-binding</artifactId>

--- a/nosqldb/pom.xml
+++ b/nosqldb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>nosqldb-binding</artifactId>

--- a/orientdb/pom.xml
+++ b/orientdb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.yahoo.ycsb</groupId>
 		<artifactId>root</artifactId>
-		<version>0.1.4</version>
+                <version>0.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>orientdb-binding</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.yahoo.ycsb</groupId>
   <artifactId>root</artifactId>
-  <version>0.1.4</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>YCSB Root</name>
@@ -13,6 +13,12 @@
   <description>
     This is the top level project that builds, packages the core and all the DB bindings for YCSB infrastructure.
   </description>
+
+  <scm>
+    <connection>scm:git:git://github.com/brianfrankcooper/YCSB.git</connection>
+    <tag>master</tag>
+    <url>https://github.com/brianfrankcooper/YCSB</url>
+  </scm>
   <dependencies>
     <!-- voldemort -->
     <dependency>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>redis-binding</artifactId>

--- a/voldemort/pom.xml
+++ b/voldemort/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.yahoo.ycsb</groupId>
     <artifactId>root</artifactId>
-    <version>0.1.4</version>
+    <version>0.2.0-SNAPSHOT</version>
    </parent>
   
    <artifactId>voldemort-binding</artifactId>


### PR DESCRIPTION
* Need a SNAPSHOT version because non-SNAPSHOT is reserved for actual releases.
* Increment minor version per pre-1.0 guidelines from the Version Numbers guide

Fixes #236.