### PR TITLE
[jdbc] Use `TEXT` for fields instead of VARCHAR

### DIFF
--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
@@ -73,7 +73,7 @@ public final class JdbcDBCreateTable {
       for (int idx = 0; idx < fieldcount; idx++) {
         sql.append(", FIELD");
         sql.append(idx);
-        sql.append(" VARCHAR");
+        sql.append(" TEXT");
       }
       sql.append(");");
 


### PR DESCRIPTION
The original statement specify field type of VARCHAR, which might not be able to store the random-length string produced by YCSB and is also inconsistent with the schema in documentation.
