### PR TITLE
[scripts] Rados missing from properties file for new platform-specific scripts.

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -55,6 +55,7 @@ mongodb:com.yahoo.ycsb.db.MongoDbClient
 mongodb-async:com.yahoo.ycsb.db.AsyncMongoDbClient
 nosqldb:com.yahoo.ycsb.db.NoSqlDbClient
 orientdb:com.yahoo.ycsb.db.OrientDBClient
+rados:com.yahoo.ycsb.db.RadosClient
 redis:com.yahoo.ycsb.db.RedisClient
 riak:com.yahoo.ycsb.db.riak.RiakKVClient
 s3:com.yahoo.ycsb.db.S3Client


### PR DESCRIPTION
The new Rados binding from 0.10.0 is missing an entry in the properties file used to handle the platform specific scripts.

If someone can review quickly, I'm fine with pulling this into the release for #772.