### PR TITLE
Execute correct number of operations

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -743,7 +743,15 @@ public class Client
 			}
 
 			
-            Thread t=new ClientThread(db,dotransactions,workload,threadid,threadcount,props,opcount/threadcount, targetperthreadperms);
+            int threadopcount = opcount/threadcount;
+
+            // ensure correct number of operations, in case opcount is not a multiple of threadcount
+            if (threadid<opcount%threadcount)
+            {
+              ++threadopcount;
+            }
+
+            Thread t=new ClientThread(db,dotransactions,workload,threadid,threadcount,props,threadopcount, targetperthreadperms);
 
 			threads.add(t);
 			//t.start();


### PR DESCRIPTION
As it is right now, the number of executed operations is rounded down to the nearest multiple of the thread count.

This is a little confusing, if you, say, insert 3,000,000 records into a database using 7 threads and the database then contains only 2,999,997 records after that.
