### PR TITLE
[mongodb] added logback.xml to mongodb module

### DIFF
--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2012 - 2015 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -91,6 +91,13 @@ Then, run the workload:
     ./bin/ycsb run mongodb -s -P workloads/workloada > outputRun.txt
     
 See the next section for the list of configuration parameters for MongoDB.
+
+## Log Level Control
+Due to the mongodb driver defaulting to a log level of DEBUG, a logback.xml file is included with this module that restricts the org.mongodb logging to WARN. You can control this by overriding the logback.xml and defining it in your ycsb command by adding this flag:
+
+```
+bin/ycsb run mongodb -jvm-args="-Dlogback.configurationFile=/path/to/logback.xml"
+```
 
 ## MongoDB Configuration Parameters
 

--- a/mongodb/src/main/resources/logback.xml
+++ b/mongodb/src/main/resources/logback.xml
@@ -1,0 +1,32 @@
+<!-- 
+Copyright (c) 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.mongodb" level="WARN">
+		<appender-ref ref="STDOUT"/>
+	</logger>
+
+	<root level="INFO">
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>


### PR DESCRIPTION
In response to #752, I thought it might be a good idea to restrict the mongodb driver logging by default. In the README I provided instructions on how to manipulate the log level without rebuilding if anyone decides they do want all the logs.