### PR TITLE
[mongodb] return OK on updates with w=0

### DIFF
--- a/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/com/yahoo/ycsb/db/AsyncMongoDbClient.java
@@ -462,7 +462,7 @@ public class AsyncMongoDbClient extends DB {
       }
       final long res =
           collection.update(query, update, false, false, writeConcern);
-      return res == 1 ? Status.OK : Status.NOT_FOUND;
+      return writeConcern == Durability.NONE || res == 1 ? Status.OK : Status.NOT_FOUND;
     } catch (final Exception e) {
       System.err.println(e.toString());
       return Status.ERROR;


### PR DESCRIPTION
in #746 it was found that when using the `mongodb-async` binding with a write concern of `w=0` then update operations will always return `-1` which in turn reports an operation status of `NOT_FOUND`.

Since you cannot tell what the result of the update operation is whne you fire and forget, it is reasonable to just return success for all update operations in the `mongodb-async` binding when using a write concern of `w=0`.