### PR TITLE
[packaging] ensure datastore binding specific distributions include core transitive deps

### DIFF
--- a/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
+++ b/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
@@ -46,6 +46,7 @@
         <include>com.yahoo.ycsb:core</include>
       </includes>
       <scope>provided</scope>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
     </dependencySet>
     <dependencySet>
       <outputDirectory>lib</outputDirectory>


### PR DESCRIPTION
found an error in our packaging while reviewing #302 that keeps all of our datastore binding specific distribution artifacts from working.

this should block starting the release branch for #266, since we know it breaks so much.