### PR TITLE
Add posix compatibility to distribution.

### DIFF
--- a/binding-parent/pom.xml
+++ b/binding-parent/pom.xml
@@ -60,6 +60,7 @@ LICENSE file.
               <format>tar.gz</format>
             </formats>
             <appendAssemblyId>false</appendAssemblyId>
+            <tarLongFileMode>posix</tarLongFileMode>
           </configuration>
           <executions>
             <execution>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -148,6 +148,7 @@ LICENSE file.
             <descriptor>src/main/assembly/distribution.xml</descriptor>
           </descriptors>
           <appendAssemblyId>false</appendAssemblyId>
+          <tarLongFileMode>posix</tarLongFileMode>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Without this people who have a large gid will error out with:

group id '1519764623' is too big ( > 2097151 )