### PR TITLE
change the default port and host property parsing for cassandra CQL binding

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -102,12 +102,12 @@ public class CassandraCQLClient extends DB {
 
                 _debug = Boolean.parseBoolean(getProperties().getProperty("debug", "false"));
 
-                String host = getProperties().getProperty("host");
+                String host = getProperties().getProperty("hosts");
                 if (host == null) {
                     throw new DBException("Required property \"host\" missing for CassandraClient");
                 }
-                String hosts[] = host.split(" ");
-                String port = getProperties().getProperty("port", "9160");
+                String hosts[] = host.split(",");
+                String port = getProperties().getProperty("port", "9042");
                 if (port == null) {
                     throw new DBException("Required property \"port\" missing for CassandraClient");
                 }


### PR DESCRIPTION
Close the issue #419. The following changes are made to Cassandra CQL binding:
1.  change the default port from 9160 to 9042
2.  unify the host property name ("host" --> "hosts")
3.  separating multiple hosts with comma