### PR TITLE
[kudu] Bump Kudu dependency to 0.6.0

### DIFF
--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -156,7 +156,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
     }
     schema = new Schema(columns);
 
-    CreateTableBuilder builder = new CreateTableBuilder();
+    CreateTableOptions builder = new CreateTableOptions();
     builder.setNumReplicas(numReplicas);
     // create n-1 split keys, which will end up being n tablets master-side
     for (int i = 1; i < numTablets + 0; i++) {

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ LICENSE file.
     <cassandra2.cql.version>2.1.8</cassandra2.cql.version>
     <gemfire.version>8.1.0</gemfire.version>
     <infinispan.version>7.2.2.Final</infinispan.version>
-    <kudu.version>0.5.0</kudu.version>
+    <kudu.version>0.6.0</kudu.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>3.0.3</mongodb.version>


### PR DESCRIPTION
This version and the previous one are wire compatible, the only code
chance reflects a naming change in the client API.