### PR TITLE
[mongodb] Add mongodb.upsert configuration option.

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -108,8 +108,14 @@ See the next section for the list of configuration parameters for MongoDB.
   - Useful for the insert workload as it will submit the inserts in batches inproving throughput.
   - Default value is `1`.
 
+- `mongodb.upsert`
+  - Determines if the insert operation performs an update with the upsert operation or a insert. 
+    Upserts have the advantage that they will continue to work for a partially loaded data set.
+  - Setting to `true` uses updates, `false` uses insert operations.
+  - Default value is `false`.
+
 - `mongodb.writeConcern`
-  - **Deprecated** - Use the `w` and `journal` options on the MongoDB URI provided by the `mongodb.uri`.
+  - **Deprecated** - Use the `w` and `journal` options on the MongoDB URI provided by the `mongodb.url`.
   - Allowed values are :
     - `errors_ignored`
     - `unacknowledged`
@@ -120,7 +126,7 @@ See the next section for the list of configuration parameters for MongoDB.
   - Default value is `acknowledged`.
  
 - `mongodb.readPreference`
-  - **Deprecated** - Use the `readPreference` options on the MongoDB URI provided by the `mongodb.uri`.
+  - **Deprecated** - Use the `readPreference` options on the MongoDB URI provided by the `mongodb.url`.
   - Allowed values are :
     - `primary`
     - `primary_preferred`
@@ -130,11 +136,11 @@ See the next section for the list of configuration parameters for MongoDB.
   - Default value is `primary`.
  
 - `mongodb.maxconnections`
-  - **Deprecated** - Use the `maxPoolSize` options on the MongoDB URI provided by the `mongodb.uri`.
+  - **Deprecated** - Use the `maxPoolSize` options on the MongoDB URI provided by the `mongodb.url`.
   - Default value is `100`.
 
 - `mongodb.threadsAllowedToBlockForConnectionMultiplier`
-  - **Deprecated** - Use the `waitQueueMultiple` options on the MongoDB URI provided by the `mongodb.uri`.
+  - **Deprecated** - Use the `waitQueueMultiple` options on the MongoDB URI provided by the `mongodb.url`.
   - Default value is `5`.
 
 For example:

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/AsyncMongoDbClientTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/AsyncMongoDbClientTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assume.assumeNoException;
 import java.util.Properties;
 
 import org.junit.After;
-import org.junit.Before;
 
 import com.yahoo.ycsb.DB;
 
@@ -32,20 +31,6 @@ public class AsyncMongoDbClientTest extends AbstractDBTestCases {
 
   /** The client to use. */
   private AsyncMongoDbClient myClient = null;
-
-  /**
-   * Start a test client.
-   */
-  @Before
-  public void setUp() {
-    myClient = new AsyncMongoDbClient();
-    myClient.setProperties(new Properties());
-    try {
-      myClient.init();
-    } catch (Exception error) {
-      assumeNoException(error);
-    }
-  }
 
   /**
    * Stops the test client.
@@ -64,11 +49,20 @@ public class AsyncMongoDbClientTest extends AbstractDBTestCases {
   /**
    * {@inheritDoc}
    * <p>
-   * Overriden to return the {@link AsyncMongoDbClient}.
+   * Overridden to return the {@link AsyncMongoDbClient}.
    * </p>
    */
   @Override
-  protected DB getDB() {
+  protected DB getDB(Properties props) {
+    if( myClient == null ) {
+      myClient = new AsyncMongoDbClient();
+      myClient.setProperties(props);
+      try {
+        myClient.init();
+      } catch (Exception error) {
+        assumeNoException(error);
+      }
+    }
     return myClient;
   }
 }

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/MongoDbClientTest.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/MongoDbClientTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assume.assumeNoException;
 import java.util.Properties;
 
 import org.junit.After;
-import org.junit.Before;
 
 import com.yahoo.ycsb.DB;
 
@@ -32,20 +31,6 @@ public class MongoDbClientTest extends AbstractDBTestCases {
 
   /** The client to use. */
   private MongoDbClient myClient = null;
-
-  /**
-   * Start a test client.
-   */
-  @Before
-  public void setUp() {
-    myClient = new MongoDbClient();
-    myClient.setProperties(new Properties());
-    try {
-      myClient.init();
-    } catch (Exception error) {
-      assumeNoException(error);
-    }
-  }
 
   /**
    * Stops the test client.
@@ -64,11 +49,20 @@ public class MongoDbClientTest extends AbstractDBTestCases {
   /**
    * {@inheritDoc}
    * <p>
-   * Overriden to return the {@link MongoDbClient}.
+   * Overridden to return the {@link MongoDbClient}.
    * </p>
    */
   @Override
-  protected DB getDB() {
+  protected DB getDB(Properties props) {
+    if( myClient == null ) {
+      myClient = new MongoDbClient();
+      myClient.setProperties(props);
+      try {
+        myClient.init();
+      } catch (Exception error) {
+        assumeNoException(error);
+      }
+    }
     return myClient;
   }
 }


### PR DESCRIPTION
Added a configuration option (mongodb.upsert) to control if the driver
performs inserts or upserts operations for the DB.insert() method.
Defaults to doing inserts.

Note: Change in behavior from previous versions that performed upserts
for non-batched DB.insert() operations.

Fixes #400.