### PR TITLE
Orientdb checkstyle

### DIFF
--- a/orientdb/pom.xml
+++ b/orientdb/pom.xml
@@ -17,41 +17,65 @@ LICENSE file.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.yahoo.ycsb</groupId>
-                <artifactId>binding-parent</artifactId>
-                <version>0.7.0-SNAPSHOT</version>
-                <relativePath>../binding-parent</relativePath>
-	</parent>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.7.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
 
-	<artifactId>orientdb-binding</artifactId>
-	<name>OrientDB Binding</name>
-	<packaging>jar</packaging>
-	<repositories>
-		<repository>
-			<id>sonatype-nexus-snapshots</id>
-			<name>Sonatype Nexus Snapshots</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</repository>
-	</repositories>
-	<dependencies>
-		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
-			<artifactId>core</artifactId>
-			<version>${project.version}</version>
-                        <scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.orientechnologies</groupId>
-			<artifactId>orientdb-client</artifactId>
-			<version>${orientdb.version}</version>
-		</dependency>
+  <artifactId>orientdb-binding</artifactId>
+  <name>OrientDB Binding</name>
+  <packaging>jar</packaging>
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.orientechnologies</groupId>
+      <artifactId>orientdb-client</artifactId>
+      <version>${orientdb.version}</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-	</dependencies>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.15</version>
+        <configuration>
+          <consoleOutput>true</consoleOutput>
+          <configLocation>../checkstyle.xml</configLocation>
+          <failOnViolation>true</failOnViolation>
+          <failsOnError>true</failsOnError>
+        </configuration>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>checkstyle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -47,8 +47,8 @@ import java.util.Vector;
  */
 public class OrientDBClient extends DB {
 
-  private static final String             CLASS = "usertable";
-  protected ODatabaseDocumentTx             db;
+  private static final String CLASS = "usertable";
+  protected ODatabaseDocumentTx db;
   private ODictionary<ORecord> dictionary;
   private boolean isRemote = false;
 
@@ -71,7 +71,8 @@ public class OrientDBClient extends DB {
   private static final String ORIENTDB_DOCUMENT_TYPE = "document";
 
   /**
-   * Initialize any state for this DB. Called once per DB instance; there is one DB instance per client thread.
+   * Initialize any state for this DB. Called once per DB instance; there is one
+   * DB instance per client thread.
    */
   public void init() throws DBException {
     Properties props = getProperties();
@@ -154,21 +155,29 @@ public class OrientDBClient extends DB {
     }
   }
 
-  @Override
   /**
-   * Insert a record in the database. Any field/value pairs in the specified values HashMap will be written into the record with the specified
-   * record key.
+   * Insert a record in the database. Any field/value pairs in the specified
+   * values HashMap will be written into the record with the specified record
+   * key.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to insert.
-   * @param values A HashMap of field/value pairs to insert in the record
-   * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+   * @param table
+   *          The name of the table
+   * @param key
+   *          The record key of the record to insert.
+   * @param values
+   *          A HashMap of field/value pairs to insert in the record
+   * @return Zero on success, a non-zero error code on error. See this class's
+   *         description for a discussion of error codes.
    */
-  public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
+  @Override
+  public Status insert(String table, String key,
+      HashMap<String, ByteIterator> values) {
     try {
       final ODocument document = new ODocument(CLASS);
-      for (Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet())
+      for (Entry<String, String> entry : StringByteIterator.getStringMap(values)
+          .entrySet()) {
         document.field(entry.getKey(), entry.getValue());
+      }
       document.save();
       dictionary.put(key, document);
 
@@ -179,14 +188,17 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  @Override
   /**
    * Delete a record from the database.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to delete.
-   * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+   * @param table
+   *          The name of the table
+   * @param key
+   *          The record key of the record to delete.
+   * @return Zero on success, a non-zero error code on error. See this class's
+   *         description for a discussion of error codes.
    */
+  @Override
   public Status delete(String table, String key) {
     try {
       dictionary.remove(key);
@@ -197,26 +209,37 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  @Override
   /**
-   * Read a record from the database. Each field/value pair from the result will be stored in a HashMap.
+   * Read a record from the database. Each field/value pair from the result will
+   * be stored in a HashMap.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to read.
-   * @param fields The list of fields to read, or null for all of them
-   * @param result A HashMap of field/value pairs for the result
+   * @param table
+   *          The name of the table
+   * @param key
+   *          The record key of the record to read.
+   * @param fields
+   *          The list of fields to read, or null for all of them
+   * @param result
+   *          A HashMap of field/value pairs for the result
    * @return Zero on success, a non-zero error code on error or "not found".
    */
-  public Status read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+      HashMap<String, ByteIterator> result) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {
-        if (fields != null)
-          for (String field : fields)
-            result.put(field, new StringByteIterator((String) document.field(field)));
-        else
-          for (String field : document.fieldNames())
-            result.put(field, new StringByteIterator((String) document.field(field)));
+        if (fields != null) {
+          for (String field : fields) {
+            result.put(field,
+                new StringByteIterator((String) document.field(field)));
+          }
+        } else {
+          for (String field : document.fieldNames()) {
+            result.put(field,
+                new StringByteIterator((String) document.field(field)));
+          }
+        }
         return Status.OK;
       }
     } catch (Exception e) {
@@ -225,22 +248,30 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  @Override
   /**
-   * Update a record in the database. Any field/value pairs in the specified values HashMap will be written into the record with the specified
-   * record key, overwriting any existing values with the same field name.
+   * Update a record in the database. Any field/value pairs in the specified
+   * values HashMap will be written into the record with the specified record
+   * key, overwriting any existing values with the same field name.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to write.
-   * @param values A HashMap of field/value pairs to update in the record
-   * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+   * @param table
+   *          The name of the table
+   * @param key
+   *          The record key of the record to write.
+   * @param values
+   *          A HashMap of field/value pairs to update in the record
+   * @return Zero on success, a non-zero error code on error. See this class's
+   *         description for a discussion of error codes.
    */
-  public Status update(String table, String key, HashMap<String, ByteIterator> values) {
+  @Override
+  public Status update(String table, String key,
+      HashMap<String, ByteIterator> values) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {
-        for (Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet())
+        for (Entry<String, String> entry : StringByteIterator
+            .getStringMap(values).entrySet()) {
           document.field(entry.getKey(), entry.getValue());
+        }
         document.save();
         return Status.OK;
       }
@@ -250,17 +281,25 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  @Override
   /**
-   * Perform a range scan for a set of records in the database. Each field/value pair from the result will be stored in a HashMap.
+   * Perform a range scan for a set of records in the database. Each field/value
+   * pair from the result will be stored in a HashMap.
    *
-   * @param table The name of the table
-   * @param startkey The record key of the first record to read.
-   * @param recordcount The number of records to read
-   * @param fields The list of fields to read, or null for all of them
-   * @param result A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
-   * @return Zero on success, a non-zero error code on error. See this class's description for a discussion of error codes.
+   * @param table
+   *          The name of the table
+   * @param startkey
+   *          The record key of the first record to read.
+   * @param recordcount
+   *          The number of records to read
+   * @param fields
+   *          The list of fields to read, or null for all of them
+   * @param result
+   *          A Vector of HashMaps, where each HashMap is a set field/value
+   *          pairs for one record
+   * @return Zero on success, a non-zero error code on error. See this class's
+   *         description for a discussion of error codes.
    */
+  @Override
   public Status scan(String table, String startkey, int recordcount, Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
     if (isRemote) {
       // Iterator methods needed for scanning are Unsupported for remote database connections.
@@ -275,7 +314,8 @@ public class OrientDBClient extends DB {
         final Entry<Object, OIdentifiable> entry = entries.nextEntry();
         final ODocument document = entry.getValue().getRecord();
 
-        final HashMap<String, ByteIterator> map = new HashMap<String, ByteIterator>();
+        final HashMap<String, ByteIterator> map =
+            new HashMap<String, ByteIterator>();
         result.add(map);
 
         for (String field : fields) {

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -48,7 +48,7 @@ import java.util.Vector;
 public class OrientDBClient extends DB {
 
   private static final String CLASS = "usertable";
-  protected ODatabaseDocumentTx db;
+  private ODatabaseDocumentTx db;
   private ODictionary<ORecord> dictionary;
   private boolean isRemote = false;
 
@@ -70,10 +70,7 @@ public class OrientDBClient extends DB {
 
   private static final String ORIENTDB_DOCUMENT_TYPE = "document";
 
-  /**
-   * Initialize any state for this DB. Called once per DB instance; there is one
-   * DB instance per client thread.
-   */
+  @Override
   public void init() throws DBException {
     Properties props = getProperties();
 
@@ -82,7 +79,8 @@ public class OrientDBClient extends DB {
     String password = props.getProperty(PASSWORD_PROPERTY, PASSWORD_PROPERTY_DEFAULT);
     Boolean newdb = Boolean.parseBoolean(props.getProperty(NEWDB_PROPERTY, NEWDB_PROPERTY_DEFAULT));
     String remoteStorageType = props.getProperty(STORAGE_TYPE_PROPERTY);
-    Boolean dotransactions = Boolean.parseBoolean(props.getProperty(DO_TRANSACTIONS_PROPERTY, DO_TRANSACTIONS_PROPERTY_DEFAULT));
+    Boolean dotransactions = Boolean.parseBoolean(
+        props.getProperty(DO_TRANSACTIONS_PROPERTY, DO_TRANSACTIONS_PROPERTY_DEFAULT));
 
     if (url == null) {
       throw new DBException(String.format("Required property \"%s\" missing for OrientDBClient", URL_PROPERTY));
@@ -94,7 +92,8 @@ public class OrientDBClient extends DB {
     if (url.startsWith(OEngineRemote.NAME)) {
       isRemote = true;
       if (remoteStorageType == null) {
-        throw new DBException("When connecting to a remote OrientDB instance, specify a database storage type (plocal or memory) with " + STORAGE_TYPE_PROPERTY);
+        throw new DBException("When connecting to a remote OrientDB instance, " +
+          "specify a database storage type (plocal or memory) with " + STORAGE_TYPE_PROPERTY);
       }
 
       try {
@@ -137,10 +136,10 @@ public class OrientDBClient extends DB {
 
     System.err.println("OrientDB connection created with " + url);
     dictionary = db.getMetadata().getIndexManager().getDictionary();
-    if (!db.getMetadata().getSchema().existsClass(CLASS))
+    if (!db.getMetadata().getSchema().existsClass(CLASS)) {
       db.getMetadata().getSchema().createClass(CLASS);
+    }
 
-    // TODO: This is a transparent optimization that should be openned up to the user.
     db.declareIntent(new OIntentMassiveInsert());
   }
 
@@ -155,27 +154,11 @@ public class OrientDBClient extends DB {
     }
   }
 
-  /**
-   * Insert a record in the database. Any field/value pairs in the specified
-   * values HashMap will be written into the record with the specified record
-   * key.
-   *
-   * @param table
-   *          The name of the table
-   * @param key
-   *          The record key of the record to insert.
-   * @param values
-   *          A HashMap of field/value pairs to insert in the record
-   * @return Zero on success, a non-zero error code on error. See this class's
-   *         description for a discussion of error codes.
-   */
   @Override
-  public Status insert(String table, String key,
-      HashMap<String, ByteIterator> values) {
+  public Status insert(String table, String key, HashMap<String, ByteIterator> values) {
     try {
       final ODocument document = new ODocument(CLASS);
-      for (Entry<String, String> entry : StringByteIterator.getStringMap(values)
-          .entrySet()) {
+      for (Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
         document.field(entry.getKey(), entry.getValue());
       }
       document.save();
@@ -188,16 +171,6 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  /**
-   * Delete a record from the database.
-   *
-   * @param table
-   *          The name of the table
-   * @param key
-   *          The record key of the record to delete.
-   * @return Zero on success, a non-zero error code on error. See this class's
-   *         description for a discussion of error codes.
-   */
   @Override
   public Status delete(String table, String key) {
     try {
@@ -209,35 +182,18 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  /**
-   * Read a record from the database. Each field/value pair from the result will
-   * be stored in a HashMap.
-   *
-   * @param table
-   *          The name of the table
-   * @param key
-   *          The record key of the record to read.
-   * @param fields
-   *          The list of fields to read, or null for all of them
-   * @param result
-   *          A HashMap of field/value pairs for the result
-   * @return Zero on success, a non-zero error code on error or "not found".
-   */
   @Override
-  public Status read(String table, String key, Set<String> fields,
-      HashMap<String, ByteIterator> result) {
+  public Status read(String table, String key, Set<String> fields, HashMap<String, ByteIterator> result) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {
         if (fields != null) {
           for (String field : fields) {
-            result.put(field,
-                new StringByteIterator((String) document.field(field)));
+            result.put(field, new StringByteIterator((String) document.field(field)));
           }
         } else {
           for (String field : document.fieldNames()) {
-            result.put(field,
-                new StringByteIterator((String) document.field(field)));
+            result.put(field, new StringByteIterator((String) document.field(field)));
           }
         }
         return Status.OK;
@@ -248,28 +204,12 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  /**
-   * Update a record in the database. Any field/value pairs in the specified
-   * values HashMap will be written into the record with the specified record
-   * key, overwriting any existing values with the same field name.
-   *
-   * @param table
-   *          The name of the table
-   * @param key
-   *          The record key of the record to write.
-   * @param values
-   *          A HashMap of field/value pairs to update in the record
-   * @return Zero on success, a non-zero error code on error. See this class's
-   *         description for a discussion of error codes.
-   */
   @Override
-  public Status update(String table, String key,
-      HashMap<String, ByteIterator> values) {
+  public Status update(String table, String key, HashMap<String, ByteIterator> values) {
     try {
       final ODocument document = dictionary.get(key);
       if (document != null) {
-        for (Entry<String, String> entry : StringByteIterator
-            .getStringMap(values).entrySet()) {
+        for (Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
           document.field(entry.getKey(), entry.getValue());
         }
         document.save();
@@ -281,26 +221,9 @@ public class OrientDBClient extends DB {
     return Status.ERROR;
   }
 
-  /**
-   * Perform a range scan for a set of records in the database. Each field/value
-   * pair from the result will be stored in a HashMap.
-   *
-   * @param table
-   *          The name of the table
-   * @param startkey
-   *          The record key of the first record to read.
-   * @param recordcount
-   *          The number of records to read
-   * @param fields
-   *          The list of fields to read, or null for all of them
-   * @param result
-   *          A Vector of HashMaps, where each HashMap is a set field/value
-   *          pairs for one record
-   * @return Zero on success, a non-zero error code on error. See this class's
-   *         description for a discussion of error codes.
-   */
   @Override
-  public Status scan(String table, String startkey, int recordcount, Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+  public Status scan(String table, String startkey, int recordcount, Set<String> fields,
+                     Vector<HashMap<String, ByteIterator>> result) {
     if (isRemote) {
       // Iterator methods needed for scanning are Unsupported for remote database connections.
       return Status.NOT_IMPLEMENTED;
@@ -330,5 +253,12 @@ public class OrientDBClient extends DB {
       e.printStackTrace();
     }
     return Status.ERROR;
+  }
+
+  /**
+   * Access method to db variable for unit testing.
+   **/
+  ODatabaseDocumentTx getDB() {
+    return db;
   }
 }

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+ * Copyright (c) 2015 - 2016, Yahoo!, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://orientdb.com/orientdb/">OrientDB</a>.
+ */
+package com.yahoo.ycsb.db;
+

--- a/orientdb/src/test/java/com/yahoo/ycsb/db/OrientDBClientTest.java
+++ b/orientdb/src/test/java/com/yahoo/ycsb/db/OrientDBClientTest.java
@@ -54,7 +54,7 @@ public class OrientDBClientTest {
 
     orientDBClient.setProperties(p);
     orientDBClient.init();
-    orientDBDictionary = orientDBClient.db.getDictionary();
+    orientDBDictionary = orientDBClient.getDB().getDictionary();
   }
 
   @After


### PR DESCRIPTION
* Rabased pull/489/head to master
* Backed out unnecessary line breaks for 120 char limit
* Enforced checkstyle on new code
  * Was required to make db variable private, updated in tests
  * Removed TODO

Closes #489