### PR TITLE
Update cassandra2-cql driver to only run tests on jdk8

### DIFF
--- a/cassandra2/pom.xml
+++ b/cassandra2/pom.xml
@@ -31,6 +31,11 @@ LICENSE file.
   <name>Cassandra 2.1+ DB Binding</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <!-- Skip tests by default. will be activated by jdk8 profile -->
+    <skipTests>true</skipTests>
+  </properties>
+
   <dependencies>
     <!-- CQL driver -->
     <dependency>
@@ -58,4 +63,19 @@ LICENSE file.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- Cassandra 2.2+ requires JDK8 to run, so none of our tests
+         will work unless we're using jdk8.
+      -->
+    <profile>
+      <id>jdk8-tests</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/cassandra2/pom.xml
+++ b/cassandra2/pom.xml
@@ -46,8 +46,9 @@ LICENSE file.
     </dependency>
     <dependency>
       <groupId>org.cassandraunit</groupId>
-      <artifactId>cassandra-unit-shaded</artifactId>
-      <version>2.1.9.2</version>
+      <artifactId>cassandra-unit</artifactId>
+      <version>3.0.0.1</version>
+      <classifier>shaded</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra2/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -41,7 +41,6 @@ import com.yahoo.ycsb.workloads.CoreWorkload;
 import org.cassandraunit.CassandraCQLUnit;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -68,10 +67,6 @@ public class CassandraCQLClientTest {
 
   @Before
   public void setUp() throws Exception {
-    // check that this is Java 8+
-    int javaVersion = Integer.parseInt(System.getProperty("java.version").split("\\.")[1]);
-    Assume.assumeTrue(javaVersion >= 8);
-
     session = cassandraUnit.getSession();
 
     Properties p = new Properties();

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ LICENSE file.
     <accumulo.version>1.6.0</accumulo.version>
     <cassandra.version>1.2.9</cassandra.version>
     <cassandra.cql.version>1.0.3</cassandra.cql.version>
-    <cassandra2.cql.version>2.1.8</cassandra2.cql.version>
+    <cassandra2.cql.version>3.0.0</cassandra2.cql.version>
     <geode.version>1.0.0-incubating.M1</geode.version>
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>0.6.0</kudu.version>


### PR DESCRIPTION
update the work in #614 so that maven skips tests under jdk7 and uses a profile to turn them on under jdk8.