### PR TITLE
pmd:UnnecessaryConstructor - Unnecessary constructor, squid:EmptyStatementUsageCheck - Empty statements should be removed

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
+++ b/core/src/main/java/com/yahoo/ycsb/StringByteIterator.java
@@ -62,7 +62,7 @@ public class StringByteIterator extends ByteIterator {
 		HashMap<String, String> ret = new HashMap<String,String>();
 
 		for(String s: m.keySet()) {
-			ret.put(s, m.get(s).toString());;
+			ret.put(s, m.get(s).toString());
 		}
 		return ret;
 	}

--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -174,7 +174,7 @@ public class Measurements {
   ThreadLocal<StartTimeHolder> tlIntendedStartTime = new ThreadLocal<Measurements.StartTimeHolder>() {
     protected StartTimeHolder initialValue() {
       return new StartTimeHolder();
-    };
+    }
   };
 
   public void setIntendedStartTimeNs(long time) {

--- a/dynamodb/src/main/java/com/yahoo/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/com/yahoo/ycsb/db/DynamoDBClient.java
@@ -87,8 +87,6 @@ public class DynamoDBClient extends DB {
         "An error occurred on the client.");
     private static final String DEFAULT_HASH_KEY_VALUE = "YCSB_0";
 
-    public DynamoDBClient() {}
-
     /**
      * Initialize any state for this DB. Called once per DB instance; there is
      * one DB instance per client thread.

--- a/googledatastore/src/main/java/com/yahoo/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/com/yahoo/ycsb/db/GoogleDatastoreClient.java
@@ -83,8 +83,6 @@ public class GoogleDatastoreClient extends DB {
 
   private Datastore datastore = null;
 
-  public GoogleDatastoreClient() {}
-
   /**
    * Initialize any state for this DB. Called once per DB instance; there is
    * one DB instance per client thread.

--- a/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
+++ b/infinispan/src/main/java/com/yahoo/ycsb/db/InfinispanRemoteClient.java
@@ -47,10 +47,6 @@ public class InfinispanRemoteClient extends DB {
 
    private static final Log logger = LogFactory.getLog(InfinispanRemoteClient.class);
 
-   public InfinispanRemoteClient() {
-      
-   }
-   
    @Override
    public void init() throws DBException {
 	  remoteIspnManager = RemoteCacheManagerHolder.getInstance(getProperties());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
pmd:UnnecessaryConstructor - Unnecessary constructor, 
squid:EmptyStatementUsageCheck - Empty statements should be removed

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=pmd:UnnecessaryConstructor
https://dev.eclipse.org/sonar/coding_rules#q=squid:EmptyStatementUsageCheck
Please let me know if you have any questions.
Kirill Vlasov
