### PR TITLE
Primitives should not be boxed just for "String" conversion

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -591,7 +591,7 @@ public class Client
           System.exit(0);
         }
         int tcount=Integer.parseInt(args[argindex]);
-        props.setProperty(THREAD_COUNT_PROPERTY, tcount+"");
+        props.setProperty(THREAD_COUNT_PROPERTY, String.valueOf(tcount));
         argindex++;
       }
       else if (args[argindex].compareTo("-target")==0)
@@ -603,7 +603,7 @@ public class Client
           System.exit(0);
         }
         int ttarget=Integer.parseInt(args[argindex]);
-        props.setProperty(TARGET_PROPERTY, ttarget+"");
+        props.setProperty(TARGET_PROPERTY, String.valueOf(ttarget));
         argindex++;
       }
       else if (args[argindex].compareTo("-load")==0)

--- a/core/src/main/java/com/yahoo/ycsb/generator/IntegerGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/IntegerGenerator.java
@@ -46,7 +46,7 @@ public abstract class IntegerGenerator extends Generator
 	 */
 	public String nextString()
 	{
-		return ""+nextInt();
+		return String.valueOf(nextInt());
 	}
 	
 	/**
@@ -57,7 +57,7 @@ public abstract class IntegerGenerator extends Generator
 	@Override
 	public String lastString()
 	{
-		return ""+lastInt();
+		return String.valueOf(lastInt());
 	}
 	
 	/**

--- a/core/src/main/java/com/yahoo/ycsb/generator/ScrambledZipfianGenerator.java
+++ b/core/src/main/java/com/yahoo/ycsb/generator/ScrambledZipfianGenerator.java
@@ -123,7 +123,7 @@ public class ScrambledZipfianGenerator extends IntegerGenerator
 		
 		for (int i=0; i<1000000; i++)
 		{
-			System.out.println(""+gen.nextInt());
+			System.out.println(gen.nextInt());
 		}
 	}
 

--- a/core/src/main/java/com/yahoo/ycsb/workloads/ConstantOccupancyWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/ConstantOccupancyWorkload.java
@@ -64,9 +64,9 @@ public class ConstantOccupancyWorkload extends CoreWorkload {
 	@Override
 	public void init(Properties p) throws WorkloadException
 	{
-		disksize    = Long.parseLong(    p.getProperty(DISK_SIZE_PROPERTY, DISK_SIZE_PROPERTY_DEFAULT+""));
-		storageages = Long.parseLong(    p.getProperty(STORAGE_AGE_PROPERTY, STORAGE_AGE_PROPERTY_DEFAULT+""));
-		occupancy   = Double.parseDouble(p.getProperty(OCCUPANCY_PROPERTY, OCCUPANCY_PROPERTY_DEFAULT+""));
+		disksize    = Long.parseLong(    p.getProperty(DISK_SIZE_PROPERTY, String.valueOf(DISK_SIZE_PROPERTY_DEFAULT)));
+		storageages = Long.parseLong(    p.getProperty(STORAGE_AGE_PROPERTY, String.valueOf(STORAGE_AGE_PROPERTY_DEFAULT)));
+		occupancy   = Double.parseDouble(p.getProperty(OCCUPANCY_PROPERTY, String.valueOf(OCCUPANCY_PROPERTY_DEFAULT)));
 		
 		if(p.getProperty(Client.RECORD_COUNT_PROPERTY) != null ||
 		   p.getProperty(Client.INSERT_COUNT_PROPERTY) != null ||
@@ -81,9 +81,9 @@ public class ConstantOccupancyWorkload extends CoreWorkload {
                 if(object_count == 0) {
                     throw new IllegalStateException("Object count was zero.  Perhaps disksize is too low?");
                 }
-		p.setProperty(Client.RECORD_COUNT_PROPERTY, object_count+"");
-		p.setProperty(Client.OPERATION_COUNT_PROPERTY, (storageages*object_count)+"");
-		p.setProperty(Client.INSERT_COUNT_PROPERTY, object_count+"");
+		p.setProperty(Client.RECORD_COUNT_PROPERTY, String.valueOf(object_count));
+		p.setProperty(Client.OPERATION_COUNT_PROPERTY, String.valueOf(storageages*object_count));
+		p.setProperty(Client.INSERT_COUNT_PROPERTY, String.valueOf(object_count));
 
 		super.init(p);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131
Please let me know if you have any questions.
Kirill Vlasov