### PR TITLE
MongoDBClient cleanup

### DIFF
--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -58,7 +58,7 @@ public class MongoDbClient extends DB {
     protected static final Integer INCLUDE = Integer.valueOf(1);
 
     /** The options to use for inserting many documents */
-    protected static final InsertManyOptions INSERT_MANY_OPTIONS =
+    protected static final InsertManyOptions INSERT_UNORDERED =
     new InsertManyOptions().ordered(false);
 
     /**
@@ -246,7 +246,7 @@ public class MongoDbClient extends DB {
 
             bulkInserts.add(toInsert);
             if (bulkInserts.size() == batchSize) {
-                collection.insertMany(bulkInserts, INSERT_MANY_OPTIONS);
+                collection.insertMany(bulkInserts, INSERT_UNORDERED);
                 bulkInserts.clear();
             }
             return 0;

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -202,7 +202,9 @@ public class MongoDbClient extends DB {
                 writeConcern = uri.getOptions().getWriteConcern();
 
                 mongoClient = new MongoClient(uri);
-                database = mongoClient.getDatabase(databaseName);
+                database = mongoClient.getDatabase(databaseName)
+                                      .withReadPreference(readPreference)
+                                      .withWriteConcern(writeConcern);
 
                 System.out.println("mongo client connection created with "
                         + url);
@@ -244,8 +246,7 @@ public class MongoDbClient extends DB {
 
             bulkInserts.add(toInsert);
             if (bulkInserts.size() == batchSize) {
-                collection.withWriteConcern(writeConcern)
-                          .insertMany(bulkInserts, INSERT_MANY_OPTIONS);
+                collection.insertMany(bulkInserts, INSERT_MANY_OPTIONS);
                 bulkInserts.clear();
             }
             return 0;
@@ -281,9 +282,7 @@ public class MongoDbClient extends DB {
                     .getCollection(table);
             Document query = new Document("_id", key);
 
-            FindIterable<Document> findIterable = collection
-                                                  .withReadPreference(readPreference)
-                                                  .find(query);
+            FindIterable<Document> findIterable = collection.find(query);
 
             Document queryResult = null;
             if (fields != null) {
@@ -344,7 +343,7 @@ public class MongoDbClient extends DB {
                 }
             }
 
-            cursor = collection.withReadPreference(readPreference).find(query)
+            cursor = collection.find(query)
                     .projection(projection).sort(sort).limit(recordcount).iterator();
             if (!cursor.hasNext()) {
                 System.err.println("Nothing found in scan for key " + startkey);
@@ -400,8 +399,7 @@ public class MongoDbClient extends DB {
             }
             Document update = new Document("$set", fieldsToSet);
 
-            UpdateResult result = collection.withWriteConcern(writeConcern)
-                    .updateOne(query, update);
+            UpdateResult result = collection.updateOne(query, update);
             if (result.wasAcknowledged() && result.getMatchedCount() == 0) {
                 System.err.println("Nothing updated for key " + key);
                 return 1;

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -353,6 +353,9 @@ public class MongoDbClient extends DB {
                 System.err.println("Nothing found in scan for key " + startkey);
                 return 1;
             }
+
+            result.ensureCapacity(recordcount);
+
             while (cursor.hasNext()) {
                 HashMap<String, ByteIterator> resultMap = new HashMap<String, ByteIterator>();
 

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -284,7 +284,6 @@ public class MongoDbClient extends DB {
 
             FindIterable<Document> findIterable = collection.find(query);
 
-            Document queryResult = null;
             if (fields != null) {
                 Document projection = new Document();
                 for (String field : fields) {
@@ -293,7 +292,7 @@ public class MongoDbClient extends DB {
                 findIterable.projection(projection);
             }
 
-            queryResult = findIterable.first();
+            Document queryResult = findIterable.first();
 
             if (queryResult != null) {
                 fillMap(result, queryResult);
@@ -335,16 +334,21 @@ public class MongoDbClient extends DB {
             Document scanRange = new Document("$gte", startkey);
             Document query = new Document("_id", scanRange);
             Document sort = new Document("_id", INCLUDE);
-            Document projection = null;
+
+            FindIterable<Document> findIterable = collection.find(query)
+                                                            .sort(sort)
+                                                            .limit(recordcount);
+
             if (fields != null) {
-                projection = new Document();
+                Document projection = new Document();
                 for (String fieldName : fields) {
                     projection.put(fieldName, INCLUDE);
                 }
+                findIterable.projection(projection);
             }
 
-            cursor = collection.find(query)
-                    .projection(projection).sort(sort).limit(recordcount).iterator();
+            cursor = findIterable.iterator();
+
             if (!cursor.hasNext()) {
                 System.err.println("Nothing found in scan for key " + startkey);
                 return 1;

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -76,7 +76,7 @@ public final class OptionsSupport {
                 result = addUrlOption(result, "w", "1");
             }
             else if ("journaled".equals(writeConcernType)) {
-                result = addUrlOption(result, "journal", "true");
+                result = addUrlOption(result, "j", "true");
             }
             else if ("replica_acknowledged".equals(writeConcernType)) {
                 result = addUrlOption(result, "w", "2");

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -30,7 +30,7 @@ import java.util.Properties;
 public final class OptionsSupport {
 
     /** Value for an unavailable property. */
-    protected static final String UNAVAILABLE = "n/a";
+    private static final String UNAVAILABLE = "n/a";
 
     /**
      * Updates the URL with the appropriate attributes if legacy properties are

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -76,7 +76,8 @@ public final class OptionsSupport {
                 result = addUrlOption(result, "w", "1");
             }
             else if ("journaled".equals(writeConcernType)) {
-                result = addUrlOption(result, "j", "true");
+                result = addUrlOption(result, "journal", "true"); // this is the documented option name
+                result = addUrlOption(result, "j", "true");       // but keep this until MongoDB Java driver supports "journal" option
             }
             else if ("replica_acknowledged".equals(writeConcernType)) {
                 result = addUrlOption(result, "w", "2");

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
@@ -110,7 +110,7 @@ public class OptionsSupportTest {
         assertThat(
                 updateUrl("mongodb://locahost:27017/?foo=bar",
                         props("mongodb.writeConcern", "journaled")),
-                is("mongodb://locahost:27017/?foo=bar&j=true"));
+                is("mongodb://locahost:27017/?foo=bar&journal=true&j=true"));
         assertThat(
                 updateUrl("mongodb://locahost:27017/?foo=bar",
                         props("mongodb.writeConcern", "replica_acknowledged")),

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/OptionsSupportTest.java
@@ -110,7 +110,7 @@ public class OptionsSupportTest {
         assertThat(
                 updateUrl("mongodb://locahost:27017/?foo=bar",
                         props("mongodb.writeConcern", "journaled")),
-                is("mongodb://locahost:27017/?foo=bar&journal=true"));
+                is("mongodb://locahost:27017/?foo=bar&j=true"));
         assertThat(
                 updateUrl("mongodb://locahost:27017/?foo=bar",
                         props("mongodb.writeConcern", "replica_acknowledged")),


### PR DESCRIPTION
I reviewed the changes to the MongoDBClient class that update it to use the 3.0 Java driver, and found a number of issues, all of which are addressed in the commits in this pull request.  Most are changes that simplify the MongoDBClient code in order to improve readability and reduce repetition.  The only functional change should be the fix to a bug in the way that journaling is enabled in the MongoClientURI.
