### PR TITLE
Added support for Vim and Emacs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,15 +4,20 @@ target
 # ignore output files from testing
 output*
 
-# ignore standard eclipse
+# ignore standard Eclipse files
 .project
 .classpath
 .settings
 .checkstyle
 
-# ignore standard intellij
+# ignore standard IntelliJ files
 .idea/
 *.iml
 *.iws
 
+# ignore standard Vim and Emacs temp files
+*.swp
+*~
+
+# ignore standard Mac OS X files/dirs
 .DS_Store


### PR DESCRIPTION
This change ignores temporary files created by Vim and Emacs.