### PR TITLE
[core] passing full fieldset for verification

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -637,7 +637,10 @@ public class CoreWorkload extends Workload
 
 			fields=new HashSet<String>();
 			fields.add(fieldname);
-		}
+		} else if (dataintegrity) {
+      // pass the full field list if dataintegrity is on for verification
+      fields = new HashSet<String>(fieldnames);
+    }
 
     HashMap<String,ByteIterator> cells =
         new HashMap<String,ByteIterator>();


### PR DESCRIPTION
When dataintegrity and readallfields are both true, pass the full field
set to db.read() so that the field values can be verified.

Fixes #496