### PR TITLE
[build] changed checkstyle linelength to 120

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -115,7 +115,9 @@ LICENSE file.
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength"/>
+        <module name="LineLength">
+            <property name="max" value="120"/>
+        </module>
         <module name="MethodLength"/>
         <module name="ParameterNumber"/>
 


### PR DESCRIPTION
Discussion for this change is in #267. Abridged - 80 character limit is too short to be practical.

This should not invalidate any checkstyle enforcement PRs already merged since we are making the limit larger. I can assist in reevaluating the modules that have already had their checkstyle enforcement merged.

@allanbank - I can help with the open checkstyle PRs as well, just let me know.