### PR TITLE
Bring Aerospike adapter in line with adapter policy

### DIFF
--- a/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
+++ b/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
@@ -27,7 +27,6 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
-import com.aerospike.client.ResultCode;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.RecordExistsAction;
@@ -38,8 +37,6 @@ import com.yahoo.ycsb.ByteIterator;
 import com.yahoo.ycsb.DBException;
 
 public class AerospikeClient extends com.yahoo.ycsb.DB {
-  private static final boolean DEBUG = false;
-
   private static final String DEFAULT_HOST = "localhost";
   private static final String DEFAULT_PORT = "3000";
   private static final String DEFAULT_TIMEOUT = "10000";
@@ -47,9 +44,6 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
 
   private static final int RESULT_OK = 0;
   private static final int RESULT_ERROR = -1;
-
-  private static final int WRITE_OVERLOAD_DELAY = 5;
-  private static final int WRITE_OVERLOAD_TRIES = 3;
 
   private String namespace = null;
 
@@ -116,10 +110,7 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
       }
 
       if (record == null) {
-        if (DEBUG) {
-          System.err.println("Record key " + key + " not found (read)");
-        }
-
+        System.err.println("Record key " + key + " not found (read)");
         return RESULT_ERROR;
       }
 
@@ -152,36 +143,15 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
       ++index;
     }
 
-    int delay = WRITE_OVERLOAD_DELAY;
     Key keyObj = new Key(namespace, table, key);
 
-    for (int tries = 0; tries < WRITE_OVERLOAD_TRIES; ++tries) {
-      try {
-        client.put(writePolicy, keyObj, bins);
-        return RESULT_OK;
-      } catch (AerospikeException e) {
-        if (e.getResultCode() != ResultCode.DEVICE_OVERLOAD) {
-          System.err.println("Error while writing key " + key + ": " + e);
-          return RESULT_ERROR;
-        }
-
-        try {
-          Thread.sleep(delay);
-        } catch (InterruptedException e2) {
-          if (DEBUG) {
-            System.err.println("Interrupted: " + e2);
-          }
-        }
-
-        delay *= 2;
-      }
+    try {
+      client.put(writePolicy, keyObj, bins);
+      return RESULT_OK;
+    } catch (AerospikeException e) {
+      System.err.println("Error while writing key " + key + ": " + e);
+      return RESULT_ERROR;
     }
-
-    if (DEBUG) {
-      System.err.println("Device overload");
-    }
-
-    return RESULT_ERROR;
   }
 
   @Override
@@ -200,10 +170,7 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
   public int delete(String table, String key) {
     try {
       if (!client.delete(deletePolicy, new Key(namespace, table, key))) {
-        if (DEBUG) {
-          System.err.println("Record key " + key + " not found (delete)");
-        }
-
+        System.err.println("Record key " + key + " not found (delete)");
         return RESULT_ERROR;
       }
 


### PR DESCRIPTION
As per @cmccoy's comment in #324: Database adapters shouldn't introduce any new functionality. They should just pass things back and forth between YCSB and the database client.

This change removes back-off/retry logic for cluster overload conditions from the Aerospike adapter.
