### PR TITLE
[docs] Update link to old Yahoo! page due to site redesign.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Yahoo! Cloud System Benchmark (YCSB)
 Links
 -----
 http://wiki.github.com/brianfrankcooper/YCSB/  
-http://research.yahoo.com/Web_Information_Management/YCSB/  
+https://labs.yahoo.com/news/yahoo-cloud-serving-benchmark/
 ycsb-users@yahoogroups.com  
 
 Getting Started


### PR DESCRIPTION
Yahoo! redesigned their website and our link to them is dead.