### PR TITLE
"return" statements should not occur in "finally" blocks

### DIFF
--- a/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
+++ b/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
@@ -414,14 +414,14 @@ public class S3Client extends DB {
         System.err.println("Not possible to write object :"+key);
         e.printStackTrace();
         return Status.ERROR;
-      } finally {
-        return Status.OK;
       }
     } catch (Exception e) {
       System.err.println("Error in the creation of the stream :"+e.toString());
       e.printStackTrace();
       return Status.ERROR;
     }
+
+    return Status.OK;
   }
 
   /**
@@ -465,9 +465,9 @@ public class S3Client extends DB {
       System.err.println("Not possible to get the object "+key);
       e.printStackTrace();
       return Status.ERROR;
-    } finally {
-      return Status.OK;
     }
+
+    return Status.OK;
   }
 
   /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1143 - "return" statements should not occur in "finally" blocks
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1143
Please let me know if you have any questions.
Kirill Vlasov