### PR TITLE
[hbase] Changes to support secured HBase cluster 

### DIFF
--- a/hbase098/README.md
+++ b/hbase098/README.md
@@ -74,3 +74,6 @@ Following options can be configurable using `-p`.
 * `hbase.usepagefilter` : If true, HBase
   [PageFilter](https://hbase.apache.org/apidocs/org/apache/hadoop/hbase/filter/PageFilter.html)s
   are used to limit the number of records consumed in a scan operation. The default is true.
+* `principal`: If testing need to be done against a secure HBase cluster using Kerberos Keytab, 
+  this property can be used to pass the principal in the keytab file.
+* `keytab`: The Kerberos keytab file name and location can be passed through this property.

--- a/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
+++ b/hbase098/src/main/java/com/yahoo/ycsb/db/HBaseClient.java
@@ -23,10 +23,14 @@ import com.yahoo.ycsb.DBException;
 import com.yahoo.ycsb.Status;
 import com.yahoo.ycsb.measurements.Measurements;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.HConnectionManager;
+import org.apache.hadoop.hbase.client.HConnection;
+import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTable;
@@ -59,7 +63,8 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public boolean _debug=false;
 
     public String _table="";
-    public HTable _hTable=null;
+    public HConnection _hConn=null;
+    public HTableInterface _hTable=null;
     public String _columnFamily="";
     public byte _columnFamilyBytes[];
     public boolean _clientSideBuffering = false;
@@ -94,7 +99,24 @@ public class HBaseClient extends com.yahoo.ycsb.DB
         if ("false".equals(getProperties().getProperty("hbase.usepagefilter", "true"))) {
           _usePageFilter = false;
         }
-
+        if ("kerberos".equalsIgnoreCase(config.get("hbase.security.authentication"))) {
+          config.set("hadoop.security.authentication", "Kerberos");
+          UserGroupInformation.setConfiguration(config);
+        }
+        if ( (getProperties().getProperty("principal")!=null) && (getProperties().getProperty("keytab")!=null) ){
+            try {
+                UserGroupInformation.loginUserFromKeytab(getProperties().getProperty("principal"), getProperties().getProperty("keytab"));
+            } catch (IOException e) {
+                System.err.println("Keytab file is not readable or not found");
+                throw new DBException(e);
+            }
+        }
+        try {
+            _hConn = HConnectionManager.createConnection(config);
+        } catch (IOException e) {
+            System.err.println("Connection to HBase was not successful");
+            throw new DBException(e);  
+        }
         _columnFamily = getProperties().getProperty("columnfamily");
         if (_columnFamily == null)
         {
@@ -109,7 +131,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
       String table = com.yahoo.ycsb.workloads.CoreWorkload.table;
       try
 	  {
-	      HTable ht = new HTable(config, table);
+	      HTableInterface ht = _hConn.getTable(table);
 	      ht.getTableDescriptor();
 	  }
       catch (IOException e)
@@ -132,6 +154,9 @@ public class HBaseClient extends com.yahoo.ycsb.DB
             if (_hTable != null) {
                 _hTable.flushCommits();
             }
+            if (_hConn != null) {
+                _hConn.close();
+            }
             long en=System.nanoTime();
             _measurements.measure("UPDATE", (int)((en-st)/1000));
         } catch (IOException e) {
@@ -142,7 +167,7 @@ public class HBaseClient extends com.yahoo.ycsb.DB
     public void getHTable(String table) throws IOException
     {
         synchronized (tableLock) {
-            _hTable = new HTable(config, table);
+            _hTable = _hConn.getTable(table);
             //2 suggestions from http://ryantwopointoh.blogspot.com/2009/01/performance-of-hbase-importing.html
             _hTable.setAutoFlush(!_clientSideBuffering, true);
             _hTable.setWriteBufferSize(_writeBufferSize);

--- a/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
+++ b/hbase10/src/main/java/com/yahoo/ycsb/db/HBaseClient10.java
@@ -24,6 +24,7 @@ import com.yahoo.ycsb.DBException;
 import com.yahoo.ycsb.Status;
 import com.yahoo.ycsb.measurements.Measurements;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
@@ -110,6 +111,22 @@ public class HBaseClient10 extends com.yahoo.ycsb.DB {
     if (getProperties().getProperty("durability") != null) {
       this.durability =
           Durability.valueOf(getProperties().getProperty("durability"));
+    }
+
+    if ("kerberos".equalsIgnoreCase(config.get("hbase.security.authentication"))) {
+      config.set("hadoop.security.authentication", "Kerberos");
+      UserGroupInformation.setConfiguration(config);
+    }
+
+    if ((getProperties().getProperty("principal")!=null) 
+        && (getProperties().getProperty("keytab")!=null)) {
+      try {
+        UserGroupInformation.loginUserFromKeytab(getProperties().getProperty("principal"), 
+              getProperties().getProperty("keytab"));
+      } catch (IOException e) {
+        System.err.println("Keytab file is not readable or not found");
+        throw new DBException(e);
+      }
     }
 
     try {


### PR DESCRIPTION
Changes in this pull request include

**For hbase098**
- Use HBase ``connection`` object to create ``table`` object
- Changes to make YCSB hbase tests run against a kerberized hbase cluster
- Update to README.txt to document the new parameters

**For hbase10**
- Changes to make YCSB hbase tests run against a kerberized hbase cluster

If users like to use **kerberos** keytab to make the connection to secure hbase cluster instead of using the ``user-id`` of the user running the test they can be passed using ``principal=keytab-principal-name`` and ``keytab=keytab=file`` properties.

**Update:** After the conversation in issue #322 , changes were made to **hbase098** and **hbase10** to use single HBase connection across all the threads when running a multi-thread test.