### PR TITLE
[orientdb] fixed end table scan issue

### DIFF
--- a/orientdb/README.md
+++ b/orientdb/README.md
@@ -23,7 +23,7 @@ This section describes how to run YCSB on OrientDB running locally.
 
 Clone the YCSB git repository and compile:
 
-    git clone git://github.com/nuvolabase/YCSB.git
+    git clone https://github.com/brianfrankcooper/YCSB.git
     cd YCSB
     mvn clean package
 
@@ -46,3 +46,8 @@ See the next section for the list of configuration parameters for OrientDB.
 ### `OrientDB.user` (default `admin`)
 
 ### `OrientDB.password` (default `admin`)
+
+## Known Issues
+
+* There is a performance issue around the scan operation. This binding uses OIndex.iterateEntriesMajor() which will return unnecessarily large iterators. This has a performance impact as the recordcount goes up. There are ideas in the works to fix it, track it here: [#568](https://github.com/brianfrankcooper/YCSB/issues/568).
+* The OIndexCursor used to run the scan operation currently seems to be broken. Because of this, if the startkey and recordcount combination on a particular operation were to cause the iterator to go to the end, a NullPointerException is thrown. With sufficiently high record counts, this does not happen very often, but it could cause false negatives. Track that issue here: https://github.com/orientechnologies/orientdb/issues/5541.

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -230,16 +230,21 @@ public class OrientDBClient extends DB {
    */
   public Status scan(String table, String startkey, int recordcount, Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
     try {
+      int entrycount = 0;
       final OIndexCursor entries = dictionary.getIndex().iterateEntriesMajor(startkey, true, true);
-      while (entries.hasNext()) {
+
+      while (entries.hasNext() && entrycount < recordcount) {
         final Entry<Object, OIdentifiable> entry = entries.nextEntry();
         final ODocument document = entry.getValue().getRecord();
 
         final HashMap<String, ByteIterator> map = new HashMap<String, ByteIterator>();
         result.add(map);
 
-        for (String field : fields)
+        for (String field : fields) {
           map.put(field, new StringByteIterator((String) document.field(field)));
+        }
+
+        entrycount++;
       }
 
       return Status.OK;


### PR DESCRIPTION
This fixes the end table scanning brought up in #562.

While working on this I found some things that should probably be marked as known issues.

1. First is a performance issue, after testing with a few different recordcounts I found that iterateEntriesMajor() return time is directly linked with number of records in the table. So, a relatively small scan size will start to perform worse on larger tables. The better solution would have been to use iterateEntriesBetween(), problem is it takes a start and end key which is not how the current scan framework is set up. It may be a good idea to think about updating the scan operation to pass a recordcount as well as a corresponding endkey. This would benefit more bindings then OrientDB I believe. There are a few things that complicate that idea, but I'll save that for that discussion.
2. The OIndexCursor implementation used here seems to be broken. It does not track the entries properly when iterating so when you get to the end of the iterator you get a ```NullPointerException```. For more info on why, here is the issue I posted: https://github.com/orientechnologies/orientdb/issues/5541. With a sufficiently high recordcount, +10000, this doesn't happen too often. I choose to not try and catch it, you never know if a legitimate null will pop up sometime. False negatives seemed better to me then false positives.

Should known issues go into the orientdb README? anywhere else?