### PR TITLE
Class variable fields should not have public accessibility

### DIFF
--- a/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -122,7 +122,7 @@ public class CassandraCQLClientTest {
     insertRow();
 
     final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    final Status status = client.read(CoreWorkload.table, DEFAULT_ROW_KEY, null, result);
+    final Status status = client.read(CoreWorkload.getTable(), DEFAULT_ROW_KEY, null, result);
     assertThat(status, is(Status.OK));
     assertThat(result.entrySet(), hasSize(11));
     assertThat(result, hasEntry("field2", null));
@@ -143,7 +143,7 @@ public class CassandraCQLClientTest {
     insertRow();
     final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
     final Set<String> fields = Sets.newHashSet("field1");
-    final Status status = client.read(CoreWorkload.table, DEFAULT_ROW_KEY, fields, result);
+    final Status status = client.read(CoreWorkload.getTable(), DEFAULT_ROW_KEY, fields, result);
     assertThat(status, is(Status.OK));
     assertThat(result.entrySet(), hasSize(1));
     final Map<String, String> strResult = StringByteIterator.getStringMap(result);

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -81,7 +81,7 @@ public class CoreWorkload extends Workload {
    */
   public static final String TABLENAME_PROPERTY_DEFAULT = "usertable";
 
-  public static String table;
+  private static String table;
 
 
   /**
@@ -328,6 +328,10 @@ public class CoreWorkload extends Workload {
   int insertionRetryInterval;
 
   private Measurements _measurements = Measurements.getMeasurements();
+
+  public static String getTable() {
+    return table;
+  }
 
   protected static IntegerGenerator getFieldLengthGenerator(Properties p) throws WorkloadException {
     IntegerGenerator fieldlengthgenerator;

--- a/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -56,20 +56,20 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     //private static final Configuration config = HBaseConfiguration.create();
     private static final Configuration config = HBaseConfiguration.create(); //new HBaseConfiguration();
 
-    public boolean _debug=false;
+    private boolean _debug=false;
 
-    public String _table="";
-    public HTable _hTable=null;
-    public String _columnFamily="";
-    public byte _columnFamilyBytes[];
-    public boolean _clientSideBuffering = false;
-    public long _writeBufferSize = 1024 * 1024 * 12;
+    private String _table="";
+    private HTable _hTable=null;
+    private String _columnFamily="";
+    private byte _columnFamilyBytes[];
+    private boolean _clientSideBuffering = false;
+    private long _writeBufferSize = 1024 * 1024 * 12;
     /** Whether or not a page filter should be used to limit scan length. */
-    public boolean _usePageFilter = true;
+    private boolean _usePageFilter = true;
 
-    public static final int HttpError=-2;
+    private static final int HttpError=-2;
 
-    public static final Object tableLock = new Object();
+    private static final Object tableLock = new Object();
 
     /**
      * Initialize any state for this DB.
@@ -106,7 +106,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
       // Terminate right now if table does not exist, since the client
       // will not propagate this error upstream once the workload
       // starts.
-      String table = com.yahoo.ycsb.workloads.CoreWorkload.table;
+      String table = com.yahoo.ycsb.workloads.CoreWorkload.getTable();
       try
 	  {
 	      HTable ht = new HTable(config, table);

--- a/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -139,7 +139,7 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
     // Terminate right now if table does not exist, since the client
     // will not propagate this error upstream once the workload
     // starts.
-    String table = com.yahoo.ycsb.workloads.CoreWorkload.table;
+    String table = com.yahoo.ycsb.workloads.CoreWorkload.getTable();
     try {
       final TableName tName = TableName.valueOf(table);
       HTableDescriptor dsc =

--- a/hbase10/src/test/java/com/yahoo/ycsb/db/HBaseClient10Test.java
+++ b/hbase10/src/test/java/com/yahoo/ycsb/db/HBaseClient10Test.java
@@ -106,7 +106,7 @@ public class HBaseClient10Test {
     final CoreWorkload workload = new CoreWorkload();
     workload.init(p);
 
-    table = testingUtil.createTable(TableName.valueOf(CoreWorkload.table), Bytes.toBytes(COLUMN_FAMILY));
+    table = testingUtil.createTable(TableName.valueOf(CoreWorkload.getTable()), Bytes.toBytes(COLUMN_FAMILY));
 
     client.setProperties(p);
     client.init();
@@ -115,7 +115,7 @@ public class HBaseClient10Test {
   @After
   public void tearDown() throws Exception {
     table.close();
-    testingUtil.deleteTable(CoreWorkload.table);
+    testingUtil.deleteTable(CoreWorkload.getTable());
   }
 
   @Test
@@ -129,7 +129,7 @@ public class HBaseClient10Test {
     table.put(p);
 
     final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    final Status status = client.read(CoreWorkload.table, rowKey, null, result);
+    final Status status = client.read(CoreWorkload.getTable(), rowKey, null, result);
     assertEquals(Status.OK, status);
     assertEquals(2, result.size());
     assertEquals("value1", result.get("column1").toString());
@@ -139,7 +139,7 @@ public class HBaseClient10Test {
   @Test
   public void testReadMissingRow() throws Exception {
     final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
-    final Status status = client.read(CoreWorkload.table, "Missing row", null, result);
+    final Status status = client.read(CoreWorkload.getTable(), "Missing row", null, result);
     assertEquals(Status.NOT_FOUND, status);
     assertEquals(0, result.size());
   }
@@ -165,7 +165,7 @@ public class HBaseClient10Test {
         new Vector<HashMap<String, ByteIterator>>();
 
     // Scan 5 records, skipping the first
-    client.scan(CoreWorkload.table, "00001", 5, null, result);
+    client.scan(CoreWorkload.getTable(), "00001", 5, null, result);
 
     assertEquals(5, result.size());
     for(int i = 0; i < 5; i++) {
@@ -185,7 +185,7 @@ public class HBaseClient10Test {
     final HashMap<String, String> input = new HashMap<String, String>();
     input.put("column1", "value1");
     input.put("column2", "value2");
-    final Status status = client.insert(CoreWorkload.table, key, StringByteIterator.getByteIteratorMap(input));
+    final Status status = client.insert(CoreWorkload.getTable(), key, StringByteIterator.getByteIteratorMap(input));
     assertEquals(Status.OK, status);
 
     // Verify result

--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -93,7 +93,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
       this.printErrors =
           getProperties().getProperty(PRINT_ROW_ERRORS_OPT).equals("true");
     }
-    this.tableName = com.yahoo.ycsb.workloads.CoreWorkload.table;
+    this.tableName = com.yahoo.ycsb.workloads.CoreWorkload.getTable();
     initClient(debug, tableName, getProperties());
     this.session = client.newSession();
     if (getProperties().getProperty(SYNC_OPS_OPT) != null


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
Kirill Vlasov
