### PR TITLE
Proposed fix for #327.

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
@@ -1,0 +1,43 @@
+package com.yahoo.ycsb.generator;
+
+import java.util.PriorityQueue;
+
+/**
+ * A CounterGenerator that reports generated integers via lastInt()
+ * only after they have been acknowledged.
+ */
+public class AcknowledgedCounterGenerator extends CounterGenerator
+{
+	private PriorityQueue<Integer> ack;
+	private int limit;
+
+	/**
+	 * Create a counter that starts at countstart.
+	 */
+	public AcknowledgedCounterGenerator(int countstart)
+	{
+		super(countstart);
+		ack = new PriorityQueue<Integer>();
+		limit = countstart - 1;
+	}
+
+	@Override
+	public int lastInt()
+	{
+		return limit;
+	}
+
+	public synchronized void acknowledge(int value)
+	{
+		ack.add(value);
+
+		// move a contiguous sequence from the priority queue
+		// over to the "limit" variable
+
+		Integer min;
+
+		while ((min = ack.peek()) != null && min == limit + 1) {
+			limit = ack.poll();
+		}
+	}
+}

--- a/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
@@ -21,12 +21,19 @@ public class AcknowledgedCounterGenerator extends CounterGenerator
 		limit = countstart - 1;
 	}
 
+	/**
+	 * In this generator, the highest acknowledged counter value
+	 * (as opposed to the highest generated counter value).
+	 */
 	@Override
 	public int lastInt()
 	{
 		return limit;
 	}
 
+	/**
+	 * Make a generated counter value available via lastInt().
+	 */
 	public synchronized void acknowledge(int value)
 	{
 		ack.add(value);

--- a/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/AcknowledgedCounterGenerator.java
@@ -40,9 +40,6 @@ public class AcknowledgedCounterGenerator extends CounterGenerator
 	 */
 	public void acknowledge(int value)
 	{
-		// read volatile variable to see other threads' changes
-		limit = limit;
-
 		if (value > limit + WINDOW_SIZE) {
 			throw new RuntimeException("Too many unacknowledged insertion keys.");
 		}
@@ -71,8 +68,5 @@ public class AcknowledgedCounterGenerator extends CounterGenerator
 				lock.unlock();
 			}
 		}
-
-		// write volatile variable to make other threads see changes
-		limit = limit;
 	}
 }

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -20,6 +20,7 @@ package com.yahoo.ycsb.workloads;
 import java.util.Properties;
 
 import com.yahoo.ycsb.*;
+import com.yahoo.ycsb.generator.AcknowledgedCounterGenerator;
 import com.yahoo.ycsb.generator.CounterGenerator;
 import com.yahoo.ycsb.generator.DiscreteGenerator;
 import com.yahoo.ycsb.generator.ExponentialGenerator;
@@ -299,7 +300,7 @@ public class CoreWorkload extends Workload
 
 	Generator fieldchooser;
 
-	CounterGenerator transactioninsertkeysequence;
+	AcknowledgedCounterGenerator transactioninsertkeysequence;
 	
 	IntegerGenerator scanlength;
 	
@@ -417,7 +418,7 @@ public class CoreWorkload extends Workload
 			operationchooser.addValue(readmodifywriteproportion,"READMODIFYWRITE");
 		}
 
-		transactioninsertkeysequence=new CounterGenerator(recordcount);
+		transactioninsertkeysequence=new AcknowledgedCounterGenerator(recordcount);
 		if (requestdistrib.compareTo("uniform")==0)
 		{
 			keychooser=new UniformIntegerGenerator(0,recordcount-1);
@@ -763,5 +764,6 @@ public class CoreWorkload extends Workload
 
 		HashMap<String, ByteIterator> values = buildValues(dbkey);
 		db.insert(table,dbkey,values);
+		transactioninsertkeysequence.acknowledge(keynum);
 	}
 }

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -760,10 +760,13 @@ public class CoreWorkload extends Workload
 		//choose the next key
 		int keynum=transactioninsertkeysequence.nextInt();
 
-		String dbkey = buildKeyName(keynum);
+		try {
+			String dbkey = buildKeyName(keynum);
 
-		HashMap<String, ByteIterator> values = buildValues(dbkey);
-		db.insert(table,dbkey,values);
-		transactioninsertkeysequence.acknowledge(keynum);
+			HashMap<String, ByteIterator> values = buildValues(dbkey);
+			db.insert(table,dbkey,values);
+		} finally {
+			transactioninsertkeysequence.acknowledge(keynum);
+		}
 	}
 }


### PR DESCRIPTION
I had been having issues with workload D, where a lot of reads try to access records that don't exist. The reason was how insert transactions worked:

  1) Generate a new key for the record to be inserted with transactioninsertkeysequence.nextInt().
  2) Write the record to the database using the new key.

However, between 1) and 2), nextKeynum() already considered the new key to be valid, i.e., reads of workload D tried to use that key. Even though the record was not yet in the database.

The proposed fix makes using transactioninsertkeysequence a 2-step process:

  1) Invoke transactioninsertkeysequence.nextInt() to get a new key, x.
  2) Write the new record to the database.
  3) Invoke transactioninsertkeysequence.acknowledge(x) to acknowledge the new key, i.e., signal that it is now available in the database.

Only 3) makes the new key visible via getLast() and thus visible to nextKeynum().

As we can have arbitrary many threads using transactioninsertkeysequence, we have to be prepared to receive out-of-order acknowledgements, etc. The proposed fix uses a priority queue to temporarily store acknowledgements.

The proposed fix introduces additional synchronization, i.e., it has a potential performance impact when benchmarking with 1) a lot of threads and 2) a lot of inserts. This means, though, that I wouldn't expect any impact on workload D with its 5% insertions.

Sanity test: With 25 threads on my laptop,there wasn't any consistent difference with workload D before and after the proposed fix. Neither in transaction rates (~97.4k - 102.4k), nor in insertion latency (286 - 310 us).
