### PR TITLE
Rebase and updated PR-94: "bump gemfire version to 7.0.2"

### DIFF
--- a/gemfire/pom.xml
+++ b/gemfire/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.gemstone.gemfire</groupId>
       <artifactId>gemfire</artifactId>
-      <version>6.6</version>
+      <version>7.0.2</version>
     </dependency>
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
@@ -27,7 +27,7 @@
   <repositories>
     <repository>
       <id>gemstone</id>
-      <url>http://dist.gemstone.com.s3.amazonaws.com/maven/release/</url>
+      <url>http://dist.gemstone.com.s3.amazonaws.com/maven/release</url>
     </repository>
   </repositories>	
  

--- a/gemfire/pom.xml
+++ b/gemfire/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.gemstone.gemfire</groupId>
       <artifactId>gemfire</artifactId>
-      <version>7.0.2</version>
+      <version>${gemfire.version}</version>
     </dependency>
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <module>accumulo</module>
     <module>dynamodb</module>
     <module>elasticsearch</module>
+    <module>gemfire</module>
     <module>infinispan</module>
     <module>jdbc</module>
     <module>mongodb</module>
@@ -86,7 +87,6 @@
     <module>distribution</module>
     <!--<module>mapkeeper</module>-->
     <!--module>nosqldb</module-->
-    <!--<module>gemfire</module>-->
     <module>couchbase</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <accumulo.version>1.6.0</accumulo.version>
     <cassandra.version>1.2.9</cassandra.version>
     <cassandra.cql.version>1.0.3</cassandra.cql.version>
+    <gemfire.version>8.1.0</gemfire.version>
     <infinispan.version>7.1.0.CR1</infinispan.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->


### PR DESCRIPTION

* rebased the changes from #94 to current master, squashed them into one commit.
* looking at the references S3 based repo, the most recent version of the artifact the original binding is based on is 8.1.0.


I'd really like to update to a more recent gemfire binding, and one that isn't coming from an s3 bucket. I'll file a follow-on once this goes in. if we can find someone to do the work maybe spring-data-gemfire is the way to go?

