### PR TITLE
Elasticsearch cleanup

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -59,7 +59,7 @@ DATABASES = {
     "cassandra2-cql": "com.yahoo.ycsb.db.CassandraCQLClient",
     "couchbase"    : "com.yahoo.ycsb.db.CouchbaseClient",
     "dynamodb"     : "com.yahoo.ycsb.db.DynamoDBClient",
-    "elasticsearch": "com.yahoo.ycsb.db.ElasticSearchClient",
+    "elasticsearch": "com.yahoo.ycsb.db.ElasticsearchClient",
     "geode"        : "com.yahoo.ycsb.db.GeodeClient",
     "googledatastore" : "com.yahoo.ycsb.db.GoogleDatastoreClient",
     "hbase094"     : "com.yahoo.ycsb.db.HBaseClient",

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -17,7 +17,7 @@ LICENSE file.
 
 ## Quick Start
 
-This section describes how to run YCSB on ElasticSearch running locally. 
+This section describes how to run YCSB on Elasticsearch running locally. 
 
 ### 1. Set Up YCSB
 
@@ -40,7 +40,7 @@ Then, run the workload:
 For further configuration see below: 
 
 ### Defaults Configuration
-The default setting for the ElasticSearch node that is created is as follows:
+The default setting for the Elasticsearch node that is created is as follows:
 
     cluster.name=es.ycsb.cluster
     node.local=true
@@ -54,14 +54,14 @@ The default setting for the ElasticSearch node that is created is as follows:
     es.index.key=es.ycsb
 
 ### Custom Configuration
-If you wish to customize the settings used to create the ElasticSerach node
-you can created a new property file that contains your desired ElasticSearch 
+If you wish to customize the settings used to create the Elasticsearch node
+you can created a new property file that contains your desired Elasticsearch 
 node settings and pass it in via the parameter to 'bin/ycsb' script. Note that 
 the default properties will be kept if you don't explicitly overwrite them.
 
 Assuming that we have a properties file named "myproperties.data" that contains 
-custom ElasticSearch node configuration you can execute the following to
-pass it into the ElasticSearch client:
+custom Elasticsearch node configuration you can execute the following to
+pass it into the Elasticsearch client:
 
 
     ./bin/ycsb run elasticsearch -P workloads/workloada -P myproperties.data -s

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -26,7 +26,7 @@ LICENSE file.
     </parent>
 
     <artifactId>elasticsearch-binding</artifactId>
-    <name>ElasticSearch Binding</name>
+    <name>Elasticsearch Binding</name>
     <packaging>jar</packaging>
     <properties>
         <elasticsearch-version>2.1.1</elasticsearch-version>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -29,7 +29,7 @@ LICENSE file.
     <name>Elasticsearch Binding</name>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch-version>2.1.1</elasticsearch-version>
+        <elasticsearch-version>2.2.0</elasticsearch-version>
     </properties>
     <dependencies>
         <dependency>

--- a/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticsearchClient.java
+++ b/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticsearchClient.java
@@ -51,7 +51,7 @@ import java.util.Set;
 import java.util.Vector;
 
 /**
- * ElasticSearch client for YCSB framework.
+ * Elasticsearch client for YCSB framework.
  *
  * <p>
  * Default properties to set:
@@ -65,7 +65,7 @@ import java.util.Vector;
  * @author Sharmarke Aden
  *
  */
-public class ElasticSearchClient extends DB {
+public class ElasticsearchClient extends DB {
 
   public static final String DEFAULT_CLUSTER_NAME = "es.ycsb.cluster";
   public static final String DEFAULT_INDEX_KEY = "es.ycsb";
@@ -105,10 +105,10 @@ public class ElasticSearchClient extends DB {
     // add it to the settings file (will overwrite the defaults).
     settings.put(props);
     System.out.println(
-        "ElasticSearch starting node = " + settings.get("cluster.name"));
+        "Elasticsearch starting node = " + settings.get("cluster.name"));
     System.out
-        .println("ElasticSearch node data path = " + settings.get("path.data"));
-    System.out.println("ElasticSearch Remote Mode = " + remoteMode);
+        .println("Elasticsearch node data path = " + settings.get("path.data"));
+    System.out.println("Elasticsearch Remote Mode = " + remoteMode);
     // Remote mode support for connecting to remote elasticsearch cluster
     if (remoteMode) {
       settings.put("client.transport.sniff", true)
@@ -119,7 +119,7 @@ public class ElasticSearchClient extends DB {
       String[] nodeList =
           props.getProperty("elasticsearch.hosts.list", DEFAULT_REMOTE_HOST)
               .split(",");
-      System.out.println("ElasticSearch Remote Hosts = "
+      System.out.println("Elasticsearch Remote Hosts = "
           + props.getProperty("elasticsearch.hosts.list", DEFAULT_REMOTE_HOST));
       TransportClient tClient = TransportClient.builder()
                                   .settings(settings).build();

--- a/elasticsearch/src/test/java/com/yahoo/ycsb/db/ElasticsearchClientTest.java
+++ b/elasticsearch/src/test/java/com/yahoo/ycsb/db/ElasticsearchClientTest.java
@@ -42,9 +42,9 @@ import java.util.Vector;
  *
  * @author saden
  */
-public class ElasticSearchClientTest {
+public class ElasticsearchClientTest {
 
-    protected final static ElasticSearchClient instance = new ElasticSearchClient();
+    protected final static ElasticsearchClient instance = new ElasticsearchClient();
     protected final static HashMap<String, ByteIterator> MOCK_DATA;
     protected final static String MOCK_TABLE = "MOCK_TABLE";
     protected final static String MOCK_KEY0 = "0";
@@ -81,7 +81,7 @@ public class ElasticSearchClientTest {
     }
 
     /**
-     * Test of insert method, of class ElasticSearchClient.
+     * Test of insert method, of class ElasticsearchClient.
      */
     @Test
     public void testInsert() {
@@ -91,7 +91,7 @@ public class ElasticSearchClientTest {
     }
 
     /**
-     * Test of delete method, of class ElasticSearchClient.
+     * Test of delete method, of class ElasticsearchClient.
      */
     @Test
     public void testDelete() {
@@ -101,7 +101,7 @@ public class ElasticSearchClientTest {
     }
 
     /**
-     * Test of read method, of class ElasticSearchClient.
+     * Test of read method, of class ElasticsearchClient.
      */
     @Test
     public void testRead() {
@@ -113,7 +113,7 @@ public class ElasticSearchClientTest {
     }
 
     /**
-     * Test of update method, of class ElasticSearchClient.
+     * Test of update method, of class ElasticsearchClient.
      */
     @Test
     public void testUpdate() {
@@ -139,7 +139,7 @@ public class ElasticSearchClientTest {
     }
 
     /**
-     * Test of scan method, of class ElasticSearchClient.
+     * Test of scan method, of class ElasticsearchClient.
      */
     @Test
     public void testScan() {


### PR DESCRIPTION
This pull request fixes all instances of the name "ElasticSearch" to "Elasticsearch" (the official name of the project) and bumps the Elasticsearch version from version 2.1.1 to version 2.2.0 (the latest stable version of Elasticsearch).