### PR TITLE
[kudu] Bump the default admin timeout

### DIFF
--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -134,7 +134,8 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
 
     client = new KuduClient.KuduClientBuilder(masterAddresses)
         .defaultSocketReadTimeoutMs(DEFAULT_SLEEP)
-        .defaultOperationTimeoutMs(DEFAULT_SLEEP).build();
+        .defaultOperationTimeoutMs(DEFAULT_SLEEP)
+        .defaultAdminOperationTimeoutMs(DEFAULT_SLEEP).build();
     if (debug) {
       System.out.println("Connecting to the masters at " + masterAddresses);
     }


### PR DESCRIPTION
The default 10s timeout can be too low when creating large tables on
slow devices. This patch just uses the already-defined default of
60s for that operation.