### PR TITLE
[cassandra] added large deprecation message

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -205,6 +205,13 @@ def main():
 
     # Classpath set up
     binding = args.database.split("-")[0]
+
+    # Deprecation message for the entire cassandra-binding
+    if binding == "cassandra":
+        warn("The 'cassandra-7', 'cassandra-8', 'cassandra-10', and "
+             "cassandra-cql' clients are deprecated. If you are using "
+             "Cassandra 2.X try using the 'cassandra2-cql' client instead.")
+
     if is_distribution():
         db_dir = os.path.join(ycsb_home, binding + "-binding")
         # include top-level conf for when we're a binding-specific artifact.

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -14,6 +14,13 @@ implied. See the License for the specific language governing
 permissions and limitations under the License. See accompanying
 LICENSE file.
 -->
+# THIS BINDING IS DEPRECATED
+----------------------------
+Date of removal from YCSB: **March 2016**
+
+Due to the low amount of use and support for older Cassandra lineages (0.X and 1.X), YCSB will not support clients for these versions either.
+
+For Cassandra 2.X use the ```cassandra2-cql``` client: https://github.com/brianfrankcooper/YCSB/tree/master/cassandra2.
 
 # Cassandra (0.7, 0.8, 1.x) drivers for YCSB
 


### PR DESCRIPTION
I chose 3 month deprecation period, sounds like no one is really using Cassandra 0.X or 1.X anymore. Also, this binding has caused some confusion on which to use for different versions of Cassandra (most Cassandra issues start with 'try using ```cassandra2-cql```), so best to remove it sooner rather than later.

Fixes #532 