### PR TITLE
 [exporter] added JSONArrayMeasurementsExporter

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONArrayMeasurementsExporter.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/exporter/JSONArrayMeasurementsExporter.java
@@ -1,5 +1,5 @@
 /**                                                                                                                                                                                
- * Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+ * Copyright (c) 2015 Yahoo! Inc. All rights reserved.
  *                                                                                                                                                                                 
  * Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
  * may not use this file except in compliance with the License. You                                                                                                                
@@ -26,20 +26,21 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.util.DefaultPrettyPrinter;
 
 /**
- * Export measurements into a machine readable JSON file.
+ * Export measurements into a machine readable JSON Array of measurement objects.
  */
-public class JSONMeasurementsExporter implements MeasurementsExporter
+public class JSONArrayMeasurementsExporter implements MeasurementsExporter
 {
 
   private JsonFactory factory = new JsonFactory();
   private JsonGenerator g;
 
-  public JSONMeasurementsExporter(OutputStream os) throws IOException
+  public JSONArrayMeasurementsExporter(OutputStream os) throws IOException
   {
 
     BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os));
     g = factory.createJsonGenerator(bw);
     g.setPrettyPrinter(new DefaultPrettyPrinter());
+    g.writeStartArray();
   }
 
   public void write(String metric, String measurement, int i) throws IOException
@@ -64,6 +65,7 @@ public class JSONMeasurementsExporter implements MeasurementsExporter
   {
     if (g != null)
     {
+      g.writeEndArray();
       g.close();
     }
   }

--- a/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
+++ b/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015 Yahoo! Inc. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.measurements.exporter;
+
+import com.yahoo.ycsb.generator.ZipfianGenerator;
+import com.yahoo.ycsb.measurements.Measurements;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class TestMeasurementsExporter {
+    @Test
+    public void testJSONArrayMeasurementsExporter() throws IOException {
+        Measurements mm = new Measurements(new Properties());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JSONArrayMeasurementsExporter export = new JSONArrayMeasurementsExporter(out);
+
+        long min = 5000;
+        long max = 100000;
+        ZipfianGenerator zipfian = new ZipfianGenerator(min, max);
+        for (int i = 0; i < 1000; i++) {
+            int rnd = zipfian.nextInt();
+            mm.measure("UPDATE", rnd);
+        }
+        mm.exportMeasurements(export);
+        export.close();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode  json = mapper.readTree(out.toString("UTF-8"));
+        assertTrue(json.isArray());
+        assertEquals(json.get(0).get("measurement").asText(), "Operations");
+        assertEquals(json.get(3).get("measurement").asText(), "MaxLatency(us)");
+        assertEquals(json.get(11).get("measurement").asText(), "5");
+    }
+}


### PR DESCRIPTION
Had some problems with my branch for #287. In this branch i fixed the depricated message for DefaultPrettyPrinter by importing `org.codehaus.jackson.util.DefaultPrettyPrinter` and added the JSONArrayMeasurementsExporter, which generates one JSON array with many measurement objects.