### PR TITLE
[client] Added basic command line argument error messages to Client.java

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -66,7 +66,7 @@ class StatusThread extends Thread
    * @param statusIntervalSeconds The number of seconds between status updates.
    */
   public StatusThread(CountDownLatch completeLatch, List<ClientThread> clients,
-      String label, boolean standardstatus, int statusIntervalSeconds)
+                      String label, boolean standardstatus, int statusIntervalSeconds)
   {
     _completeLatch=completeLatch;
     _clients=clients;
@@ -117,7 +117,7 @@ class StatusThread extends Thread
    * @return The current operation count.
    */
   private long computeStats(final long startTimeMs, long startIntervalMs, long endIntervalMs,
-      long lastTotalOps) {
+                            long lastTotalOps) {
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:SSS");
 
     long totalops=0;
@@ -147,7 +147,7 @@ class StatusThread extends Thread
       msg.append(d.format(curthroughput)).append(" current ops/sec; ");
     }
     if (todoops != 0) {
-        msg.append("est completion in ").append(RemainingFormatter.format(estremaining));
+      msg.append("est completion in ").append(RemainingFormatter.format(estremaining));
     }
 
     msg.append(Measurements.getMeasurements().getSummary());
@@ -194,32 +194,32 @@ class StatusThread extends Thread
  * i.e. if there are hours or days worth of seconds, use them.
  */
 class RemainingFormatter {
-	public static StringBuilder format(long seconds) {
-		StringBuilder time = new StringBuilder();
-		long days = TimeUnit.SECONDS.toDays(seconds);
-		if (days > 0) {
-			time.append(days).append(" days ");
-			seconds -= TimeUnit.DAYS.toSeconds(days);
-		}
-		long hours = TimeUnit.SECONDS.toHours(seconds);
-		if (hours > 0) {
-			time.append(hours).append(" hours ");
-			seconds -= TimeUnit.HOURS.toSeconds(hours);
-		}
-		/* Only include minute granularity if we're < 1 day. */
-		if (days < 1) {
-			long minutes = TimeUnit.SECONDS.toMinutes(seconds);
-			if (minutes > 0) {
-				time.append(minutes).append(" minutes ");
-				seconds -= TimeUnit.MINUTES.toSeconds(seconds);
-			}
-		}
-		/* Only bother to include seconds if we're < 1 minute */
-		if (time.length() == 0) {
-			time.append(seconds).append(" seconds ");
-		}
-		return time;
-	}
+  public static StringBuilder format(long seconds) {
+    StringBuilder time = new StringBuilder();
+    long days = TimeUnit.SECONDS.toDays(seconds);
+    if (days > 0) {
+      time.append(days).append(" days ");
+      seconds -= TimeUnit.DAYS.toSeconds(days);
+    }
+    long hours = TimeUnit.SECONDS.toHours(seconds);
+    if (hours > 0) {
+      time.append(hours).append(" hours ");
+      seconds -= TimeUnit.HOURS.toSeconds(hours);
+    }
+    /* Only include minute granularity if we're < 1 day. */
+    if (days < 1) {
+      long minutes = TimeUnit.SECONDS.toMinutes(seconds);
+      if (minutes > 0) {
+        time.append(minutes).append(" minutes ");
+        seconds -= TimeUnit.MINUTES.toSeconds(seconds);
+      }
+    }
+    /* Only bother to include seconds if we're < 1 minute */
+    if (time.length() == 0) {
+      time.append(seconds).append(" seconds ");
+    }
+    return time;
+  }
 }
 
 /**
@@ -475,13 +475,13 @@ public class Client
     System.out.println("Usage: java com.yahoo.ycsb.Client [options]");
     System.out.println("Options:");
     System.out.println("  -threads n: execute using n threads (default: 1) - can also be specified as the \n" +
-        "        \"threadcount\" property using -p");
+                       "        \"threadcount\" property using -p");
     System.out.println("  -target n: attempt to do n operations per second (default: unlimited) - can also\n" +
-        "       be specified as the \"target\" property using -p");
+                       "       be specified as the \"target\" property using -p");
     System.out.println("  -load:  run the loading phase of the workload");
     System.out.println("  -t:  run the transactions phase of the workload (default)");
     System.out.println("  -db dbname: specify the name of the DB to use (default: com.yahoo.ycsb.BasicDB) - \n" +
-        "        can also be specified as the \"db\" property using -p");
+                       "        can also be specified as the \"db\" property using -p");
     System.out.println("  -P propertyfile: load properties from the given file. Multiple files can");
     System.out.println("           be specified, and will be processed in the order specified");
     System.out.println("  -p name=value:  specify a property to be passed to the DB and workloads;");
@@ -516,7 +516,7 @@ public class Client
    * @throws IOException Either failed to write to output stream or failed to close it.
    */
   private static void exportMeasurements(Properties props, int opcount, long runtime)
-      throws IOException
+    throws IOException
   {
     MeasurementsExporter exporter = null;
     try
@@ -540,7 +540,7 @@ public class Client
       } catch (Exception e)
       {
         System.err.println("Could not find exporter " + exporterStr
-            + ", will use default text reporter.");
+                           + ", will use default text reporter.");
         e.printStackTrace();
         exporter = new TextMeasurementsExporter(out);
       }
