### PR TITLE
Add class OneMeasurementTimeSeriesOps to count ops per time (tps).

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -41,6 +41,7 @@ public class Measurements {
     HDRHISTOGRAM_AND_HISTOGRAM,
     HDRHISTOGRAM_AND_RAW,
     TIMESERIES,
+    HDRHISTOGRAM_AND_TIMESERIES,
     RAW
   }
 
@@ -107,6 +108,10 @@ public class Measurements {
     {
       _measurementType = MeasurementType.TIMESERIES;
     }
+    else if (mTypeString.equals("hdrhistogram+timeseries"))
+    {
+      _measurementType = MeasurementType.HDRHISTOGRAM_AND_TIMESERIES;
+    }
     else if (mTypeString.equals("raw"))
     {
       _measurementType = MeasurementType.RAW;
@@ -151,6 +156,10 @@ public class Measurements {
           new OneMeasurementHistogram("Raw"+name, _props));
     case TIMESERIES:
       return new OneMeasurementTimeSeries(name, _props);
+    case HDRHISTOGRAM_AND_TIMESERIES:
+      return new TwoInOneMeasurement(name,
+              new OneMeasurementHdrHistogram(name, _props),
+              new OneMeasurementTimeSeriesOps("Timeseries", _props));
     case RAW:
       return new OneMeasurementRaw(name, _props);
     default:


### PR DESCRIPTION
Hi

I wanted YCSB to output the actual ops-per-second, not just summaries, so I've added a class and a configuration that does that. If you could merge this, would be great, so I don't have to patch YCSB every time I do testing.

Add class OneMeasurementTimeSeriesOps to count ops per time (tps).
Add option measurementtype = hdrhistogram+timeseriesops