### PR TITLE
change the port of CassandraClient10 from 9160 to get value form prop…

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -136,7 +136,7 @@ public class CassandraClient10 extends DB
 
     for (int retry = 0; retry < ConnectionRetries; retry++)
     {
-      tr = new TFramedTransport(new TSocket(myhost, 9160));
+      tr = new TFramedTransport(new TSocket(myhost, getProperties().getProperty("port",9160)));
       TProtocol proto = new TBinaryProtocol(tr);
       client = new Cassandra.Client(proto);
       try

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -136,7 +136,7 @@ public class CassandraClient10 extends DB
 
     for (int retry = 0; retry < ConnectionRetries; retry++)
     {
-      tr = new TFramedTransport(new TSocket(myhost, getProperties().getProperty("port",9160)));
+      tr = new TFramedTransport(new TSocket(myhost, getProperties().getProperty("port","9160")));
       TProtocol proto = new TBinaryProtocol(tr);
       client = new Cassandra.Client(proto);
       try


### PR DESCRIPTION
Because different clusters may monitor different ports. I think make the port as a parameter instead of a constant value is better. Just like what CassandraCQLClient does.