### PR TITLE
[core] added return codes to VERIFY

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -172,16 +172,6 @@ public class CoreWorkload extends Workload
    */
   private boolean dataintegrity;
 
-  /**
-   * Response values for data integrity checks.
-   * Need to be multiples of 1000 to match bucket offsets of
-   * measurements/OneMeasurementHistogram.java.
-   */
-  private final int DATA_INT_MATCH = 0;
-  private final int DATA_INT_DEVIATE = 1000;
-  private final int DATA_INT_UNEXPECTED_NULL = 2000;
-
-
 	/**
 	 * The name of the property for the proportion of transactions that are reads.
 	 */
@@ -594,20 +584,23 @@ public class CoreWorkload extends Workload
    * Bucket 2 means null data was returned when some data was expected. 
    */
   protected void verifyRow(String key, HashMap<String,ByteIterator> cells) {
-    int matchType = DATA_INT_MATCH;
-    if (!cells.isEmpty()) {
+		Status verifyStatus = Status.OK;
+		long startTime = System.nanoTime();
+		if (!cells.isEmpty()) {
       for (Map.Entry<String, ByteIterator> entry : cells.entrySet()) {
-        if (!entry.getValue().toString().equals(
+				if (!entry.getValue().toString().equals(
             buildDeterministicValue(key, entry.getKey()))) {
-          matchType = DATA_INT_DEVIATE;
-          break;
+          verifyStatus = Status.UNEXPECTED_STATE;
+					break;
         }
       }
     } else {
       //This assumes that null data is never valid
-      matchType = DATA_INT_UNEXPECTED_NULL;
+			verifyStatus = Status.ERROR;
     }
-    Measurements.getMeasurements().measure("VERIFY", matchType);
+		long endTime = System.nanoTime();
+    _measurements.measure("VERIFY", (int) (endTime - startTime) / 1000);
+		_measurements.reportStatus("VERIFY",verifyStatus);
   }
 
     int nextKeynum() {

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -584,23 +584,23 @@ public class CoreWorkload extends Workload
    * Bucket 2 means null data was returned when some data was expected. 
    */
   protected void verifyRow(String key, HashMap<String,ByteIterator> cells) {
-		Status verifyStatus = Status.OK;
-		long startTime = System.nanoTime();
-		if (!cells.isEmpty()) {
+    Status verifyStatus = Status.OK;
+    long startTime = System.nanoTime();
+    if (!cells.isEmpty()) {
       for (Map.Entry<String, ByteIterator> entry : cells.entrySet()) {
-				if (!entry.getValue().toString().equals(
+        if (!entry.getValue().toString().equals(
             buildDeterministicValue(key, entry.getKey()))) {
           verifyStatus = Status.UNEXPECTED_STATE;
-					break;
+          break;
         }
       }
     } else {
       //This assumes that null data is never valid
-			verifyStatus = Status.ERROR;
+      verifyStatus = Status.ERROR;
     }
-		long endTime = System.nanoTime();
+    long endTime = System.nanoTime();
     _measurements.measure("VERIFY", (int) (endTime - startTime) / 1000);
-		_measurements.reportStatus("VERIFY",verifyStatus);
+    _measurements.reportStatus("VERIFY",verifyStatus);
   }
 
     int nextKeynum() {


### PR DESCRIPTION
Changed measurement latency to actual latency time of the verifyRow step and now recording Status codes for verify operations.

Fixes #479