### PR TITLE
[orientdb] Added remote connection capabilties

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2010 - 2016 Yahoo! Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -469,6 +469,11 @@ public class Client
    */
   public static final String MAX_EXECUTION_TIME = "maxexecutiontime";
 
+  /**
+   * Whether or not this is the transaction phase (run) or not (load).
+   */
+  public static final String DO_TRANSACTIONS_PROPERTY = "dotransactions";
+
 
   public static void usageMessage()
   {
@@ -733,6 +738,8 @@ public class Client
     {
       System.exit(0);
     }
+
+    props.setProperty(DO_TRANSACTIONS_PROPERTY, String.valueOf(dotransactions));
 
     long maxExecutionTime = Integer.parseInt(props.getProperty(MAX_EXECUTION_TIME, "0"));
 

--- a/orientdb/README.md
+++ b/orientdb/README.md
@@ -42,16 +42,20 @@ See the next section for the list of configuration parameters for OrientDB.
 ## OrientDB Configuration Parameters
 
 * ```orientdb.url``` - (required) The address to your database.
-    * Supported storage types: memory, plocal
+    * Supported storage types: memory, plocal, remote
     * EX. ```plocal:/path/to/database```
 * ```orientdb.user``` - The user to connect to the database with.
     * Default: ```admin```
 * ```orientdb.password``` - The password to connect to the database with.
     * Default: ```admin```
-* ```orientdb.newdb``` - Create the database if it does not exists, or overwrite the database if it does exist.
+* ```orientdb.newdb``` - Overwrite the database if it already exists.
+    * Only effects the ```load``` phase.
     * Default: ```false```
+* ```orientdb.remote.storagetype``` - Storage type of the database on remote server
+    * This is only required if using a ```remote:``` connection url
 
 ## Known Issues
 
 * There is a performance issue around the scan operation. This binding uses OIndex.iterateEntriesMajor() which will return unnecessarily large iterators. This has a performance impact as the recordcount goes up. There are ideas in the works to fix it, track it here: [#568](https://github.com/brianfrankcooper/YCSB/issues/568).
 * The OIndexCursor used to run the scan operation currently seems to be broken. Because of this, if the startkey and recordcount combination on a particular operation were to cause the iterator to go to the end, a NullPointerException is thrown. With sufficiently high record counts, this does not happen very often, but it could cause false negatives. Track that issue here: https://github.com/orientechnologies/orientdb/issues/5541.
+* Iterator methods needed to perform scans are Unsupported in the OrientDB API for remote database connections and so will return NOT_IMPLEMENTED status if attempted.

--- a/orientdb/pom.xml
+++ b/orientdb/pom.xml
@@ -44,7 +44,7 @@ LICENSE file.
 		</dependency>
 		<dependency>
 			<groupId>com.orientechnologies</groupId>
-			<artifactId>orientdb-core</artifactId>
+			<artifactId>orientdb-client</artifactId>
 			<version>${orientdb.version}</version>
 		</dependency>
     <dependency>


### PR DESCRIPTION
Had to implement a separate init path for remote connections using OServerAdmin. The old, local init path is essentially the same as before.

OrientDB does not support the iterator methods that scan is built off of for remote connections, so had to check for that and record NOT_IMPLEMENTED. Made a note of that in the README as well.