### PR TITLE
[hbase10] Turn off info servers during tests

### DIFF
--- a/hbase10/src/test/resources/hbase-site.xml
+++ b/hbase10/src/test/resources/hbase-site.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<configuration>
+  <property>
+    <name>hbase.master.info.port</name>
+    <value>-1</value>
+    <description>The port for the hbase master web UI
+    Set to -1 if you do not want the info server to run.
+    </description>
+  </property>
+  <property>
+    <name>hbase.regionserver.info.port</name>
+    <value>-1</value>
+    <description>The port for the hbase regionserver web UI
+    Set to -1 if you do not want the info server to run.
+    </description>
+  </property>
+</configuration>


### PR DESCRIPTION
Currently YCSB can't be built on the machine running HBase cluster, because the local testing cluster tries to bind a master info server on the same port with the actual cluster's port. See the following output...

```
$ mvn clean package
...
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.yahoo.ycsb.db.HBaseClient10Test
...
2016/02/13 14:24:06 ERROR org.apache.hadoop.hbase.regionserver.HRegionServer  - Failed binding http info server to port: 16010
2016/02/13 14:24:06 ERROR org.apache.hadoop.hbase.MiniHBaseCluster  - Error starting cluster
java.lang.RuntimeException: Failed construction of Master: class org.apache.hadoop.hbase.master.HMasterAddress already in use
...
```

This is a bit annoying, so I turn off a master info server during tests. A region info server does not cause a port conflict, but any info server is not necessary during tests, so I turn off region's info server, too.