### PR TITLE
[redis] Fix the label for a redis parameter

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -36,7 +36,7 @@ Git clone YCSB and compile:
 Set the host, port, and password (do not redis auth is not turned on) in the 
 workload you plan to run.
 
-- `redis.url`
+- `redis.host`
 - `redis.port`
 - `redis.password`
 


### PR DESCRIPTION
`redis.host`, is correct, rather than `redis.url`.