### PR TITLE
[memcached] Removed groupId (duplicates parent).

### DIFF
--- a/memcached/pom.xml
+++ b/memcached/pom.xml
@@ -27,7 +27,6 @@ LICENSE file.
 
   <artifactId>memcached-binding</artifactId>
   <name>memcached binding</name>
-  <groupId>com.yahoo.ycsb</groupId>
   <packaging>jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
For reference, other bindings don't appear to specify a `groupId` at this level
in their `pom.xml` files.

@shivam-maharshi says in a [comment][1]:

> The groupId here is the duplicate of the parent groupId. This is creating a
> problem in the maven build.

  [1]: https://github.com/brianfrankcooper/YCSB/commit/d4b1d247a31cf9fbf42b2e324b5b1cc27fdd9565#commitcomment-15030853