### PR TITLE
[jdbc]Fix bug in constructing CREATE TABLE SQL statement

### DIFF
--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
@@ -68,7 +68,7 @@ public final class JdbcDBCreateTable {
 
       sql = new StringBuilder("CREATE TABLE ");
       sql.append(tablename);
-      sql.append(" (KEY VARCHAR PRIMARY KEY");
+      sql.append(" (YCSB_KEY VARCHAR PRIMARY KEY");
 
       for (int idx = 0; idx < fieldcount; idx++) {
         sql.append(", FIELD");


### PR DESCRIPTION
The name of primary key in the original statement conflicts with reserved keyword and is inconsistent with the specified table schema in the documentation.

Fixed.