### PR TITLE
Given the min and max parameter the ZipfianGenerator should not return *0*…

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/generator/ZipfianGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/ZipfianGenerator.java
@@ -276,12 +276,12 @@ public class ZipfianGenerator extends IntegerGenerator
 
 		if (uz<1.0)
 		{
-			return 0;
+			return base;
 		}
 
 		if (uz<1.0+Math.pow(0.5,theta)) 
 		{
-			return 1;
+			return base + 1;
 		}
 
 		long ret=base+(long)((itemcount) * Math.pow(eta*u - eta + 1, alpha));

--- a/core/src/test/java/com/yahoo/ycsb/generator/TestZipfianGenerator.java
+++ b/core/src/test/java/com/yahoo/ycsb/generator/TestZipfianGenerator.java
@@ -1,0 +1,23 @@
+package com.yahoo.ycsb.generator;
+
+import org.testng.annotations.Test;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class TestZipfianGenerator {
+    @Test
+    public void testMinParameter() {
+        long min = 5;
+        long max = 100;
+        Boolean gr_max = true;
+
+        ZipfianGenerator zipfian = new ZipfianGenerator(min, max);
+
+        for (int i = 0; i < 1000; i++) {
+            long rnd = zipfian.nextLong();
+            // System.out.println(rnd);
+            if(rnd < min) gr_max = false;
+        }
+
+        assertTrue(gr_max);
+    }
+}

--- a/core/src/test/java/com/yahoo/ycsb/generator/TestZipfianGenerator.java
+++ b/core/src/test/java/com/yahoo/ycsb/generator/TestZipfianGenerator.java
@@ -1,23 +1,39 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
 package com.yahoo.ycsb.generator;
 
 import org.testng.annotations.Test;
-import static org.testng.AssertJUnit.assertTrue;
+
+import static org.testng.AssertJUnit.assertFalse;
+
 
 public class TestZipfianGenerator {
     @Test
-    public void testMinParameter() {
+    public void testMinAndMaxParameter() {
         long min = 5;
-        long max = 100;
-        Boolean gr_max = true;
-
+        long max = 10;
         ZipfianGenerator zipfian = new ZipfianGenerator(min, max);
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10000; i++) {
             long rnd = zipfian.nextLong();
-            // System.out.println(rnd);
-            if(rnd < min) gr_max = false;
+            assertFalse(rnd < min);
+            assertFalse(rnd > max);
         }
 
-        assertTrue(gr_max);
     }
 }


### PR DESCRIPTION
… `if (uz < 1)` nor **1** `if (uz<1.0+Math.pow(0.5,theta))`. The pseudo code in <cite>[1]</cite> (referenced by ycsb) assumes that only values between 1 and N are drawn from the distribution, but given a min parameter the min value should be returned `if (uz < 1)`, resp. min + 1 `if (uz<1.0+Math.pow(0.5,theta))`.

[1]  J. Gray et al. Quickly generating billion-record synthetic databases. In SIGMOD, 1994.