### PR TITLE
[exporter] Fixed deprecated 'org.codehaus.jackson.impl.DefaultPrettyPrinter' ...

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONArrayMeasurementsExporter.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONArrayMeasurementsExporter.java
@@ -1,0 +1,73 @@
+/**                                                                                                                                                                                
+ * Copyright (c) 2015 Yahoo! Inc. All rights reserved.
+ *                                                                                                                                                                                 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+ * may not use this file except in compliance with the License. You                                                                                                                
+ * may obtain a copy of the License at                                                                                                                                             
+ *                                                                                                                                                                                 
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+ *                                                                                                                                                                                 
+ * Unless required by applicable law or agreed to in writing, software                                                                                                             
+ * distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+ * implied. See the License for the specific language governing                                                                                                                    
+ * permissions and limitations under the License. See accompanying                                                                                                                 
+ * LICENSE file.                                                                                                                                                                   
+ */
+package com.yahoo.ycsb.measurements.exporter;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.util.DefaultPrettyPrinter;
+
+/**
+ * Export measurements into a machine readable JSON Array of measurement objects.
+ */
+public class JSONArrayMeasurementsExporter implements MeasurementsExporter
+{
+
+  private JsonFactory factory = new JsonFactory();
+  private JsonGenerator g;
+
+  public JSONArrayMeasurementsExporter(OutputStream os) throws IOException
+  {
+
+    BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os));
+    g = factory.createJsonGenerator(bw);
+    g.setPrettyPrinter(new DefaultPrettyPrinter());
+    g.writeStartArray();
+  }
+
+  public void write(String metric, String measurement, int i) throws IOException
+  {
+    g.writeStartObject();
+    g.writeStringField("metric", metric);
+    g.writeStringField("measurement", measurement);
+    g.writeNumberField("value", i);
+    g.writeEndObject();
+  }
+
+  public void write(String metric, String measurement, double d) throws IOException
+  {
+    g.writeStartObject();
+    g.writeStringField("metric", metric);
+    g.writeStringField("measurement", measurement);
+    g.writeNumberField("value", d);
+    g.writeEndObject();
+  }
+
+  public void close() throws IOException
+  {
+    if (g != null)
+    {
+      g.writeEndArray();
+      g.close();
+    }
+  }
+
+}

--- a/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONMeasurementsExporter.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONMeasurementsExporter.java
@@ -1,12 +1,12 @@
-/**                                                                                                                                                                                
+/**
  * Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
- *                                                                                                                                                                                 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
  * may not use this file except in compliance with the License. You                                                                                                                
  * may obtain a copy of the License at                                                                                                                                             
- *                                                                                                                                                                                 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
- *                                                                                                                                                                                 
+ *
  * Unless required by applicable law or agreed to in writing, software                                                                                                             
  * distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
@@ -23,7 +23,7 @@ import java.io.OutputStreamWriter;
 
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.impl.DefaultPrettyPrinter;
+import org.codehaus.jackson.util.DefaultPrettyPrinter;
 
 /**
  * Export measurements into a machine readable JSON file.

--- a/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
+++ b/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015 Yahoo! Inc. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.measurements.exporter;
+
+import com.yahoo.ycsb.generator.ZipfianGenerator;
+import com.yahoo.ycsb.measurements.Measurements;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class TestMeasurementsExporter {
+    @Test
+    public void testJSONArrayMeasurementsExporter() throws IOException {
+        Measurements mm = new Measurements(new Properties());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JSONArrayMeasurementsExporter export = new JSONArrayMeasurementsExporter(out);
+
+        long min = 5000;
+        long max = 100000;
+        ZipfianGenerator zipfian = new ZipfianGenerator(min, max);
+        for (int i = 0; i < 1000; i++) {
+            int rnd = zipfian.nextInt();
+            mm.measure("UPDATE", rnd);
+        }
+        mm.exportMeasurements(export);
+        export.close();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode  json = mapper.readTree(out.toString("UTF-8"));
+
+        assertTrue(json.get(0).get("measurement").asText().equals("Operations"));
+        assertTrue(json.get(3).get("measurement").asText().equals("MaxLatency(us)"));
+        assertTrue(json.get(11).get("measurement").asText().equals("5"));
+    }
+}


### PR DESCRIPTION
…  and changed  json export  to an array of measurement objects. 
Once again a small change. I wanted to parse an exported json file, but  with the `readTree()` method (see my test case) i got only the first measurement value ("Operations"), because the json export consists of many small objects which are not separated by comas. My suggestion is to export the measurements as an json array, so you are able to simply parse and plot the histogram, e.g. in javascript.