### PR TITLE
[cassandra] properly clear cached containers.

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient10.java
@@ -453,6 +453,10 @@ public class CassandraClient10 extends DB {
     }
 
     for (int i = 0; i < operationRetries; i++) {
+      mutations.clear();
+      mutationMap.clear();
+      record.clear();
+
       if (debug) {
         System.out.println("Inserting key: " + key);
       }
@@ -478,10 +482,6 @@ public class CassandraClient10 extends DB {
         record.put(wrappedKey, mutationMap);
 
         client.batch_mutate(record, writeConsistencyLevel);
-
-        mutations.clear();
-        mutationMap.clear();
-        record.clear();
 
         if (debug) {
           System.out

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient7.java
@@ -418,6 +418,10 @@ public class CassandraClient7 extends DB {
     }
 
     for (int i = 0; i < operationRetries; i++) {
+      mutations.clear();
+      mutationMap.clear();
+      record.clear();
+
       if (debug) {
         System.out.println("Inserting key: " + key);
       }
@@ -443,10 +447,6 @@ public class CassandraClient7 extends DB {
         record.put(wrappedKey, mutationMap);
 
         client.batch_mutate(record, ConsistencyLevel.ONE);
-
-        mutations.clear();
-        mutationMap.clear();
-        record.clear();
 
         return Status.OK;
       } catch (Exception e) {

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraClient8.java
@@ -397,6 +397,10 @@ public class CassandraClient8 extends DB {
     }
 
     for (int i = 0; i < operationRetries; i++) {
+      mutations.clear();
+      mutationMap.clear();
+      record.clear();
+
       if (debug) {
         System.out.println("Inserting key: " + key);
       }
@@ -422,10 +426,6 @@ public class CassandraClient8 extends DB {
         record.put(wrappedKey, mutationMap);
 
         client.batch_mutate(record, ConsistencyLevel.ONE);
-
-        mutations.clear();
-        mutationMap.clear();
-        record.clear();
 
         return Status.OK;
       } catch (Exception e) {


### PR DESCRIPTION
clear containers before we use them rather than after, so that in the case of
exceptions we can recover.

closes #127