### PR TITLE
[mongodb] update parameter for connection url to match previous behavior and docs.

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -85,6 +85,7 @@ See the next section for the list of configuration parameters for MongoDB.
     - For the complete set of options for the synchronous driver see:
       - http://api.mongodb.org/java/current/index.html?com/mongodb/MongoClientURI.html
   - Default value is `mongodb://localhost:27017/ycsb?w=1`
+  - Default value of database is `ycsb`
 
 - `mongodb.batchsize`
   - Useful for the insert workload as it will submit the inserts in batches inproving throughput.

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -55,7 +55,7 @@ import com.yahoo.ycsb.DBException;
  * 
  * Properties to set:
  * 
- * mongodb.url=mongodb://localhost:27017 mongodb.database=ycsb
+ * mongodb.url=mongodb://localhost:27017 
  * mongodb.writeConcern=normal
  * 
  * @author rjm
@@ -180,7 +180,7 @@ public class AsyncMongoDbClient extends DB {
             batchSize = Integer.parseInt(props.getProperty("mongodb.batchsize", "1"));
 
             // Just use the standard connection format URL
-            // http://docs.mongodatabase.org/manual/reference/connection-string/
+            // http://docs.mongodb.org/manual/reference/connection-string/ 
             // to configure the client.
             String url = props.getProperty("mongodb.url",
                     "mongodb://localhost:27017/ycsb?w=1");

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -46,8 +46,8 @@ import com.yahoo.ycsb.DBException;
  * 
  * Properties to set:
  * 
- * mongodatabase.url=mongodb://localhost:27017 mongodatabase.database=ycsb
- * mongodatabase.writeConcern=acknowledged
+ * mongodb.url=mongodb://localhost:27017
+ * mongodb.writeConcern=acknowledged
  * 
  * @author ypai
  */
@@ -159,11 +159,9 @@ public class MongoDbClient extends DB {
             batchSize = Integer.parseInt(props.getProperty("batchsize", "1"));
 
             // Just use the standard connection format URL
-            // http://docs.mongodatabase.org/manual/reference/connection-string/
+            // http://docs.mongodb.org/manual/reference/connection-string/ 
             // to configure the client.
-            //
-            // Support legacy options by updating the URL as appropriate.
-            String url = props.getProperty("mongodatabase.url", null);
+            String url = props.getProperty("mongodb.url", null);
             boolean defaultedUrl = false;
             if (url == null) {
                 defaultedUrl = true;
@@ -178,7 +176,7 @@ public class MongoDbClient extends DB {
                                 + url
                                 + "'. Must be of the form "
                                 + "'mongodb://<host1>:<port1>,<host2>:<port2>/database?options'. "
-                                + "See http://docs.mongodatabase.org/manual/reference/connection-string/.");
+                                + "http://docs.mongodb.org/manual/reference/connection-string/");
                 System.exit(1);
             }
 
@@ -191,18 +189,11 @@ public class MongoDbClient extends DB {
                     databaseName = uriDb;
                 }
                 else {
-                    databaseName = props.getProperty("mongodatabase.database",
-                            "ycsb");
+                    //If no database is specified in URI, use "ycsb"
+                    databaseName = "ycsb"; 
+
                 }
 
-                if ((databaseName == null) || databaseName.isEmpty()) {
-                    System.err
-                            .println("ERROR: Invalid URL: '"
-                                    + url
-                                    + "'. Must provide a database name with the URI. "
-                                    + "'mongodb://<host1>:<port1>,<host2>:<port2>/database");
-                    System.exit(1);
-                }
 
                 readPreference = uri.getOptions().getReadPreference();
                 writeConcern = uri.getOptions().getWriteConcern();


### PR DESCRIPTION
[mongodb] update parameter for connection url to match previous behavior and docs.

Changes:
1. mongodb configuration parameter bug (mongodb.url)
    Even though the documentation mentioned mongodb.url, the code was expecting mongodatabase.url property. Modified the code and comments in code to point to correct link.

2. README file change
    Default DB is 'ycsb'
3. Some cleanup. 