### PR TITLE
[solr] tune down log output during tests.

### DIFF
--- a/solr/src/test/resources/log4j.properties
+++ b/solr/src/test/resources/log4j.properties
@@ -1,0 +1,29 @@
+# Copyright (c) 2015-2016 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+
+# Root logger option
+log4j.rootLogger=INFO, stderr
+
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.target=System.err
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.conversionPattern=%d{yyyy/MM/dd HH:mm:ss} %-5p %c %x - %m%n
+
+# Suppress messages from ZooKeeper
+log4j.logger.org.apache.zookeeper=ERROR
+# Solr classes are too chatty in test at INFO
+log4j.logger.org.apache.solr=ERROR
+log4j.logger.org.eclipse.jetty=ERROR


### PR DESCRIPTION
the Solr tests are particularly chatty at the default log settings. this PR keeps them at INFO messages from the YCSB classes, but reduces them to ERROR from the Solr / jetty/ zk ones.