### PR TITLE
Orientdb scan fix

### DIFF
--- a/orientdb/README.md
+++ b/orientdb/README.md
@@ -72,5 +72,4 @@ WARNING: Creating a new database will be done safely with multiple threads on a 
 ## Known Issues
 
 * There is a performance issue around the scan operation. This binding uses OIndex.iterateEntriesMajor() which will return unnecessarily large iterators. This has a performance impact as the recordcount goes up. There are ideas in the works to fix it, track it here: [#568](https://github.com/brianfrankcooper/YCSB/issues/568).
-* The OIndexCursor used to run the scan operation currently seems to be broken. Because of this, if the startkey and recordcount combination on a particular operation were to cause the iterator to go to the end, a NullPointerException is thrown. With sufficiently high record counts, this does not happen very often, but it could cause false negatives. Track that issue here: https://github.com/orientechnologies/orientdb/issues/5541.
 * Iterator methods needed to perform scans are Unsupported in the OrientDB API for remote database connections and so will return NOT_IMPLEMENTED status if attempted.

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -280,19 +280,20 @@ public class OrientDBClient extends DB {
       int entrycount = 0;
       final OIndexCursor entries = dictionary.getIndex().iterateEntriesMajor(startkey, true, true);
 
-      while (entries.hasNext() && entrycount < recordcount) {
-        final Entry<Object, OIdentifiable> entry = entries.nextEntry();
-        final ODocument document = entry.getValue().getRecord();
+      if (fields != null && !fields.isEmpty()) {
+        while (entries.hasNext() && entrycount < recordcount) {
+          final Entry<Object, OIdentifiable> entry = entries.nextEntry();
+          final ODocument document = entry.getValue().getRecord();
 
-        final HashMap<String, ByteIterator> map =
-            new HashMap<String, ByteIterator>();
-        result.add(map);
+          final HashMap<String, ByteIterator> map = new HashMap<String, ByteIterator>();
+          result.add(map);
 
-        for (String field : fields) {
-          map.put(field, new StringByteIterator((String) document.field(field)));
+          for (String field : fields) {
+            map.put(field, new StringByteIterator((String) document.field(field)));
+          }
+
+          entrycount++;
         }
-
-        entrycount++;
       }
 
       return Status.OK;

--- a/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/com/yahoo/ycsb/db/OrientDBClient.java
@@ -282,8 +282,8 @@ public class OrientDBClient extends DB {
 
       if (fields != null && !fields.isEmpty()) {
         while (entries.hasNext() && entrycount < recordcount) {
-          final Entry<Object, OIdentifiable> entry = entries.nextEntry();
-          final ODocument document = entry.getValue().getRecord();
+          final OIdentifiable entry = entries.next();
+          final ODocument document = entry.getRecord();
 
           final HashMap<String, ByteIterator> map = new HashMap<String, ByteIterator>();
           result.add(map);

--- a/orientdb/src/test/java/com/yahoo/ycsb/db/OrientDBClientTest.java
+++ b/orientdb/src/test/java/com/yahoo/ycsb/db/OrientDBClientTest.java
@@ -224,7 +224,7 @@ public class OrientDBClientTest {
      * Track the issue here: https://github.com/orientechnologies/orientdb/issues/5541
      * This fix was implemented for orientechnologies:orientdb-client:2.1.8
      */
-    int testIndex = startIndex + 1; // <-- Remove the +1 when the known issue of broken iterator is fixed.
+    int testIndex = startIndex;
 
     // Check each vector row to make sure we have the correct fields
     for (HashMap<String, ByteIterator> result: resultVector) {


### PR DESCRIPTION
Fixed two issues in the scan operation for OrientDBClient:

1. orientdb client was not handling fields being null which happens when you use ```readallfields=true```. I handled this the way a lot of other clients handle it, which is to just not iterate through the results.
2. There was a known issue where the scan operation would throw a NullPointerException if the scan range ran over the end of the record key range. This was because of a bad mixing of iterator implementations. This has now been fixed.