### PR TITLE
[cassandra2] add sigar dependency in the test scope and add tracing function

### DIFF
--- a/cassandra2/pom.xml
+++ b/cassandra2/pom.xml
@@ -62,6 +62,14 @@ LICENSE file.
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <!-- only for Cassandra test (Cassandra 2.2+ uses Sigar for collecting system information, and Sigar requires some native lib files) -->
+	<dependency>
+	    <groupId>org.hyperic</groupId>
+	    <artifactId>sigar-dist</artifactId>
+	    <version>1.6.4.129</version>
+	    <type>zip</type>
+	    <scope>test</scope>
+	</dependency>
   </dependencies>
 
   <profiles>
@@ -78,4 +86,60 @@ LICENSE file.
       </properties>
     </profile>
   </profiles>
+  <!-- sigar-dist can be downloaded from jboss repository -->
+	<repositories>
+		<repository>
+			<id>central2</id>
+			<name>sigar Repository</name>
+			<url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+	<!-- unzip sigar-dist/lib files. 
+		References: 
+		http://stackoverflow.com/questions/5388661/unzip-dependency-in-maven 
+		https://arviarya.wordpress.com/2013/09/22/sigar-access-operating-system-and-hardware-level-information/
+	 -->
+ 	<build>
+	 	<plugins>
+	 		<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-dependency-plugin</artifactId>
+			    <executions>
+			      <execution>
+			        <id>unpack-sigar</id>
+			        <phase>test<!-- or any other valid maven phase --></phase>
+			        <goals>
+			          <goal>unpack-dependencies</goal>
+			        </goals>
+			        <configuration>
+			          <includeGroupIds>org.hyperic</includeGroupIds>
+			          <includeArtifactIds>sigar-dist</includeArtifactIds>
+			          <includes>**/sigar-bin/lib/*</includes>
+					  <excludes>**/sigar-bin/lib/*jar</excludes>
+			          <outputDirectory>
+			             ${project.build.directory}/cassandra-dependency
+			          </outputDirectory>
+			        </configuration>
+			      </execution>
+			    </executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+				<systemProperties>
+				<property>
+					<name>java.library.path</name>
+					<value>${project.build.directory}/cassandra-dependency/hyperic-sigar-1.6.4/sigar-bin/lib</value>
+				</property>
+				</systemProperties>
+				</configuration>
+			</plugin>
+	 	</plugins>
+ 	</build>
 </project>


### PR DESCRIPTION
This pull request is a modification from #776, while in this PR, 
1. I set the sigar-dist dependency as test scope. 
2. I clean the commit logs and simplify them.
(both of them are suggested by @busbey )