### PR TITLE
[elasticsearch] Bump version to 2.3.2

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -29,7 +29,7 @@ LICENSE file.
     <name>Elasticsearch Binding</name>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch-version>2.3.1</elasticsearch-version>
+        <elasticsearch-version>2.3.2</elasticsearch-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This commit bumps the version of the Elasticsearch dependency for the
Elasticsearch binding to version 2.3.2.