### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
+++ b/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
@@ -416,7 +416,7 @@ public class AccumuloClient extends DB {
           // If the results are empty, the key is enqueued in
           // Zookeeper
           // and tried again, until the results are found.
-          if (result.size() == 0) {
+          if (result.isEmpty()) {
             q.produce(strKey);
             int count = ((Integer) hmKeyNumReads.get(strKey)).intValue();
             hmKeyNumReads.put(strKey, new Integer(count + 1));

--- a/accumulo/src/main/java/com/yahoo/ycsb/db/ZKProducerConsumer.java
+++ b/accumulo/src/main/java/com/yahoo/ycsb/db/ZKProducerConsumer.java
@@ -174,7 +174,7 @@ public class ZKProducerConsumer implements Watcher {
       while (true) {
         synchronized (mutex) {
           List<String> list = zk.getChildren(getRoot(), true);
-          if (list.size() == 0) {
+          if (list.isEmpty()) {
             System.out.println("Going to wait");
             mutex.wait();
           } else {

--- a/core/src/main/java/com/yahoo/ycsb/CommandLine.java
+++ b/core/src/main/java/com/yahoo/ycsb/CommandLine.java
@@ -327,7 +327,7 @@ public class CommandLine
 		  Status ret=db.scan(table,tokens[1],Integer.parseInt(tokens[2]),fields,results);
 		  System.out.println("Result: "+ret.getName());
 		  int record=0;
-		  if (results.size()==0)
+		  if (results.isEmpty())
 		  {
 		     System.out.println("0 records");
 		  }

--- a/couchbase/src/main/java/com/yahoo/ycsb/db/CouchbaseClient.java
+++ b/couchbase/src/main/java/com/yahoo/ycsb/db/CouchbaseClient.java
@@ -291,7 +291,7 @@ public class CouchbaseClient extends DB {
     if (useJson) {
       try {
         JsonNode json = JSON_MAPPER.readTree((String) source);
-        boolean checkFields = fields != null && fields.size() > 0;
+        boolean checkFields = fields != null && !fields.isEmpty();
         for (Iterator<Map.Entry<String, JsonNode>> jsonFields = json.fields(); jsonFields.hasNext();) {
           Map.Entry<String, JsonNode> jsonField = jsonFields.next();
           String name = jsonField.getKey();

--- a/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
+++ b/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
@@ -262,7 +262,7 @@ public class MemcachedClient extends DB {
       String value, Set<String> fields,
       Map<String, ByteIterator> result) throws IOException {
     JsonNode json = MAPPER.readTree(value);
-    boolean checkFields = fields != null && fields.size() > 0;
+    boolean checkFields = fields != null && !fields.isEmpty();
     for (Iterator<Map.Entry<String, JsonNode>> jsonFields = json.getFields();
          jsonFields.hasNext();
          /* increment in loop body */) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov