### PR TITLE
[elasticsearch] Fix race condition

### DIFF
--- a/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticsearchClient.java
+++ b/elasticsearch/src/main/java/com/yahoo/ycsb/db/ElasticsearchClient.java
@@ -149,8 +149,8 @@ public class ElasticsearchClient extends DB {
                                       .put("index.number_of_replicas", numberOfReplicas)
                                       .put("index.mapping._id.indexed", true)
                       )).actionGet();
-      client.admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet();
     }
+    client.admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet();
   }
 
   private int parseIntegerProperty(Properties properties, String key, int defaultValue) {


### PR DESCRIPTION
This commit fixes a race condition that exists between the shards being
ready to serve requests and the execution of the workload.