### PR TITLE
[mongodb] Update to use BATCHED_OK Status for batched inserts.

### DIFF
--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -286,7 +286,7 @@ public class AsyncMongoDbClient extends DB {
         batchedWriteCount += 1;
 
         if (batchedWriteCount < batchSize) {
-          return Status.OK;
+          return OptionsSupport.BATCHED_OK;
         }
 
         long count = collection.write(batchedWrite);

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -56,7 +56,7 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * MongoDB asynchronous client for YCSB framework using the MongoDB Inc. <a
+ * MongoDB binding for YCSB framework using the MongoDB Inc. <a
  * href="http://docs.mongodb.org/ecosystem/drivers/java/">driver</a>
  * <p>
  * See the <code>README.md</code> for configuration information.
@@ -285,6 +285,8 @@ public class MongoDbClient extends DB {
             collection.insertMany(bulkInserts, INSERT_UNORDERED);
           }
           bulkInserts.clear();
+        } else {
+          return OptionsSupport.BATCHED_OK;
         }
       }
       return Status.OK;

--- a/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/OptionsSupport.java
@@ -18,12 +18,21 @@ package com.yahoo.ycsb.db;
 
 import java.util.Properties;
 
+import com.yahoo.ycsb.Status;
+
 /**
  * OptionsSupport provides methods for handling legacy options.
  *
  * @author rjm
  */
 public final class OptionsSupport {
+
+  /** 
+   * Status used for operations that have not been send to the server and have 
+   * only been batched by the client.
+   */
+  public static final Status BATCHED_OK = new Status("BATCHED_OK", 
+      "The operation has been batched by the binding.");
 
   /** Value for an unavailable property. */
   private static final String UNAVAILABLE = "n/a";


### PR DESCRIPTION
This ensures that users do not confuse the results from batched
and non-batched operations.

Closes #522