@@ -577,6 +577,7 @@ public class Client
     if (args.length==0)
     {
       usageMessage();
+      System.out.println("At least one argument specifying a workload is required.");
       System.exit(0);
     }
 
@@ -588,6 +589,7 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -threads.");
           System.exit(0);
         }
         int tcount=Integer.parseInt(args[argindex]);
@@ -600,6 +602,7 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -target.");
           System.exit(0);
         }
         int ttarget=Integer.parseInt(args[argindex]);
@@ -627,6 +630,7 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -db.");
           System.exit(0);
         }
         props.setProperty(DB_PROPERTY,args[argindex]);
@@ -638,6 +642,7 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -l.");
           System.exit(0);
         }
         label=args[argindex];
@@ -649,6 +654,7 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -P.");
           System.exit(0);
         }
         String propfile=args[argindex];
@@ -661,6 +667,7 @@ public class Client
         }
         catch (IOException e)
         {
+          System.out.println("Unable to open the properties file " + propfile);
           System.out.println(e.getMessage());
           System.exit(0);
         }
@@ -680,12 +687,14 @@ public class Client
         if (argindex>=args.length)
         {
           usageMessage();
+          System.out.println("Missing argument value for -p");
           System.exit(0);
         }
         int eq=args[argindex].indexOf('=');
         if (eq<0)
         {
           usageMessage();
+          System.out.println("Argument '-p' expected to be in key=value format (e.g., -p operationcount=99999)");
           System.exit(0);
         }
 
@@ -697,8 +706,8 @@ public class Client
       }
       else
       {
-        System.out.println("Unknown option "+args[argindex]);
         usageMessage();
+        System.out.println("Unknown option " + args[argindex]);
         System.exit(0);
       }
 
@@ -708,9 +717,15 @@ public class Client
       }
     }
 
-    if (argindex!=args.length)
+    if (argindex != args.length)
     {
       usageMessage();
+      if (argindex < args.length) {
+        System.out.println("An argument value without corresponding argument specifier (e.g., -p, -s) was found. "
+                           + "We expected an argument specifier and instead found " + args[argindex]);
+      } else {
+        System.out.println("An argument specifier without corresponding value was found at the end of the supplied command line arguments.");
+      }
       System.exit(0);
     }
 
@@ -731,6 +746,7 @@ public class Client
 
     if (!checkRequiredProperties(props))
     {
+      System.out.println("Failed check required properties.");
       System.exit(0);
     }
 
@@ -762,21 +778,21 @@ public class Client
     //but only do so if it is taking longer than 2 seconds
     //(showing the message right away if the setup wasn't taking very long was confusing people)
     Thread warningthread=new Thread()
-    {
-      @Override
-      public void run()
       {
-        try
+        @Override
+        public void run()
         {
-          sleep(2000);
+          try
+          {
+            sleep(2000);
+          }
+          catch (InterruptedException e)
+          {
+            return;
+          }
+          System.err.println(" (might take a few minutes for large data sets)");
         }
-        catch (InterruptedException e)
-        {
-          return;
-        }
-        System.err.println(" (might take a few minutes for large data sets)");
-      }
-    };
+      };
 
     warningthread.start();
 


### PR DESCRIPTION
This stems from my earlier adventures (see #407) trying to get a basic MySQL benchmark to run over JDBC, and improperly supplying the classpath but having no way to know what was upsetting the Java command line argument parser.

also "fixed" some indentation, because the alternative would have been to submit poorly indented code. Emacs is great for keeping indentation consistent, but if you're trying to match a file that isn't consistent, you're pretty much screwed. :)