### PR TITLE
[accumulo] Accumulo binding does not work in 0.5.0 release

### DIFF
--- a/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
+++ b/accumulo/src/main/java/com/yahoo/ycsb/db/AccumuloClient.java
@@ -169,11 +169,11 @@ public class AccumuloClient extends DB {
     bwc.setMaxWriteThreads(Integer.parseInt(
         getProperties().getProperty("accumulo.batchWriterThreads", "1")));
 
-    bw = connector.createBatchWriter(table, bwc);
+    bw = connector.createBatchWriter(t, bwc);
 
     // Create our scanners
-    singleScanner = connector.createScanner(table, Authorizations.EMPTY);
-    scanScanner = connector.createScanner(table, Authorizations.EMPTY);
+    singleScanner = connector.createScanner(t, Authorizations.EMPTY);
+    scanScanner = connector.createScanner(t, Authorizations.EMPTY);
 
     table = t; // Store the name of the table we have open.
   }


### PR DESCRIPTION
YCSB with Accumulo doesn't work in 0.5.0. 

The datastore binding caches a connection to the Accumulo client and handles set up only when the table being interacted with changes. The changes from #464 accidentally used the cached table name rather than the newly proposed table name.

On the first operation, the cached table name is blank which causes the Accumulo driver to error out.