### PR TITLE
Make write buffer size of HBase client configurable

### DIFF
--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -61,6 +61,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public String _columnFamily="";
     public byte _columnFamilyBytes[];
     public boolean _clientSideBuffering = false;
+    public long _writeBufferSize = 1024 * 1024 * 12;
 
     public static final int Ok=0;
     public static final int ServerError=-1;
@@ -84,6 +85,10 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         if (getProperties().containsKey("clientbuffering"))
         {
             _clientSideBuffering = Boolean.parseBoolean(getProperties().getProperty("clientbuffering"));
+        }
+        if (getProperties().containsKey("writebuffersize"))
+        {
+            _writeBufferSize = Long.parseLong(getProperties().getProperty("writebuffersize"));
         }
 
         _columnFamily = getProperties().getProperty("columnfamily");
@@ -123,7 +128,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
             _hTable = new HTable(config, table);
             //2 suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
             _hTable.setAutoFlush(!_clientSideBuffering, true);
-            _hTable.setWriteBufferSize(1024*1024*12);
+            _hTable.setWriteBufferSize(_writeBufferSize);
             //return hTable;
         }
 

--- a/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -89,6 +89,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
      * insert/update/delete latencies, client side buffering should be disabled.
      */
     public boolean _clientSideBuffering = false;
+    public long _writeBufferSize = 1024 * 1024 * 12;
 
     public static final int Ok=0;
     public static final int ServerError=-1;
@@ -104,6 +105,9 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
     {
         if ("true".equals(getProperties().getProperty("clientbuffering", "false"))) {
             this._clientSideBuffering = true;
+        }
+        if (getProperties().containsKey("writebuffersize")) {
+            _writeBufferSize = Long.parseLong(getProperties().getProperty("writebuffersize"));
         }
 
         if (getProperties().getProperty("durability") != null) {
@@ -166,7 +170,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB
         //suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
         if (_clientSideBuffering) {
             final BufferedMutatorParams p = new BufferedMutatorParams(tableName);
-            p.writeBufferSize(1024*1024*12);
+            p.writeBufferSize(_writeBufferSize);
             this._bufferedMutator = this._connection.getBufferedMutator(p);
         }
     }


### PR DESCRIPTION
Make write buffer size of HBase client configurable by adding a new property `writebuffersize`.