### PR TITLE
[elasticsearch] Bump version from 0.19.8 to 2.1.1

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -80,3 +80,11 @@ otherwise you will run out of memory.
 If you wish to change the default index name you can set the following property:
 
     es.index.key=my_index_key
+
+### Troubleshoot
+If you encounter error messages such as :
+"Primary shard is not active or isn't assigned is a known node."
+
+Try removing /tmp/esdata/ folder. 
+    rm -rf /tmp/esdata
+

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -33,6 +33,8 @@ LICENSE file.
     </properties>
     <dependencies>
         <dependency>
+        <!-- jna is supported in ES and will be used when provided 
+             otherwise a fallback is used -->    
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>4.1.0</version>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -29,9 +29,14 @@ LICENSE file.
     <name>ElasticSearch Binding</name>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch-version>0.19.8</elasticsearch-version>
+        <elasticsearch-version>2.1.1</elasticsearch-version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>4.1.0</version>
+        </dependency>
         <dependency>
             <groupId>com.yahoo.ycsb</groupId>
             <artifactId>core</artifactId>

--- a/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticSearchClient.java
+++ b/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticSearchClient.java
@@ -20,7 +20,6 @@ package com.yahoo.ycsb.db;
 import static org.elasticsearch.common.settings.Settings.Builder;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
 
@@ -333,10 +332,10 @@ public class ElasticSearchClient extends DB {
   public Status scan(String table, String startkey, int recordcount,
       Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
     try {
-      final RangeQueryBuilder filter = rangeQuery("_id").gte(startkey);
+      final RangeQueryBuilder rangeQuery = rangeQuery("_id").gte(startkey);
       final SearchResponse response = client.prepareSearch(indexKey)
           .setTypes(table)
-          .setQuery(matchAllQuery())
+          .setQuery(rangeQuery)
           .setSize(recordcount)
           .execute()
           .actionGet();


### PR DESCRIPTION
Bumped elasticsearch version and fix multiple api changes.
update README.md troubleshoot section.

Previous issue:
    ./bin/ycsb run elasticsearch -s -P workloads/workloada
    ...
    2015-12-24 02:19:55:472 4 sec: 1000 operations; 242.19 current ops/sec; [UPDATE-FAILED: Count=505, Max=15575, Min=93, Avg=286.22, 90=257, 99=2855, 99.9=9071, 99.99=15575] [READ: Count=0, Max=0, Min=9223372036854775807, Avg=�, 90=0, 99=0, 99.9=0, 99.99=0] [CLEANUP: Count=1, Max=87103, Min=87040, Avg=87072, 90=87103, 99=87103, 99.9=87103, 99.99=87103] [UPDATE: Count=0, Max=0, Min=9223372036854775807, Avg=�, 90=0, 99=0, 99.9=0, 99.99=0] [READ-FAILED: Count=495, Max=8615, Min=93, Avg=235.25, 90=243, 99=1975, 99.9=8615, 99.99=8615]
    [OVERALL], RunTime(ms), 4139.0
    [OVERALL], Throughput(ops/sec), 241.60425223483932
    [UPDATE-FAILED], Operations, 505.0
    [UPDATE-FAILED], AverageLatency(us), 286.21980198019804
    [UPDATE-FAILED], MinLatency(us), 93.0
    [UPDATE-FAILED], MaxLatency(us), 15575.0
    [UPDATE-FAILED], 95thPercentileLatency(us), 369.0
    [UPDATE-FAILED], 99thPercentileLatency(us), 2855.0
    [READ], Operations, 0.0
    [READ], AverageLatency(us), NaN
    [READ], MinLatency(us), 9.223372036854776E18
    [READ], MaxLatency(us), 0.0
    [READ], 95thPercentileLatency(us), 0.0
    [READ], 99thPercentileLatency(us), 0.0
    [READ], Return=ERROR, 495
    [CLEANUP], Operations, 1.0
    [CLEANUP], AverageLatency(us), 87072.0
    [CLEANUP], MinLatency(us), 87040.0
    [CLEANUP], MaxLatency(us), 87103.0
    [CLEANUP], 95thPercentileLatency(us), 87103.0
    [CLEANUP], 99thPercentileLatency(us), 87103.0
    [UPDATE], Operations, 0.0
    [UPDATE], AverageLatency(us), NaN
    [UPDATE], MinLatency(us), 9.223372036854776E18
    [UPDATE], MaxLatency(us), 0.0
    [UPDATE], 95thPercentileLatency(us), 0.0
    [UPDATE], 99thPercentileLatency(us), 0.0
    [UPDATE], Return=ERROR, 505
    [READ-FAILED], Operations, 495.0
    [READ-FAILED], AverageLatency(us), 235.24646464646466
    [READ-FAILED], MinLatency(us), 93.0
    [READ-FAILED], MaxLatency(us), 8615.0
    [READ-FAILED], 95thPercentileLatency(us), 412.0
    [READ-FAILED], 99thPercentileLatency(us), 1975.0
    ===
    fixed:
    [OVERALL], RunTime(ms), 38322.0
    [OVERALL], Throughput(ops/sec), 26.094671468086215
    [READ], Operations, 470.0
    [READ], AverageLatency(us), 1238.4914893617022
    [READ], MinLatency(us), 531.0
    [READ], MaxLatency(us), 10071.0
    [READ], 95thPercentileLatency(us), 2157.0
    [READ], 99thPercentileLatency(us), 4247.0
    [READ], Return=OK, 470
    [CLEANUP], Operations, 1.0
    [CLEANUP], AverageLatency(us), 240192.0
    [CLEANUP], MinLatency(us), 240128.0
    [CLEANUP], MaxLatency(us), 240255.0
    [CLEANUP], 95thPercentileLatency(us), 240255.0
    [CLEANUP], 99thPercentileLatency(us), 240255.0
    [UPDATE], Operations, 530.0
    [UPDATE], AverageLatency(us), 5101.537735849057
    [UPDATE], MinLatency(us), 2204.0
    [UPDATE], MaxLatency(us), 211199.0
    [UPDATE], 95thPercentileLatency(us), 9447.0
    [UPDATE], 99thPercentileLatency(us), 22383.0
    [UPDATE], Return=OK, 530