### PR TITLE
[build] Added Oracle JDK 8 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@
 language: java
 
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7  
   


### PR DESCRIPTION
Closes #676.

This should enable testing Cassandra instead of it being skipped. Will need to check the Travis run for this PR.