### PR TITLE
Shell scripts to run YCSB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,17 @@ Getting Started
    directory.
 
 3. Run YCSB command. 
-    
+
+    On Linux:
     ```sh
-    bin/ycsb load basic -P workloads/workloada
-    bin/ycsb run basic -P workloads/workloada
+    bin/ycsb.sh load basic -P workloads/workloada
+    bin/ycsb.sh run basic -P workloads/workloada
+    ```
+
+    On Windows:
+    ```bat
+    bin/ycsb.bat load basic -P workloads\workloada
+    bin/ycsb.bat run basic -P workloads\workloada
     ```
 
   Running the `ycsb` command without any argument will print the usage. 

--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+
+#DATABASE BINDINGS
+#
+# Available bindings should be listed here in the form of
+#      name:class
+#
+# - the name must start in column 0.
+# - the name is also the directory where the class can be found.
+# - if the directory contains multiple versions with different classes,
+#   use a dash with the version.  (e.g. cassandra-7, cassandra-cql)
+#
+accumulo:com.yahoo.ycsb.db.accumulo.AccumuloClient
+aerospike:com.yahoo.ycsb.db.AerospikeClient
+asynchbase:com.yahoo.ycsb.db.AsyncHBaseClient
+basic:com.yahoo.ycsb.BasicDB
+cassandra-7:com.yahoo.ycsb.db.CassandraClient7
+cassandra-8:com.yahoo.ycsb.db.CassandraClient8
+cassandra-10:com.yahoo.ycsb.db.CassandraClient10
+cassandra-cql:com.yahoo.ycsb.db.CassandraCQLClient
+cassandra2-cql:com.yahoo.ycsb.db.CassandraCQLClient
+couchbase:com.yahoo.ycsb.db.CouchbaseClient
+couchbase2:com.yahoo.ycsb.db.couchbase2.Couchbase2Client
+dynamodb:com.yahoo.ycsb.db.DynamoDBClient
+elasticsearch:com.yahoo.ycsb.db.ElasticsearchClient
+geode:com.yahoo.ycsb.db.GeodeClient
+googlebigtable:com.yahoo.ycsb.db.GoogleBigtableClient
+googledatastore:com.yahoo.ycsb.db.GoogleDatastoreClient
+hbase094:com.yahoo.ycsb.db.HBaseClient
+hbase098:com.yahoo.ycsb.db.HBaseClient
+hbase10:com.yahoo.ycsb.db.HBaseClient10
+hypertable:com.yahoo.ycsb.db.HypertableClient
+infinispan-cs:com.yahoo.ycsb.db.InfinispanRemoteClient
+infinispan:com.yahoo.ycsb.db.InfinispanClient
+jdbc:com.yahoo.ycsb.db.JdbcDBClient
+kudu:com.yahoo.ycsb.db.KuduYCSBClient
+mapkeeper:com.yahoo.ycsb.db.MapKeeperClient
+memcached:com.yahoo.ycsb.db.MemcachedClient
+mongodb:com.yahoo.ycsb.db.MongoDbClient
+mongodb-async:com.yahoo.ycsb.db.AsyncMongoDbClient
+nosqldb:com.yahoo.ycsb.db.NoSqlDbClient
+orientdb:com.yahoo.ycsb.db.OrientDBClient
+redis:com.yahoo.ycsb.db.RedisClient
+riak:com.yahoo.ycsb.db.riak.RiakKVClient
+s3:com.yahoo.ycsb.db.S3Client
+solr:com.yahoo.ycsb.db.SolrClient
+tarantool:com.yahoo.ycsb.db.TarantoolClient
+voldemort:com.yahoo.ycsb.db.VoldemortClient
+

