### PR TITLE
Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
+++ b/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
@@ -200,7 +200,7 @@ public class AccumuloClient extends DB {
 
   @Override
   public Status read(String t, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
 
     try {
       checkTable(t);
@@ -288,7 +288,7 @@ public class AccumuloClient extends DB {
 
   @Override
   public Status update(String t, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     try {
       checkTable(t);
     } catch (TableNotFoundException e) {
@@ -327,7 +327,7 @@ public class AccumuloClient extends DB {
 
   @Override
   public Status insert(String t, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return update(t, key, values);
   }
 
@@ -405,7 +405,7 @@ public class AccumuloClient extends DB {
           // (current way is kind of ugly but works, i think)
           // TODO : Get table name from configuration or argument
           String usertable = "usertable";
-          HashSet<String> fields = new HashSet<String>();
+          Set<String> fields = new HashSet<String>();
           for (int j = 0; j < 9; j++) {
             fields.add("field" + j);
           }

--- a/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
+++ b/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
@@ -98,7 +98,7 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
 
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     try {
       Record record;
 
@@ -134,7 +134,7 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
   }
 
   private Status write(String table, String key, WritePolicy writePolicy,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     Bin[] bins = new Bin[values.size()];
     int index = 0;
 
@@ -156,13 +156,13 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
 
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return write(table, key, updatePolicy, values);
   }
 
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return write(table, key, insertPolicy, values);
   }
 

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -188,7 +188,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
 
     try {
       Statement stmt;
@@ -345,7 +345,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     // Insert and updates provide the same functionality
     return insert(table, key, values);
   }
@@ -365,7 +365,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
 
     try {
       Insert insertStmt = QueryBuilder.insertInto(table);

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -223,7 +223,7 @@ public class CassandraClient10 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -244,7 +244,7 @@ public class CassandraClient10 extends DB {
               EMPTY_BYTE_BUFFER, EMPTY_BYTE_BUFFER, false, 1000000));
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -343,7 +343,7 @@ public class CassandraClient10 extends DB {
               EMPTY_BYTE_BUFFER, EMPTY_BYTE_BUFFER, false, 1000000));
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -422,7 +422,7 @@ public class CassandraClient10 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return insert(table, key, values);
   }
 
@@ -440,7 +440,7 @@ public class CassandraClient10 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -575,7 +575,7 @@ public class CassandraClient10 extends DB {
     System.out.println("Result of insert: " + res);
 
     HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    HashSet<String> fields = new HashSet<String>();
+    Set<String> fields = new HashSet<String>();
     fields.add("middlename");
     fields.add("age");
     fields.add("favoritecolor");

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
@@ -188,7 +188,7 @@ public class CassandraClient7 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -211,7 +211,7 @@ public class CassandraClient7 extends DB {
           predicate = new SlicePredicate().setSlice_range(range);
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -310,7 +310,7 @@ public class CassandraClient7 extends DB {
           predicate = new SlicePredicate().setSlice_range(range);
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -387,7 +387,7 @@ public class CassandraClient7 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return insert(table, key, values);
   }
 
@@ -405,7 +405,7 @@ public class CassandraClient7 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -533,7 +533,7 @@ public class CassandraClient7 extends DB {
     System.out.println("Result of insert: " + res.getName());
 
     HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    HashSet<String> fields = new HashSet<String>();
+    Set<String> fields = new HashSet<String>();
     fields.add("middlename");
     fields.add("age");
     fields.add("favoritecolor");

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
@@ -171,7 +171,7 @@ public class CassandraClient8 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -192,7 +192,7 @@ public class CassandraClient8 extends DB {
               EMPTY_BYTE_BUFFER, EMPTY_BYTE_BUFFER, false, 1000000));
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -289,7 +289,7 @@ public class CassandraClient8 extends DB {
               EMPTY_BYTE_BUFFER, EMPTY_BYTE_BUFFER, false, 1000000));
 
         } else {
-          ArrayList<ByteBuffer> fieldlist =
+          List<ByteBuffer> fieldlist =
               new ArrayList<ByteBuffer>(fields.size());
           for (String s : fields) {
             fieldlist.add(ByteBuffer.wrap(s.getBytes("UTF-8")));
@@ -366,7 +366,7 @@ public class CassandraClient8 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return insert(table, key, values);
   }
 
@@ -384,7 +384,7 @@ public class CassandraClient8 extends DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (!tableName.equals(table)) {
       try {
         client.set_keyspace(table);
@@ -512,7 +512,7 @@ public class CassandraClient8 extends DB {
     System.out.println("Result of insert: " + res);
 
     HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    HashSet<String> fields = new HashSet<String>();
+    Set<String> fields = new HashSet<String>();
     fields.add("middlename");
     fields.add("age");
     fields.add("favoritecolor");

--- a/cassandra2/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra2/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -233,7 +233,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     try {
       Statement stmt;
       Select.Builder selectBuilder;
@@ -390,7 +390,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     // Insert and updates provide the same functionality
     return insert(table, key, values);
   }
@@ -410,7 +410,7 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
 
     try {
       Insert insertStmt = QueryBuilder.insertInto(table);

--- a/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -153,7 +153,7 @@ public class CassandraCQLClientTest {
   @Test
   public void testUpdate() throws Exception {
     final String key = "key";
-    final HashMap<String, String> input = new HashMap<String, String>();
+    final Map<String, String> input = new HashMap<String, String>();
     input.put("field0", "value1");
     input.put("field1", "value2");
 

--- a/core/src/main/java/com/yahoo/ycsb/BasicDB.java
+++ b/core/src/main/java/com/yahoo/ycsb/BasicDB.java
@@ -18,6 +18,7 @@
 package com.yahoo.ycsb;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Enumeration;
@@ -109,7 +110,7 @@ public class BasicDB extends DB
 	 * @param result A HashMap of field/value pairs for the result
 	 * @return Zero on success, a non-zero error code on error
 	 */
-	public Status read(String table, String key, Set<String> fields, HashMap<String,ByteIterator> result)
+	public Status read(String table, String key, Set<String> fields, Map<String,ByteIterator> result)
 	{
 		delay();
 
@@ -178,7 +179,7 @@ public class BasicDB extends DB
 	 * @param values A HashMap of field/value pairs to update in the record
 	 * @return Zero on success, a non-zero error code on error
 	 */
-	public Status update(String table, String key, HashMap<String,ByteIterator> values)
+	public Status update(String table, String key, Map<String,ByteIterator> values)
 	{
 		delay();
 
@@ -207,7 +208,7 @@ public class BasicDB extends DB
 	 * @param values A HashMap of field/value pairs to insert in the record
 	 * @return Zero on success, a non-zero error code on error
 	 */
-	public Status insert(String table, String key, HashMap<String,ByteIterator> values)
+	public Status insert(String table, String key, Map<String,ByteIterator> values)
 	{
 		delay();
 

--- a/core/src/main/java/com/yahoo/ycsb/CommandLine.java
+++ b/core/src/main/java/com/yahoo/ycsb/CommandLine.java
@@ -335,7 +335,7 @@ public class CommandLine
 		  {
 		     System.out.println("--------------------------------");
 		  }
-		  for (HashMap<String,ByteIterator> result : results)
+		  for (Map<String,ByteIterator> result : results)
 		  {
 		     System.out.println("Record "+(record++));
 		     for (Map.Entry<String,ByteIterator> ent : result.entrySet())

--- a/core/src/main/java/com/yahoo/ycsb/DB.java
+++ b/core/src/main/java/com/yahoo/ycsb/DB.java
@@ -18,6 +18,7 @@
 package com.yahoo.ycsb;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
@@ -90,7 +91,7 @@ public abstract class DB
 	 * @param result A HashMap of field/value pairs for the result
 	 * @return The result of the operation.
 	 */
-	public abstract Status read(String table, String key, Set<String> fields, HashMap<String,ByteIterator> result);
+	public abstract Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result);
 
 	/**
 	 * Perform a range scan for a set of records in the database. Each field/value pair from the result will be stored in a HashMap.
@@ -113,7 +114,7 @@ public abstract class DB
 	 * @param values A HashMap of field/value pairs to update in the record
 	 * @return The result of the operation.
 	 */
-	public abstract Status update(String table, String key, HashMap<String,ByteIterator> values);
+	public abstract Status update(String table, String key, Map<String, ByteIterator> values);
 
 	/**
 	 * Insert a record in the database. Any field/value pairs in the specified values HashMap will be written into the record with the specified
@@ -124,7 +125,7 @@ public abstract class DB
 	 * @param values A HashMap of field/value pairs to insert in the record
 	 * @return The result of the operation.
 	 */
-	public abstract Status insert(String table, String key, HashMap<String,ByteIterator> values);
+	public abstract Status insert(String table, String key, Map<String, ByteIterator> values);
 
 	/**
 	 * Delete a record from the database. 

--- a/core/src/main/java/com/yahoo/ycsb/DBWrapper.java
+++ b/core/src/main/java/com/yahoo/ycsb/DBWrapper.java
@@ -19,6 +19,7 @@ package com.yahoo.ycsb;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -36,7 +37,7 @@ public class DBWrapper extends DB
   private Measurements _measurements;
 
   private boolean reportLatencyForEachError = false;
-  private HashSet<String> latencyTrackedErrors = new HashSet<String>();
+  private Set<String> latencyTrackedErrors = new HashSet<String>();
 
   private static final String REPORT_LATENCY_FOR_EACH_ERROR_PROPERTY =
       "reportlatencyforeacherror";
@@ -118,7 +119,7 @@ public class DBWrapper extends DB
    * @return The result of the operation.
    */
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String,ByteIterator> result)
+                     Map<String, ByteIterator> result)
   {
     long ist=_measurements.getIntendedtartTimeNs();
     long st = System.nanoTime();
@@ -179,7 +180,7 @@ public class DBWrapper extends DB
    * @return The result of the operation.
    */
   public Status update(String table, String key,
-      HashMap<String,ByteIterator> values)
+                       Map<String, ByteIterator> values)
   {
     long ist=_measurements.getIntendedtartTimeNs();
     long st = System.nanoTime();
@@ -201,7 +202,7 @@ public class DBWrapper extends DB
    * @return The result of the operation.
    */
   public Status insert(String table, String key,
-      HashMap<String,ByteIterator> values)
+                       Map<String, ByteIterator> values)
   {
     long ist=_measurements.getIntendedtartTimeNs();
     long st = System.nanoTime();

--- a/core/src/main/java/com/yahoo/ycsb/GoodBadUglyDB.java
+++ b/core/src/main/java/com/yahoo/ycsb/GoodBadUglyDB.java
@@ -20,6 +20,7 @@ package com.yahoo.ycsb;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.Vector;
@@ -96,7 +97,7 @@ public class GoodBadUglyDB extends DB {
      * @param result A HashMap of field/value pairs for the result
      * @return Zero on success, a non-zero error code on error
      */
-    public Status read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
+    public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
         delay();
         return Status.OK;
     }
@@ -128,7 +129,7 @@ public class GoodBadUglyDB extends DB {
      * @param values A HashMap of field/value pairs to update in the record
      * @return Zero on success, a non-zero error code on error
      */
-    public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+    public Status update(String table, String key, Map<String, ByteIterator> values) {
         delay();
 
         return Status.OK;
@@ -143,7 +144,7 @@ public class GoodBadUglyDB extends DB {
      * @param values A HashMap of field/value pairs to insert in the record
      * @return Zero on success, a non-zero error code on error
      */
-    public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+    public Status insert(String table, String key, Map<String, ByteIterator> values) {
         delay();
         return Status.OK;
     }

--- a/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
+++ b/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
@@ -44,7 +44,7 @@ public class StringByteIterator extends ByteIterator {
 	 * Create a copy of a map, converting the values from Strings to
 	 * StringByteIterators.
 	 */
-	public static HashMap<String, ByteIterator> getByteIteratorMap(Map<String, String> m) {
+	public static Map<String, ByteIterator> getByteIteratorMap(Map<String, String> m) {
 		HashMap<String, ByteIterator> ret =
 			new HashMap<String,ByteIterator>();
 
@@ -58,7 +58,7 @@ public class StringByteIterator extends ByteIterator {
 	 * Create a copy of a map, converting the values from
 	 * StringByteIterators to Strings.
 	 */
-	public static HashMap<String, String> getStringMap(Map<String, ByteIterator> m) {
+	public static Map<String, String> getStringMap(Map<String, ByteIterator> m) {
 		HashMap<String, String> ret = new HashMap<String,String>();
 
 		for(String s: m.keySet()) {

--- a/couchbase/src/main/java/com/yahoo/ycsb/db/CouchbaseClient.java
+++ b/couchbase/src/main/java/com/yahoo/ycsb/db/CouchbaseClient.java
@@ -163,7 +163,7 @@ public class CouchbaseClient extends DB {
 
   @Override
   public Status read(final String table, final String key, final Set<String> fields,
-    final HashMap<String, ByteIterator> result) {
+    final Map<String, ByteIterator> result) {
     String formattedKey = formatKey(table, key);
 
     try {
@@ -200,7 +200,7 @@ public class CouchbaseClient extends DB {
   }
 
   @Override
-  public Status update(final String table, final String key, final HashMap<String, ByteIterator> values) {
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
     String formattedKey = formatKey(table, key);
 
     try {
@@ -220,7 +220,7 @@ public class CouchbaseClient extends DB {
   }
 
   @Override
-  public Status insert(final String table, final String key, final HashMap<String, ByteIterator> values) {
+  public Status insert(final String table, final String key, final Map<String, ByteIterator> values) {
     String formattedKey = formatKey(table, key);
 
     try {
@@ -287,7 +287,7 @@ public class CouchbaseClient extends DB {
    * @param dest the result passed back to the ycsb core.
    */
   private void decode(final Object source, final Set<String> fields,
-    final HashMap<String, ByteIterator> dest) {
+    final Map<String, ByteIterator> dest) {
     if (useJson) {
       try {
         JsonNode json = JSON_MAPPER.readTree((String) source);
@@ -307,7 +307,7 @@ public class CouchbaseClient extends DB {
         throw new RuntimeException("Could not decode JSON");
       }
     } else {
-      HashMap<String, String> converted = (HashMap<String, String>) source;
+      Map<String, String> converted = (HashMap<String, String>) source;
       for (Map.Entry<String, String> entry : converted.entrySet()) {
         dest.put(entry.getKey(), new StringByteIterator(entry.getValue()));
       }
@@ -320,8 +320,8 @@ public class CouchbaseClient extends DB {
    * @param source the source value.
    * @return the storable object.
    */
-  private Object encode(final HashMap<String, ByteIterator> source) {
-    HashMap<String, String> stringMap = StringByteIterator.getStringMap(source);
+  private Object encode(final Map<String, ByteIterator> source) {
+    Map<String, String> stringMap = StringByteIterator.getStringMap(source);
     if (!useJson) {
       return stringMap;
     }

--- a/dynamodb/src/main/java/com/yahoo/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/com/yahoo/ycsb/db/DynamoDBClient.java
@@ -168,7 +168,7 @@ public class DynamoDBClient extends DB {
 
     @Override
     public Status read(String table, String key, Set<String> fields,
-            HashMap<String, ByteIterator> result) {
+            Map<String, ByteIterator> result) {
 
         logger.debug("readkey: " + key + " from table: " + table);
         GetItemRequest req = new GetItemRequest(table, createPrimaryKey(key));
@@ -254,7 +254,7 @@ public class DynamoDBClient extends DB {
     }
 
     @Override
-    public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+    public Status update(String table, String key, Map<String, ByteIterator> values) {
         logger.debug("updatekey: " + key + " from table: " + table);
 
         Map<String, AttributeValueUpdate> attributes = new HashMap<String, AttributeValueUpdate>(
@@ -280,7 +280,7 @@ public class DynamoDBClient extends DB {
     }
 
     @Override
-    public Status insert(String table, String key,HashMap<String, ByteIterator> values) {
+    public Status insert(String table, String key, Map<String, ByteIterator> values) {
         logger.debug("insertkey: " + primaryKeyName + "-" + key + " from table: " + table);
         Map<String, AttributeValue> attributes = createAttributes(values);
         // adding primary key
@@ -325,7 +325,7 @@ public class DynamoDBClient extends DB {
     }
 
     private static Map<String, AttributeValue> createAttributes(
-            HashMap<String, ByteIterator> values) {
+            Map<String, ByteIterator> values) {
         Map<String, AttributeValue> attributes = new HashMap<String, AttributeValue>(
                 values.size() + 1); //leave space for the PrimaryKey
         for (Entry<String, ByteIterator> val : values.entrySet()) {

--- a/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticSearchClient.java
+++ b/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticSearchClient.java
@@ -42,6 +42,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.search.SearchHit;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
@@ -174,7 +175,7 @@ public class ElasticSearchClient extends DB {
    */
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     try {
       final XContentBuilder doc = jsonBuilder().startObject();
 
@@ -232,7 +233,7 @@ public class ElasticSearchClient extends DB {
    */
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     try {
       final GetResponse response =
           client.prepareGet(indexKey, table, key).execute().actionGet();
@@ -273,7 +274,7 @@ public class ElasticSearchClient extends DB {
    */
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     try {
       final GetResponse response =
           client.prepareGet(indexKey, table, key).execute().actionGet();

--- a/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
+++ b/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
@@ -138,7 +138,7 @@ public class GemFireClient extends DB {
   
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     Region<String, Map<String, byte[]>> r = getRegion(table);
     Map<String, byte[]> val = r.get(key);
     if (val != null) {
@@ -164,13 +164,13 @@ public class GemFireClient extends DB {
   }
 
   @Override
-  public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+  public Status update(String table, String key, Map<String, ByteIterator> values) {
     getRegion(table).put(key, convertToBytearrayMap(values));
     return Status.OK;
   }
 
   @Override
-  public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
     getRegion(table).put(key, convertToBytearrayMap(values));
     return Status.OK;
   }

--- a/googledatastore/src/main/java/com/yahoo/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/com/yahoo/ycsb/db/GoogleDatastoreClient.java
@@ -184,7 +184,7 @@ public class GoogleDatastoreClient extends DB {
 
   @Override
   public Status read(String table, String key, Set<String> fields,
-          HashMap<String, ByteIterator> result) {
+          Map<String, ByteIterator> result) {
     LookupRequest.Builder lookupRequest = LookupRequest.newBuilder();
     lookupRequest.addKey(buildPrimaryKey(table, key));
     lookupRequest.getReadOptionsBuilder().setReadConsistency(
@@ -244,14 +244,14 @@ public class GoogleDatastoreClient extends DB {
 
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
 
     return doSingleItemMutation(table, key, values, MutationType.UPDATE);
   }
 
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     // Use Upsert to allow overwrite of existing key instead of failing the
     // load (or run) just because the DB already has the key.
     // This is the same behavior as what other DB does here (such as
@@ -278,7 +278,7 @@ public class GoogleDatastoreClient extends DB {
   }
 
   private Status doSingleItemMutation(String table, String key,
-      @Nullable HashMap<String, ByteIterator> values,
+      @Nullable Map<String, ByteIterator> values,
       MutationType mutationType) {
     // First build the key.
     Key.Builder datastoreKey = buildPrimaryKey(table, key);

--- a/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -160,7 +160,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
      * @param result A HashMap of field/value pairs for the result
      * @return Zero on success, a non-zero error code on error
      */
-    public Status read(String table, String key, Set<String> fields, HashMap<String,ByteIterator> result)
+    public Status read(String table, String key, Set<String> fields, Map<String,ByteIterator> result)
     {
         //if this is a "new" table, init HTable object.  Else, use existing one
         if (!_table.equals(table)) {
@@ -325,7 +325,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
      * @param values A HashMap of field/value pairs to update in the record
      * @return Zero on success, a non-zero error code on error
      */
-    public Status update(String table, String key, HashMap<String,ByteIterator> values)
+    public Status update(String table, String key, Map<String,ByteIterator> values)
     {
         //if this is a "new" table, init HTable object.  Else, use existing one
         if (!_table.equals(table)) {
@@ -386,7 +386,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
      * @param values A HashMap of field/value pairs to insert in the record
      * @return Zero on success, a non-zero error code on error
      */
-    public Status insert(String table, String key, HashMap<String,ByteIterator> values)
+    public Status insert(String table, String key, Map<String, ByteIterator> values)
     {
         return update(table,key,values);
     }
@@ -497,7 +497,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
                             //rescode=cli.delete("table1",key);
                             rescode=cli.read("table1", key, s, result);
                             */
-                            HashSet<String> scanFields = new HashSet<String>();
+                            Set<String> scanFields = new HashSet<String>();
                             scanFields.add("field1");
                             scanFields.add("field3");
                             Vector<HashMap<String,ByteIterator>> scanResults = new Vector<HashMap<String,ByteIterator>>();

--- a/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -204,7 +204,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
    * @return Zero on success, a non-zero error code on error
    */
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     // if this is a "new" table, init HTable object. Else, use existing one
     if (!tableName.equals(table)) {
       currentTable = null;
@@ -372,7 +372,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
    */
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     // if this is a "new" table, init HTable object. Else, use existing one
     if (!tableName.equals(table)) {
       currentTable = null;
@@ -434,7 +434,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
    */
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return update(table, key, values);
   }
 

--- a/hbase10/src/test/java/com/yahoo/ycsb/db/HBaseClient10Test.java
+++ b/hbase10/src/test/java/com/yahoo/ycsb/db/HBaseClient10Test.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
@@ -169,7 +170,7 @@ public class HBaseClient10Test {
 
     assertEquals(5, result.size());
     for(int i = 0; i < 5; i++) {
-      final HashMap<String, ByteIterator> row = result.get(i);
+      final Map<String, ByteIterator> row = result.get(i);
       assertEquals(1, row.size());
       assertTrue(row.containsKey(colStr));
       final byte[] bytes = row.get(colStr).toArray();
@@ -182,7 +183,7 @@ public class HBaseClient10Test {
   @Test
   public void testUpdate() throws Exception{
     final String key = "key";
-    final HashMap<String, String> input = new HashMap<String, String>();
+    final Map<String, String> input = new HashMap<String, String>();
     input.put("column1", "value1");
     input.put("column2", "value2");
     final Status status = client.insert(CoreWorkload.table, key, StringByteIterator.getByteIteratorMap(input));

--- a/hypertable/src/main/java/com/yahoo/ycsb/db/HypertableClient.java
+++ b/hypertable/src/main/java/com/yahoo/ycsb/db/HypertableClient.java
@@ -121,7 +121,7 @@ public class HypertableClient extends com.yahoo.ycsb.DB
      */
     @Override
     public Status read(String table, String key, Set<String> fields, 
-                    HashMap<String, ByteIterator> result)
+                    Map<String, ByteIterator> result)
     {
         //SELECT _column_family:field[i] 
         //  FROM table WHERE ROW=key MAX_VERSIONS 1;
@@ -249,8 +249,8 @@ public class HypertableClient extends com.yahoo.ycsb.DB
      * @return Zero on success, a non-zero error code on error
      */
     @Override
-    public Status update(String table, String key, 
-            HashMap<String, ByteIterator> values)
+    public Status update(String table, String key,
+                         Map<String, ByteIterator> values)
     {
         return insert(table, key, values);
     }
@@ -267,7 +267,7 @@ public class HypertableClient extends com.yahoo.ycsb.DB
      */
     @Override
     public Status insert(String table, String key, 
-            HashMap<String, ByteIterator> values)
+            Map<String, ByteIterator> values)
     {
         //INSERT INTO table VALUES 
         //  (key, _column_family:entry,getKey(), entry.getValue()), (...);

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanClient.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanClient.java
@@ -70,7 +70,7 @@ public class InfinispanClient extends DB {
       infinispanManager = null;
    }
 
-   public Status read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
+   public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
       try {
          Map<String, String> row;
          if (clustered) {
@@ -98,7 +98,7 @@ public class InfinispanClient extends DB {
       return Status.OK;
    }
 
-   public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+   public Status update(String table, String key, Map<String, ByteIterator> values) {
       try {
          if (clustered) {
             AtomicMap<String, String> row = AtomicMapLookup.getAtomicMap(infinispanManager.getCache(table), key);
@@ -120,7 +120,7 @@ public class InfinispanClient extends DB {
       }
    }
 
-   public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+   public Status insert(String table, String key, Map<String, ByteIterator> values) {
       try {
          if (clustered) {
             AtomicMap<String, String> row = AtomicMapLookup.getAtomicMap(infinispanManager.getCache(table), key);

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
@@ -64,7 +64,7 @@ public class InfinispanRemoteClient extends DB {
    }
    
    @Override
-   public Status insert(String table, String recordKey, HashMap<String, ByteIterator> values) {
+   public Status insert(String table, String recordKey, Map<String, ByteIterator> values) {
 	   String compositKey = createKey(table, recordKey);
 	   Map<String, String> stringValues = new HashMap<String,String>();
 	   StringByteIterator.putAllAsStrings(stringValues, values);
@@ -77,7 +77,7 @@ public class InfinispanRemoteClient extends DB {
    }
    
    @Override
-   public Status read(String table, String recordKey, Set<String> fields, HashMap<String, ByteIterator> result) {
+   public Status read(String table, String recordKey, Set<String> fields, Map<String, ByteIterator> result) {
 	   String compositKey = createKey(table, recordKey);
 	   try {	  
     	  Map<String, String> values = cache().get(compositKey);
@@ -110,7 +110,7 @@ public class InfinispanRemoteClient extends DB {
    }
    
    @Override
-   public Status update(String table, String recordKey, HashMap<String, ByteIterator> values) {
+   public Status update(String table, String recordKey, Map<String, ByteIterator> values) {
 	   String compositKey = createKey(table, recordKey);
       try {
     	  Map<String, String> stringValues = new HashMap<String, String>();

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
@@ -53,7 +53,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class JdbcDBClient extends DB implements JdbcDBClientConstants {
 	
-  private ArrayList<Connection> conns;
+  private List<Connection> conns;
   private boolean initialized = false;
   private Properties props;
   private Integer jdbcFetchSize;
@@ -318,7 +318,7 @@ public class JdbcDBClient extends DB implements JdbcDBClientConstants {
 
 	@Override
 	public Status read(String tableName, String key, Set<String> fields,
-			HashMap<String, ByteIterator> result) {
+			Map<String, ByteIterator> result) {
     try {
       StatementType type = new StatementType(StatementType.Type.READ, tableName, 1, getShardIndexByKey(key));
       PreparedStatement readStatement = cachedStatements.get(type);
@@ -376,7 +376,7 @@ public class JdbcDBClient extends DB implements JdbcDBClientConstants {
 	}
 
 	@Override
-	public Status update(String tableName, String key, HashMap<String, ByteIterator> values) {
+	public Status update(String tableName, String key, Map<String, ByteIterator> values) {
     try {
       int numFields = values.size();
       StatementType type = new StatementType(StatementType.Type.UPDATE, tableName, numFields, getShardIndexByKey(key));
@@ -399,7 +399,7 @@ public class JdbcDBClient extends DB implements JdbcDBClientConstants {
 	}
 
 	@Override
-	public Status insert(String tableName, String key, HashMap<String, ByteIterator> values) {
+	public Status insert(String tableName, String key, Map<String, ByteIterator> values) {
 	  try {
 	    int numFields = values.size();
 	    StatementType type = new StatementType(StatementType.Type.INSERT, tableName, numFields, getShardIndexByKey(key));

--- a/jdbc/src/test/java/com/yahoo/ycsb/db/JdbcDBClientTest.java
+++ b/jdbc/src/test/java/com/yahoo/ycsb/db/JdbcDBClientTest.java
@@ -26,7 +26,9 @@ import org.junit.*;
 
 import java.sql.*;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.Properties;
 import java.util.Vector;
 
@@ -246,7 +248,7 @@ public class JdbcDBClientTest {
     public void readTest() {
         String insertKey = "user0";
         HashMap<String, ByteIterator> insertMap = insertRow(insertKey);
-        HashSet<String> readFields = new HashSet<String>();
+        Set<String> readFields = new HashSet<String>();
         HashMap<String, ByteIterator> readResultMap = new HashMap<String, ByteIterator>();
 
         // Test reading a single field
@@ -304,12 +306,12 @@ public class JdbcDBClientTest {
 
     @Test
     public void scanTest() throws SQLException {
-        HashMap<String, HashMap<String, ByteIterator>> keyMap = new HashMap<String, HashMap<String, ByteIterator>>();
+        Map<String, HashMap<String, ByteIterator>> keyMap = new HashMap<String, HashMap<String, ByteIterator>>();
         for (int i = 0; i < 5; i++) {
             String insertKey = KEY_PREFIX + i;
             keyMap.put(insertKey, insertRow(insertKey));
         }
-        HashSet<String> fieldSet = new HashSet<String>();
+        Set<String> fieldSet = new HashSet<String>();
         fieldSet.add("FIELD0");
         fieldSet.add("FIELD1");
         int startIndex = 1;
@@ -322,7 +324,7 @@ public class JdbcDBClientTest {
         assertEquals("Assert the correct number of results rows were returned", resultRows, resultVector.size());
         // Check each vector row to make sure we have the correct fields
         int testIndex = startIndex;
-        for (HashMap<String, ByteIterator> result: resultVector) {
+        for (Map<String, ByteIterator> result: resultVector) {
             assertEquals("Assert that this row has the correct number of fields", fieldSet.size(), result.size());
             for (String field: fieldSet) {
                 // TODO: This will fail until the fix is made to insert and update fields in the correct order.

--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -29,6 +29,7 @@ import org.kududb.client.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -204,7 +205,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
 
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     Vector<HashMap<String, ByteIterator>> results =
         new Vector<HashMap<String, ByteIterator>>();
     final Status status = scan(table, key, 1, fields, results);
@@ -294,7 +295,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
 
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     Update update = this.kuduTable.newUpdate();
     PartialRow row = update.getRow();
     row.addString(KEY, key);
@@ -311,7 +312,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
 
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     Insert insert = this.kuduTable.newInsert();
     PartialRow row = insert.getRow();
     row.addString(KEY, key);

--- a/mapkeeper/src/main/java/com/yahoo/ycsb/db/MapKeeperClient.java
+++ b/mapkeeper/src/main/java/com/yahoo/ycsb/db/MapKeeperClient.java
@@ -129,7 +129,7 @@ public class MapKeeperClient extends DB {
 
     @Override
     public int read(String table, String key, Set<String> fields,
-            HashMap<String, ByteIterator> result) {
+            Map<String, ByteIterator> result) {
         try {
             ByteBuffer buf = bufStr(key);
 
@@ -177,7 +177,7 @@ public class MapKeeperClient extends DB {
 
     @Override
     public int update(String table, String key,
-            HashMap<String, ByteIterator> values) {
+            Map<String, ByteIterator> values) {
         try {
             if(!writeallfields) {
                 HashMap<String, ByteIterator> oldval = new HashMap<String, ByteIterator>();
@@ -197,7 +197,7 @@ public class MapKeeperClient extends DB {
 
     @Override
     public int insert(String table, String key,
-            HashMap<String, ByteIterator> values) {
+            Map<String, ByteIterator> values) {
         try {
             int ret = ycsbThriftRet(c.insert(table, bufStr(key), encode(values)), ResponseCode.Success, ResponseCode.RecordExists);
             return ret;

--- a/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
+++ b/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
@@ -171,7 +171,7 @@ public class MemcachedClient extends DB {
   @Override
   public Status read(
       String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     key = createQualifiedKey(table, key);
     try {
       GetFuture<Object> future = memcachedClient().asyncGet(key);
@@ -195,7 +195,7 @@ public class MemcachedClient extends DB {
 
   @Override
   public Status update(
-      String table, String key, HashMap<String, ByteIterator> values) {
+      String table, String key, Map<String, ByteIterator> values) {
     key = createQualifiedKey(table, key);
     try {
       OperationFuture<Boolean> future =
@@ -209,7 +209,7 @@ public class MemcachedClient extends DB {
 
   @Override
   public Status insert(
-      String table, String key, HashMap<String, ByteIterator> values) {
+      String table, String key, Map<String, ByteIterator> values) {
     key = createQualifiedKey(table, key);
     try {
       OperationFuture<Boolean> future =
@@ -281,7 +281,7 @@ public class MemcachedClient extends DB {
   protected static String toJson(Map<String, ByteIterator> values)
       throws IOException {
     ObjectNode node = MAPPER.createObjectNode();
-    HashMap<String, String> stringMap = StringByteIterator.getStringMap(values);
+    Map<String, String> stringMap = StringByteIterator.getStringMap(values);
     for (Map.Entry<String, String> pair : stringMap.entrySet()) {
       node.put(pair.getKey(), pair.getValue());
     }

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -251,7 +251,7 @@ public class AsyncMongoDbClient extends DB {
    */
   @Override
   public final Status insert(final String table, final String key,
-      final HashMap<String, ByteIterator> values) {
+      final Map<String, ByteIterator> values) {
     try {
       final MongoCollection collection = database.getCollection(table);
       final DocumentBuilder toInsert =
@@ -329,7 +329,7 @@ public class AsyncMongoDbClient extends DB {
    */
   @Override
   public final Status read(final String table, final String key,
-      final Set<String> fields, final HashMap<String, ByteIterator> result) {
+      final Set<String> fields, final Map<String, ByteIterator> result) {
     try {
       final MongoCollection collection = database.getCollection(table);
       final DocumentBuilder query =
@@ -450,7 +450,7 @@ public class AsyncMongoDbClient extends DB {
    */
   @Override
   public final Status update(final String table, final String key,
-      final HashMap<String, ByteIterator> values) {
+      final Map<String, ByteIterator> values) {
     try {
       final MongoCollection collection = database.getCollection(table);
       final DocumentBuilder query = BuilderFactory.start().add("_id", key);
@@ -477,7 +477,7 @@ public class AsyncMongoDbClient extends DB {
    * @param queryResult
    *          The document to fill from.
    */
-  protected final void fillMap(final HashMap<String, ByteIterator> result,
+  protected final void fillMap(final Map<String, ByteIterator> result,
       final Document queryResult) {
     for (final Element be : queryResult) {
       if (be.getType() == ElementType.BINARY) {

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -251,7 +251,7 @@ public class MongoDbClient extends DB {
    */
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     try {
       MongoCollection<Document> collection = database.getCollection(table);
       Document toInsert = new Document("_id", key);
@@ -313,7 +313,7 @@ public class MongoDbClient extends DB {
    */
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     try {
       MongoCollection<Document> collection = database.getCollection(table);
       Document query = new Document("_id", key);
@@ -426,7 +426,7 @@ public class MongoDbClient extends DB {
    */
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     try {
       MongoCollection<Document> collection = database.getCollection(table);
 

--- a/mongodb/src/test/java/com/yahoo/ycsb/db/AbstractDBTestCases.java
+++ b/mongodb/src/test/java/com/yahoo/ycsb/db/AbstractDBTestCases.java
@@ -37,6 +37,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
@@ -281,7 +282,7 @@ public abstract class AbstractDBTestCases {
     assertThat("Read did not return success (0).", result, is(Status.OK));
     assertThat(results.size(), is(5));
     for (int i = 0; i < 5; ++i) {
-      HashMap<String, ByteIterator> read = results.get(i);
+      Map<String, ByteIterator> read = results.get(i);
       for (String key : keys) {
         ByteIterator iter = read.get(key);
 

--- a/nosqldb/src/main/java/com/yahoo/ycsb/db/NoSqlDbClient.java
+++ b/nosqldb/src/main/java/com/yahoo/ycsb/db/NoSqlDbClient.java
@@ -173,7 +173,7 @@ public class NoSqlDbClient extends DB {
 	}
 
 	@Override
-	public int read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
+	public int read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
 		Key kvKey = createKey(table, key);
 		SortedMap<Key, ValueVersion> kvResult;
 		try {
@@ -202,7 +202,7 @@ public class NoSqlDbClient extends DB {
 	}
 
 	@Override
-	public int update(String table, String key, HashMap<String, ByteIterator> values) {
+	public int update(String table, String key, Map<String, ByteIterator> values) {
 		for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
 			Key kvKey = createKey(table, key, entry.getKey());
 			Value kvValue = Value.createValue(entry.getValue().toArray());
@@ -218,7 +218,7 @@ public class NoSqlDbClient extends DB {
 	}
 
 	@Override
-	public int insert(String table, String key, HashMap<String, ByteIterator> values) {
+	public int insert(String table, String key, Map<String, ByteIterator> values) {
 		return update(table, key, values);
 	}
 

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -1,4 +1,5 @@
 /**
+/**
  * Copyright (c) 2012 - 2015 YCSB contributors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
@@ -39,6 +40,7 @@ import com.yahoo.ycsb.Status;
 import com.yahoo.ycsb.StringByteIterator;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
@@ -131,7 +133,7 @@ public class OrientDBClient extends DB {
    * @param values A HashMap of field/value pairs to insert in the record
    * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
    */
-  public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
     try {
       final ODocument document = new ODocument(CLASS);
       for (Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet())
@@ -174,7 +176,7 @@ public class OrientDBClient extends DB {
    * @param result A HashMap of field/value pairs for the result
    * @return Zero on success, a non-zero error code on error or "not found".
    */
-  public Status read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
+  public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {
@@ -202,7 +204,7 @@ public class OrientDBClient extends DB {
    * @param values A HashMap of field/value pairs to update in the record
    * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
    */
-  public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+  public Status update(String table, String key, Map<String, ByteIterator> values) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {

--- a/redis/src/main/java/com/yahoo/ycsb/db/RedisClient.java
+++ b/redis/src/main/java/com/yahoo/ycsb/db/RedisClient.java
@@ -34,6 +34,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
@@ -94,7 +95,7 @@ public class RedisClient extends DB {
 
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     if (fields == null) {
       StringByteIterator.putAllAsByteIterators(result, jedis.hgetAll(key));
     } else {
@@ -116,7 +117,7 @@ public class RedisClient extends DB {
 
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (jedis.hmset(key, StringByteIterator.getStringMap(values))
         .equals("OK")) {
       jedis.zadd(INDEX_KEY, hash(key), key);
@@ -133,7 +134,7 @@ public class RedisClient extends DB {
 
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     return jedis.hmset(key, StringByteIterator.getStringMap(values))
         .equals("OK") ? Status.OK : Status.ERROR;
   }

--- a/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
+++ b/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
@@ -258,7 +258,7 @@ public class S3Client extends DB {
   */
   @Override
   public Status insert(String bucket, String key,
-      HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return writeToStorage(bucket, key, values, true, sse, ssecKey);
   }
   /**
@@ -278,7 +278,7 @@ public class S3Client extends DB {
   */
   @Override
   public Status read(String bucket, String key, Set<String> fields,
-        HashMap<String, ByteIterator> result) {
+                     Map<String, ByteIterator> result) {
     return readFromStorage(bucket, key, result, ssecKey);
   }
   /**
@@ -296,7 +296,7 @@ public class S3Client extends DB {
   */
   @Override
   public Status update(String bucket, String key,
-        HashMap<String, ByteIterator> values) {
+                       Map<String, ByteIterator> values) {
     return writeToStorage(bucket, key, values, false, sse, ssecKey);
   }
   /**
@@ -336,8 +336,8 @@ public class S3Client extends DB {
   *
   */
   protected Status writeToStorage(String bucket, String key,
-        HashMap<String, ByteIterator> values, Boolean updateMarker,
-            String sseLocal, SSECustomerKey ssecLocal) {
+                                  Map<String, ByteIterator> values, Boolean updateMarker,
+                                  String sseLocal, SSECustomerKey ssecLocal) {
     int totalSize = 0;
     int fieldCount = values.size(); //number of fields to concatenate
     // getting the first field in the values
@@ -436,7 +436,7 @@ public class S3Client extends DB {
   *
   */
   protected Status readFromStorage(String bucket, String key,
-        HashMap<String, ByteIterator> result, SSECustomerKey ssecLocal) {
+                                   Map<String, ByteIterator> result, SSECustomerKey ssecLocal) {
     try {
       GetObjectRequest getObjectRequest = null;
       GetObjectMetadataRequest getObjectMetadataRequest = null;

--- a/tarantool/src/main/java/com/yahoo/ycsb/db/TarantoolClient.java
+++ b/tarantool/src/main/java/com/yahoo/ycsb/db/TarantoolClient.java
@@ -83,7 +83,7 @@ public class TarantoolClient extends DB {
 	}
 
 	@Override
-	public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+	public Status insert(String table, String key, Map<String, ByteIterator> values) {
 		int j = 0;
 		String[] tuple = new String[1 + 2 * values.size()];
 		tuple[0] = key;
@@ -114,7 +114,7 @@ public class TarantoolClient extends DB {
 
 	@Override
 	public Status read(String table, String key, Set<String> fields,
-			HashMap<String, ByteIterator> result) {
+			Map<String, ByteIterator> result) {
 		try {
 			List<String> response;
 			response = this.connection.select(this.spaceNo, 0, Arrays.asList(key), 0, 1, 0);
@@ -163,7 +163,7 @@ public class TarantoolClient extends DB {
 	}
 	@Override
 	public Status update(String table, String key,
-			HashMap<String, ByteIterator> values) {
+			Map<String, ByteIterator> values) {
 		int j = 0;
 		String[] tuple = new String[1 + 2 * values.size()];
 		tuple[0] = key;

--- a/voldemort/src/main/java/com/yahoo/ycsb/db/VoldemortClient.java
+++ b/voldemort/src/main/java/com/yahoo/ycsb/db/VoldemortClient.java
@@ -85,7 +85,7 @@ public class VoldemortClient extends DB {
 
   @Override
   public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (checkStore(table) == Status.ERROR) {
       return Status.ERROR;
     }
@@ -96,7 +96,7 @@ public class VoldemortClient extends DB {
 
   @Override
   public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+      Map<String, ByteIterator> result) {
     if (checkStore(table) == Status.ERROR) {
       return Status.ERROR;
     }
@@ -130,7 +130,7 @@ public class VoldemortClient extends DB {
 
   @Override
   public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+      Map<String, ByteIterator> values) {
     if (checkStore(table) == Status.ERROR) {
       return Status.ERROR;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1319
Please let me know if you have any questions.
Kirill Vlasov
