### PR TITLE
Add additional IntelliJ project file to Git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ output*
 # ignore standard IntelliJ files
 .idea/
 *.iml
+*.ipr
 *.iws
 
 # ignore standard Vim and Emacs temp files


### PR DESCRIPTION
This commit adds the IntelliJ ipr extension to .gitignore. These project
files are created when running the Maven goal idea:idea.