### PR TITLE
[cassandra2] added better property handling

### DIFF
--- a/cassandra2/README.md
+++ b/cassandra2/README.md
@@ -71,3 +71,10 @@ For keyspace `ycsb`, table `usertable`:
   * Default value is `ONE`
   - Consistency level for reads and writes, respectively. See the [DataStax documentation](http://docs.datastax.com/en/cassandra/2.0/cassandra/dml/dml_config_consistency_c.html) for details.
   * *Note that the default setting does not provide durability in the face of node failure. Changing this setting will affect observed performance.* See also `replication_factor`, above.
+
+* `cassandra.maxconnections`
+* `cassandra.coreconnections`
+  * Defaults for max and core connections can be found here: https://datastax.github.io/java-driver/2.1.8/features/pooling/#pool-size. Cassandra 2.0.X falls under protocol V2, Cassandra 2.1+ falls under protocol V3.
+* `cassandra.connecttimeoutmillis`
+* `cassandra.readtimeoutmillis`
+  * Defaults for connect and read timeouts can be found here: https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/SocketOptions.html.


### PR DESCRIPTION
This PR actually fixes two issues, both related to property handling in the ```cassandra2-cql``` client.

1. In the spirit of keeping the clients as baseline as possible, I removed the magic number updates to read and connect timeouts to the cluster. Instead I exposed these properties to the user.
2. No longer setting the max connections to threadcount. As I discussed in #534, YCSB threads are not directly related with Cassandra Connections. I also exposed these settings to the user for fine tuning.

This PR would fix #534 and allows the ```cassandra2-cql``` client to be used on all Cassandra 2.X versions making the deprecation of the cassandra-binding in #532 a little easier.