--- a/bin/ycsb.bat
+++ b/bin/ycsb.bat
@@ -1,0 +1,183 @@
+@REM
+@REM Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License"); you
+@REM may not use this file except in compliance with the License. You
+@REM may obtain a copy of the License at
+@REM
+@REM http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+@REM implied. See the License for the specific language governing
+@REM permissions and limitations under the License. See accompanying
+@REM LICENSE file.
+@REM
+@REM -----------------------------------------------------------------------
+@REM Control Script for YCSB
+@REM
+@REM Environment Variable Prerequisites
+@REM
+@REM   Do not set the variables in this script. Instead put them into a script
+@REM   setenv.sh in YCSB_HOME/bin to keep your customizations separate.
+@REM
+@REM   YCSB_HOME       (Optional) YCSB installation directory.  If not set
+@REM                   this script will use the parent directory of where this
+@REM                   script is run from.
+@REM
+@REM   JAVA_HOME       (Required) Must point at your Java Development Kit
+@REM                   or Java Runtime Environment installation.
+@REM
+@REM   JAVA_OPTS       (Optional) Java runtime options used when any command
+@REM                   is executed.
+@REM
+@REM   WARNING!!! YCSB home must be located in a directory path that doesn't
+@REM   contain spaces.
+@REM
+
+@ECHO OFF
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+@REM Only set YCSB_HOME if not already set
+PUSHD %~dp0..
+IF NOT DEFINED YCSB_HOME SET YCSB_HOME=%CD%
+POPD
+
+@REM Ensure that any extra CLASSPATH variables are set via setenv.bat
+SET CLASSPATH=
+
+@REM Pull in customization options
+if exist "%YCSB_HOME%\bin\setenv.bat" call "%YCSB_HOME%\bin\setenv.bat"
+
+@REM Check if we have a usable JDK
+IF "%JAVA_HOME%." == "." GOTO noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+GOTO okJava
+:noJavaHome
+ECHO The JAVA_HOME environment variable is not defined correctly.
+GOTO exit
+:okJava
+
+@REM Determine YCSB command argument
+IF NOT "load" == "%1" GOTO noload
+SET YCSB_COMMAND=-load
+SET YCSB_CLASS=com.yahoo.ycsb.Client
+GOTO gotCommand
+:noload
+IF NOT "run" == "%1" GOTO noRun
+SET YCSB_COMMAND=-t
+SET YCSB_CLASS=com.yahoo.ycsb.Client
+GOTO gotCommand
+:noRun
+IF NOT "shell" == "%1" GOTO noShell
+SET YCSB_COMMAND=
+SET YCSB_CLASS=com.yahoo.ycsb.CommandLine
+GOTO gotCommand
+:noShell
+ECHO [ERROR] Found unknown command '%1'
+ECHO [ERROR] Expected one of 'load', 'run', or 'shell'. Exiting.
+GOTO exit
+:gotCommand
+
+@REM Find binding information
+FOR /F "delims=" %%G in (
+  'FINDSTR /B "%2:" %YCSB_HOME%\bin\bindings.properties'
+) DO SET "BINDING_LINE=%%G"
+
+IF NOT "%BINDING_LINE%." == "." GOTO gotBindingLine
+ECHO [ERROR] The specified binding '%2' was not found.  Exiting.
+GOTO exit
+:gotBindingLine
+
+@REM Pull out binding name and class
+FOR /F "tokens=1-2 delims=:" %%G IN ("%BINDING_LINE%") DO (
+  SET BINDING_NAME=%%G
+  SET BINDING_CLASS=%%H
+)
+
+@REM Some bindings have multiple versions that are managed in the same
+@REM directory.
+@REM   They are noted with a '-' after the binding name.
+@REM   (e.g. cassandra-7 & cassandra-8)
+FOR /F "tokens=1 delims=-" %%G IN ("%BINDING_NAME%") DO (
+  SET BINDING_DIR=%%G
+)
+
+@REM The 'basic' binding is core functionality
+IF NOT "%BINDING_NAME%" == "basic" GOTO noBasic
+SET BINDING_DIR=core
+:noBasic
+
+@REM Add Top level conf to classpath
+IF "%CLASSPATH%." == "." GOTO emptyClasspath
+SET CLASSPATH=%CLASSPATH%;%YCSB_HOME%\conf
+GOTO confAdded
+:emptyClasspath
+SET CLASSPATH=%YCSB_HOME%\conf
+:confAdded
+
+@REM Build classpath according to source checkout or release distribution
+IF EXIST "%YCSB_HOME%\pom.xml" GOTO gotRelease
+
+@REM Core libraries
+FOR %%F IN (%YCSB_HOME%\lib\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Database conf dir
+IF NOT EXIST "%YCSB_HOME%\%BINDING_DIR%-binding\conf" GOTO noBindingConf
+set CLASSPATH=%CLASSPATH%;%YCSB_HOME%\%BINDING_DIR%-binding\conf
+:noBindingConf
+
+@REM Database libraries
+FOR %%F IN (%YCSB_HOME%\%BINDING_DIR%-binding\lib\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+GOTO classpathComplete
+
+:gotRelease
+@REM Core libraries
+FOR %%F IN (%YCSB_HOME%\core\target\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Database conf (need to find because location is not consistent)
+FOR /D /R %YCSB_HOME%\%BINDING_DIR% %%F IN (*) DO (
+  IF "%%~nxF" == "conf" SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Database libraries
+FOR %%F IN (%YCSB_HOME%\%BINDING_DIR%\target\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Database dependency libraries
+FOR %%F IN (%YCSB_HOME%\%BINDING_DIR%\target\dependency\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+:classpathComplete
+
+@REM Cassandra deprecation message
+IF NOT "%BINDING_DIR%" == "cassandra" GOTO notOldCassandra
+echo [WARN] The 'cassandra-7', 'cassandra-8', 'cassandra-10', and cassandra-cql' clients are deprecated. If you are using Cassandra 2.X try using the 'cassandra2-cql' client instead.
+:notOldCassandra
+
+@REM Get the rest of the arguments, skipping the first 2
+FOR /F "tokens=2*" %%G IN ("%*") DO (
+  SET YCSB_ARGS=%%H
+)
+
+@REM Run YCSB
+@ECHO ON
+"%JAVA_HOME%\bin\java.exe" %JAVA_OPTS% -classpath "%CLASSPATH%" %YCSB_CLASS% %YCSB_COMMAND% -db %BINDING_CLASS% %YCSB_ARGS%
+@ECHO OFF
+
+GOTO end
+
+:exit
+EXIT /B 1;
+
+:end
+

--- a/bin/ycsb.sh
+++ b/bin/ycsb.sh
@@ -1,0 +1,183 @@
+#!/bin/sh
+#
+# Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+# -----------------------------------------------------------------------------
+# Control Script for YCSB
+#
+# Environment Variable Prerequisites
+#
+#   Do not set the variables in this script. Instead put them into a script
+#   setenv.sh in YCSB_HOME/bin to keep your customizations separate.
+#
+#   YCSB_HOME       (Optional) YCSB installation directory.  If not set
+#                   this script will use the parent directory of where this
+#                   script is run from.
+#
+#   JAVA_HOME       (Optional) Must point at your Java Development Kit
+#                   installation.  If empty, this script tries use the
+#                   available java executable.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when any command
+#                   is executed.
+#
+#   WARNING!!! YCSB home must be located in a directory path that doesn't
+#   contain spaces.
+#
+
+# Cygwin support
+CYGWIN=false
+case "`uname`" in
+CYGWIN*) CYGWIN=true;;
+esac
+
+# Get script path
+SCRIPT_DIR=`dirname "$0" 2>/dev/null`
+
+# Only set YCSB_HOME if not already set
+[ -z "$YCSB_HOME" ] && YCSB_HOME=`cd "$SCRIPT_DIR/.." 2>/dev/null; pwd`
+
+# Ensure that any extra CLASSPATH variables are set via setenv.sh
+CLASSPATH=
+
+# Pull in customization options
+if [ -r "$YCSB_HOME/bin/setenv.sh" ]; then
+  . "$YCSB_HOME/bin/setenv.sh"
+fi
+
+# Attempt to find the available JAVA, if JAVA_HOME not set
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_PATH=`which java 2>/dev/null`
+  if [ "x$JAVA_PATH" != "x" ]; then
+    JAVA_HOME=`dirname $(dirname "$JAVA_PATH" 2>/dev/null)`
+  fi
+fi
+
+# Determine YCSB command argument
+if [ "load" = "$1" ] ; then
+  YCSB_COMMAND=-load
+  YCSB_CLASS=com.yahoo.ycsb.Client
+elif [ "run" = "$1" ] ; then
+  YCSB_COMMAND=-t
+  YCSB_CLASS=com.yahoo.ycsb.Client
+elif [ "shell" = "$1" ] ; then
+  YCSB_COMMAND=
+  YCSB_CLASS=com.yahoo.ycsb.CommandLine
+else
+  echo "[ERROR] Found unknown command '$1'"
+  echo "[ERROR] Expected one of 'load', 'run', or 'shell'. Exiting."
+  exit 1;
+fi
+
+# Find binding information
+BINDING_LINE=`grep "^$2:" "$YCSB_HOME/bin/bindings.properties" -m 1`
+
+if [ -z $BINDING_LINE ] ; then
+  echo "[ERROR] The specified binding '$2' was not found.  Exiting."
+  exit 1;
+fi
+
+# Get binding name and class
+BINDING_NAME=`echo $BINDING_LINE | cut -d':' -f1`
+BINDING_CLASS=`echo $BINDING_LINE | cut -d':' -f2`
+
+# Some bindings have multiple versions that are managed in the same directory.
+#   They are noted with a '-' after the binding name.
+#   (e.g. cassandra-7 & cassandra-8)
+BINDING_DIR=`echo $BINDING_NAME | cut -d'-' -f1`
+
+# The 'basic' binding is core functionality
+if [ $BINDING_NAME = "basic" ] ; then
+  BINDING_DIR=core
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $CYGWIN; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] && CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# Check if source checkout, or release distribution
+DISTRIBUTION=true
+if [ -r "$YCSB_HOME/pom.xml" ]; then
+  DISTRIBUTION=false;
+fi
+
+# Add Top level conf to classpath
+if [ -z "$CLASSPATH" ] ; then
+  CLASSPATH="$YCSB_HOME/conf"
+else
+  CLASSPATH="$CLASSPATH:$YCSB_HOME/conf"
+fi
+
+# Build classpath
+if $DISTRIBUTION; then
+  # Core libraries
+  for f in `ls "$YCSB_HOME"/lib/*.jar`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+
+  # Database conf dir
+  if [ -r "$YCSB_HOME/$BINDING_DIR-binding/conf" ] ; then
+    CLASSPATH="$CLASSPATH:$YCSB_HOME/$BINDING_DIR-binding/conf"
+  fi
+
+  # Database libraries
+  for f in `ls "$YCSB_HOME"/$BINDING_DIR-binding/lib/*.jar 2>/dev/null`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+
+else
+  # Core libraries
+  for f in `ls "$YCSB_HOME"/core/target/*.jar`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+
+  # Database conf (need to find because location is not consistent)
+  for f in `find "$YCSB_HOME"/$BINDING_DIR -name "conf"`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+
+  # Database libraries
+  for f in `ls "$YCSB_HOME"/$BINDING_DIR/target/*.jar`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+
+  # Database dependency libraries
+  for f in `ls "$YCSB_HOME"/$BINDING_DIR/target/dependency/*.jar 2>/dev/null`; do
+    CLASSPATH="$CLASSPATH:$f"
+  done
+fi
+
+# Cassandra deprecation message
+if [ $BINDING_DIR = "cassandra" ] ; then
+  echo "[WARN] The 'cassandra-7', 'cassandra-8', 'cassandra-10', and \
+cassandra-cql' clients are deprecated. If you are using \
+Cassandra 2.X try using the 'cassandra2-cql' client instead."
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $CYGWIN; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+fi
+
+# Get the rest of the arguments
+YCSB_ARGS=`echo $* | cut -d' ' -f3-`
+
+# Run YCSB
+echo \"$JAVA_HOME/bin/java\" $JAVA_OPTS -classpath \"$CLASSPATH\" $YCSB_CLASS $YCSB_COMMAND -db $BINDING_CLASS $YCSB_ARGS
+"$JAVA_HOME/bin/java" $JAVA_OPTS -classpath "$CLASSPATH" $YCSB_CLASS $YCSB_COMMAND -db $BINDING_CLASS $YCSB_ARGS


### PR DESCRIPTION
I've been thinking for a while that it'd be better to use a unix shell script or windows batch script to run YCSB. It seems to me that the python script has been mostly sufficient but sometimes problematic. I've seen users run into issues with wrong python versions, not having python installed, and also not understanding the requirement to have python installed.

My hope was that a unix script or windows batch would make things easier for the end user. I had these following additional goals:
-     create a single point of update when new bindings are added
-     the linux script should also run under cygwin on windows
-     work with both release and source checkout
-     model after tomcat

Here are the files I've added:
- binding.properties - This file contains all the binding names and their associated classes. It is used by both the windows batch and unix script files. So, it is the single file to update when new bindings are added to YCSB.
- ycsb.sh - This is the Linux shell script. I've tested it on Ubuntu and on Windows 7 under Cygwin.
- ycsb.bat - This is the Windows batch script. I've tested this on Windows 7.

One caveat: The YCSB installation directory must be in a directory path that does not have spaces. (I tried very hard to make this work but couldn't. The current python script also has this issue.) I did verify that on Windows, the java executable does work in a path with spaces. This was especially important since many people have java.exe under "Program Files".

I hope this can play nicely with the Docker work that @risdenk is doing.