### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -581,8 +581,8 @@ public class CassandraClient10 extends DB {
     fields.add("favoritecolor");
     res = cli.read("usertable", "BrianFrankCooper", null, result);
     System.out.println("Result of read: " + res);
-    for (String s : result.keySet()) {
-      System.out.println("[" + s + "]=[" + result.get(s) + "]");
+    for (Map.Entry<String, ByteIterator> entry : result.entrySet()) {
+      System.out.println("[" + entry.getKey() + "]=[" + entry.getValue() + "]");
     }
 
     res = cli.delete("usertable", "BrianFrankCooper");

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
@@ -539,8 +539,8 @@ public class CassandraClient7 extends DB {
     fields.add("favoritecolor");
     res = cli.read("usertable", "BrianFrankCooper", null, result);
     System.out.println("Result of read: " + res.getName());
-    for (String s : result.keySet()) {
-      System.out.println("[" + s + "]=[" + result.get(s) + "]");
+    for (Map.Entry<String, ByteIterator> entry : result.entrySet()) {
+      System.out.println("[" + entry.getKey() + "]=[" + entry.getValue() + "]");
     }
 
     res = cli.delete("usertable", "BrianFrankCooper");

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
@@ -518,8 +518,8 @@ public class CassandraClient8 extends DB {
     fields.add("favoritecolor");
     res = cli.read("usertable", "BrianFrankCooper", null, result);
     System.out.println("Result of read: " + res);
-    for (String s : result.keySet()) {
-      System.out.println("[" + s + "]=[" + result.get(s) + "]");
+    for (Map.Entry<String, ByteIterator> entry : result.entrySet()) {
+      System.out.println("[" + entry.getKey() + "]=[" + entry.getValue() + "]");
     }
 
     res = cli.delete("usertable", "BrianFrankCooper");

--- a/core/src/main/java/com/yahoo/ycsb/BasicDB.java
+++ b/core/src/main/java/com/yahoo/ycsb/BasicDB.java
@@ -17,11 +17,7 @@
 
 package com.yahoo.ycsb;
 
-import java.util.HashMap;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Enumeration;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
@@ -187,9 +183,9 @@ public class BasicDB extends DB
 			System.out.print("UPDATE "+table+" "+key+" [ ");
 			if (values!=null)
 			{
-				for (String k : values.keySet())
+				for (Map.Entry<String, ByteIterator> entry : values.entrySet())
 				{
-					System.out.print(k+"="+values.get(k)+" ");
+					System.out.print(entry.getKey() +"="+ entry.getValue() +" ");
 				}
 			}
 			System.out.println("]");
@@ -216,9 +212,9 @@ public class BasicDB extends DB
 			System.out.print("INSERT "+table+" "+key+" [ ");
 			if (values!=null)
 			{
-				for (String k : values.keySet())
+				for (Map.Entry<String, ByteIterator> entry : values.entrySet())
 				{
-					System.out.print(k+"="+values.get(k)+" ");
+					System.out.print(entry.getKey() +"="+ entry.getValue() +" ");
 				}
 			}
 

--- a/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
+++ b/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
@@ -29,7 +29,7 @@ public class StringByteIterator extends ByteIterator {
 	 * String values into ByteIterators.
 	 */
 	public static void putAllAsByteIterators(Map<String, ByteIterator> out, Map<String, String> in) {
-	       for(String s: in.keySet()) { out.put(s, new StringByteIterator(in.get(s))); }
+	       for(Map.Entry<String, String> entry : in.entrySet()) { out.put(entry.getKey(), new StringByteIterator(entry.getValue())); }
 	} 
 
 	/**
@@ -37,7 +37,7 @@ public class StringByteIterator extends ByteIterator {
 	 * ByteIterator values into Strings.
 	 */
 	public static void putAllAsStrings(Map<String, String> out, Map<String, ByteIterator> in) {
-	       for(String s: in.keySet()) { out.put(s, in.get(s).toString()); }
+	       for(Map.Entry<String, ByteIterator> entry : in.entrySet()) { out.put(entry.getKey(), entry.getValue().toString()); }
 	} 
 
 	/**
@@ -48,8 +48,8 @@ public class StringByteIterator extends ByteIterator {
 		HashMap<String, ByteIterator> ret =
 			new HashMap<String,ByteIterator>();
 
-		for(String s: m.keySet()) {
-			ret.put(s, new StringByteIterator(m.get(s)));
+		for(Map.Entry<String, String> entry : m.entrySet()) {
+			ret.put(entry.getKey(), new StringByteIterator(entry.getValue()));
 		}
 		return ret;
 	}
@@ -61,8 +61,8 @@ public class StringByteIterator extends ByteIterator {
 	public static HashMap<String, String> getStringMap(Map<String, ByteIterator> m) {
 		HashMap<String, String> ret = new HashMap<String,String>();
 
-		for(String s: m.keySet()) {
-			ret.put(s, m.get(s).toString());
+		for(Map.Entry<String, ByteIterator> entry : m.entrySet()) {
+			ret.put(entry.getKey(), entry.getValue().toString());
 		}
 		return ret;
 	}

--- a/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
+++ b/gemfire/src/main/java/com/yahoo/ycsb/db/GemFireClient.java
@@ -143,8 +143,8 @@ public class GemFireClient extends DB {
     Map<String, byte[]> val = r.get(key);
     if (val != null) {
       if (fields == null) {
-        for (String k : val.keySet()) {
-          result.put(k, new ByteArrayByteIterator(val.get(k)));
+        for (Map.Entry<String, byte[]> entry : val.entrySet()) {
+          result.put(entry.getKey(), new ByteArrayByteIterator(entry.getValue()));
         }
       } else {
         for (String field : fields) {
@@ -183,8 +183,8 @@ public class GemFireClient extends DB {
 
   private Map<String, byte[]> convertToBytearrayMap(Map<String,ByteIterator> values) {
     Map<String, byte[]> retVal = new HashMap<String, byte[]>();
-    for (String key : values.keySet()) {
-      retVal.put(key, values.get(key).toArray());
+    for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
+      retVal.put(entry.getKey(), entry.getValue().toArray());
     }
     return retVal;
   }

--- a/mapkeeper/src/main/java/com/yahoo/ycsb/db/MapKeeperClient.java
+++ b/mapkeeper/src/main/java/com/yahoo/ycsb/db/MapKeeperClient.java
@@ -74,19 +74,19 @@ public class MapKeeperClient extends DB {
 
     ByteBuffer encode(HashMap<String, ByteIterator> values) {
         int len = 0;
-        for(String k : values.keySet()) {
-            len += (k.length() + 1 + values.get(k).bytesLeft() + 1);
+        for(Map.Entry<String, ByteIterator> entry : values.entrySet()) {
+            len += (entry.getKey().length() + 1 + entry.getValue().bytesLeft() + 1);
         }
         byte[] array = new byte[len];
         int i = 0;
-        for(String k : values.keySet()) {
-            for(int j = 0; j < k.length(); j++) {
-                array[i] = (byte)k.charAt(j);
+        for(Map.Entry<String, ByteIterator> entry : values.entrySet()) {
+            for(int j = 0; j < entry.getKey().length(); j++) {
+                array[i] = (byte)entry.getKey().charAt(j);
                 i++;
             }
             array[i] = '\t'; // XXX would like to use sane delimiter (null, 254, 255, ...) but java makes this nearly impossible
             i++;
-            ByteIterator v = values.get(k);
+            ByteIterator v = entry.getValue();
             i = v.nextBuf(array, i);
             array[i] = '\t';
             i++;
@@ -182,8 +182,8 @@ public class MapKeeperClient extends DB {
             if(!writeallfields) {
                 HashMap<String, ByteIterator> oldval = new HashMap<String, ByteIterator>();
                 read(table, key, null, oldval);
-                for(String k: values.keySet()) {
-                    oldval.put(k, values.get(k));
+                for(Map.Entry<String, ByteIterator> entry : values.entrySet()) {
+                    oldval.put(entry.getKey(), entry.getValue()));
                 }
                 values = oldval;
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864
Please let me know if you have any questions.
Kirill Vlasov