### PR TITLE
Add a -delete command line option?

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -20,6 +20,11 @@ COMMANDS = {
         "description" : "Execute the load phase",
         "main"        : "com.yahoo.ycsb.Client",
     },
+    "delete" : {
+        "command"     : "-delete",
+        "description" : "Execute the clean-up phase",
+        "main"        : "com.yahoo.ycsb.Client",
+    },
     "run" : {
         "command"     : "-t",
         "description" : "Execute the transaction phase",

--- a/core/src/main/java/com/yahoo/ycsb/Workload.java
+++ b/core/src/main/java/com/yahoo/ycsb/Workload.java
@@ -82,6 +82,13 @@ public abstract class Workload
        * synchronized, since each thread has its own threadstate instance.
        */
       public abstract boolean doInsert(DB db, Object threadstate);
+
+      /**
+       * Do one delete operation. Works pretty much like doInsert(), but deletes records.
+       * Accordingly, it uses the same parameters, "insertcount" and "insertstart", to
+       * determine the record keys.
+       */
+      public abstract boolean doDelete(DB db, Object threadstate);
       
       /**
        * Do one transaction operation. Because it will be called concurrently from multiple client threads, this 

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -552,6 +552,19 @@ public class CoreWorkload extends Workload
 	}
 
 	/**
+	 * Do one delete operation. Works pretty much like doInsert(), but deletes records.
+	 * Accordingly, it uses the same parameters, "insertcount" and "insertstart", to
+	 * determine the record keys.
+	 */
+	public boolean doDelete(DB db, Object threadstate)
+	{
+		int keynum = keysequence.nextInt();
+		String dbkey = buildKeyName(keynum);
+		db.delete(table, dbkey);
+		return true;
+	}
+
+	/**
 	 * Do one transaction operation. Because it will be called concurrently from multiple client threads, this 
 	 * function must be thread safe. However, avoid synchronized, or the threads will block waiting for each 
 	 * other, and it will be difficult to reach the target throughput. Ideally, this function would have no side


### PR DESCRIPTION
Maybe this is useful to others, too? It's the complement to -load. It deletes the records that -load inserted.

Also, you can use it to remove the records inserted by workload D. It was a little tedious to fully reset and reload the database after each run of workload D.

It works completely analogously to -load and thus honors the insertstart and insertcount properties.

To remove the records inserted by workload D, just set insertstart to the recordcount and insertcount to something pretty high. If you work with 10,000,000 records, for example, you'd use

  ... -p insertstart=10000000 -p insertcount=1000000

to delete the records newly inserted by workload D. The -delete command doesn't abort on error, so it's safe to try to delete non-existent records. Hence we don't need to know the exact insertcount, just a safe upper bound.
