### PR TITLE
[couchbase2] Added support for ttl in Couchbase2

### DIFF
--- a/couchbase2/README.md
+++ b/couchbase2/README.md
@@ -142,4 +142,4 @@ You can set the following properties (with the default settings applied):
    set to the number of physical cores. Setting higher than that will likely degrade performance.
  - couchbase.networkMetricsInterval=0: The interval in seconds when latency metrics will be logged.
  - couchbase.runtimeMetricsInterval=0: The interval in seconds when runtime metrics will be logged.
- - couchbase.objectExpiry=0: Object Expiry is the amount of time(second) until a document expires in Couchbase.
+ - couchbase.documentExpiry=0: Document Expiry is the amount of time(second) until a document expires in Couchbase.

--- a/couchbase2/README.md
+++ b/couchbase2/README.md
@@ -142,4 +142,4 @@ You can set the following properties (with the default settings applied):
    set to the number of physical cores. Setting higher than that will likely degrade performance.
  - couchbase.networkMetricsInterval=0: The interval in seconds when latency metrics will be logged.
  - couchbase.runtimeMetricsInterval=0: The interval in seconds when runtime metrics will be logged.
- - couchbase.timeToLive=0: Time to live (TTL) is the amount of time(second) until a document expires in Couchbase.
+ - couchbase.objectExpiry=0: Object Expiry is the amount of time(second) until a document expires in Couchbase.

--- a/couchbase2/README.md
+++ b/couchbase2/README.md
@@ -142,3 +142,4 @@ You can set the following properties (with the default settings applied):
    set to the number of physical cores. Setting higher than that will likely degrade performance.
  - couchbase.networkMetricsInterval=0: The interval in seconds when latency metrics will be logged.
  - couchbase.runtimeMetricsInterval=0: The interval in seconds when runtime metrics will be logged.
+ - couchbase.timeToLive=0: Time to live (TTL) is the amount of time(second) until a document expires in Couchbase.

--- a/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
+++ b/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
@@ -93,7 +93,7 @@ import java.util.concurrent.locks.LockSupport;
  *      set to the number of physical cores. Setting higher than that will likely degrade performance.</li>
  * <li><b>couchbase.networkMetricsInterval=0</b> The interval in seconds when latency metrics will be logged.</li>
  * <li><b>couchbase.runtimeMetricsInterval=0</b> The interval in seconds when runtime metrics will be logged.</li>
- * <li><b>couchbase.timeToLive=0</b>Time to live is the amount of time until a document expires in Couchbase.</li>
+ * <li><b>couchbase.objectExpiry=0</b> Object Expiry is the amount of time until a document expires in Couchbase.</li>
  * </ul>
  */
 public class Couchbase2Client extends DB {
@@ -128,7 +128,7 @@ public class Couchbase2Client extends DB {
   private int networkMetricsInterval;
   private int runtimeMetricsInterval;
   private String scanAllQuery;
-  private int timeToLive;
+  private int objectExpiry;
   
   @Override
   public void init() throws DBException {
@@ -151,7 +151,7 @@ public class Couchbase2Client extends DB {
     boost = Integer.parseInt(props.getProperty("couchbase.boost", "3"));
     networkMetricsInterval = Integer.parseInt(props.getProperty("couchbase.networkMetricsInterval", "0"));
     runtimeMetricsInterval = Integer.parseInt(props.getProperty("couchbase.runtimeMetricsInterval", "0"));
-    timeToLive = Integer.parseInt(props.getProperty("couchbase.timeToLive", "0"));
+    objectExpiry = Integer.parseInt(props.getProperty("couchbase.objectExpiry", "0"));
     scanAllQuery =  "SELECT RAW meta().id FROM `" + bucketName +
       "` WHERE meta().id >= '$1' ORDER BY meta().id LIMIT $2";
 
@@ -345,7 +345,7 @@ public class Couchbase2Client extends DB {
    */
   private Status updateKv(final String docId, final HashMap<String, ByteIterator> values) {
     waitForMutationResponse(bucket.async().replace(
-        RawJsonDocument.create(docId, timeToLive, encode(values)),
+        RawJsonDocument.create(docId, objectExpiry, encode(values)),
         persistTo,
         replicateTo
     ));
@@ -415,7 +415,7 @@ public class Couchbase2Client extends DB {
     for(int i = 0; i < tries; i++) {
       try {
         waitForMutationResponse(bucket.async().insert(
-            RawJsonDocument.create(docId, timeToLive, encode(values)),
+            RawJsonDocument.create(docId, objectExpiry, encode(values)),
             persistTo,
             replicateTo
         ));
@@ -494,7 +494,7 @@ public class Couchbase2Client extends DB {
    */
   private Status upsertKv(final String docId, final HashMap<String, ByteIterator> values) {
     waitForMutationResponse(bucket.async().upsert(
-        RawJsonDocument.create(docId, timeToLive, encode(values)),
+        RawJsonDocument.create(docId, objectExpiry, encode(values)),
         persistTo,
         replicateTo
     ));

--- a/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
+++ b/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
@@ -93,7 +93,7 @@ import java.util.concurrent.locks.LockSupport;
  *      set to the number of physical cores. Setting higher than that will likely degrade performance.</li>
  * <li><b>couchbase.networkMetricsInterval=0</b> The interval in seconds when latency metrics will be logged.</li>
  * <li><b>couchbase.runtimeMetricsInterval=0</b> The interval in seconds when runtime metrics will be logged.</li>
- * <li><b>couchbase.timeToLive=0</b> Time to live (TTL) is the amount of time until a document expires in Couchbase.</li>
+ * <li><b>couchbase.timeToLive=0</b>Time to live is the amount of time until a document expires in Couchbase.</li>
  * </ul>
  */
 public class Couchbase2Client extends DB {

--- a/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
+++ b/couchbase2/src/main/java/com/yahoo/ycsb/db/couchbase2/Couchbase2Client.java
@@ -93,7 +93,8 @@ import java.util.concurrent.locks.LockSupport;
  *      set to the number of physical cores. Setting higher than that will likely degrade performance.</li>
  * <li><b>couchbase.networkMetricsInterval=0</b> The interval in seconds when latency metrics will be logged.</li>
  * <li><b>couchbase.runtimeMetricsInterval=0</b> The interval in seconds when runtime metrics will be logged.</li>
- * <li><b>couchbase.objectExpiry=0</b> Object Expiry is the amount of time until a document expires in Couchbase.</li>
+ * <li><b>couchbase.documentExpiry=0</b> Document Expiry is the amount of time until a document expires in
+ *      Couchbase.</li>
  * </ul>
  */
 public class Couchbase2Client extends DB {
@@ -128,7 +129,7 @@ public class Couchbase2Client extends DB {
   private int networkMetricsInterval;
   private int runtimeMetricsInterval;
   private String scanAllQuery;
-  private int objectExpiry;
+  private int documentExpiry;
   
   @Override
   public void init() throws DBException {
@@ -151,7 +152,7 @@ public class Couchbase2Client extends DB {
     boost = Integer.parseInt(props.getProperty("couchbase.boost", "3"));
     networkMetricsInterval = Integer.parseInt(props.getProperty("couchbase.networkMetricsInterval", "0"));
     runtimeMetricsInterval = Integer.parseInt(props.getProperty("couchbase.runtimeMetricsInterval", "0"));
-    objectExpiry = Integer.parseInt(props.getProperty("couchbase.objectExpiry", "0"));
+    documentExpiry = Integer.parseInt(props.getProperty("couchbase.documentExpiry", "0"));
     scanAllQuery =  "SELECT RAW meta().id FROM `" + bucketName +
       "` WHERE meta().id >= '$1' ORDER BY meta().id LIMIT $2";
 
@@ -345,7 +346,7 @@ public class Couchbase2Client extends DB {
    */
   private Status updateKv(final String docId, final HashMap<String, ByteIterator> values) {
     waitForMutationResponse(bucket.async().replace(
-        RawJsonDocument.create(docId, objectExpiry, encode(values)),
+        RawJsonDocument.create(docId, documentExpiry, encode(values)),
         persistTo,
         replicateTo
     ));
@@ -415,7 +416,7 @@ public class Couchbase2Client extends DB {
     for(int i = 0; i < tries; i++) {
       try {
         waitForMutationResponse(bucket.async().insert(
-            RawJsonDocument.create(docId, objectExpiry, encode(values)),
+            RawJsonDocument.create(docId, documentExpiry, encode(values)),
             persistTo,
             replicateTo
         ));
@@ -494,7 +495,7 @@ public class Couchbase2Client extends DB {
    */
   private Status upsertKv(final String docId, final HashMap<String, ByteIterator> values) {
     waitForMutationResponse(bucket.async().upsert(
-        RawJsonDocument.create(docId, objectExpiry, encode(values)),
+        RawJsonDocument.create(docId, documentExpiry, encode(values)),
         persistTo,
         replicateTo
     ));


### PR DESCRIPTION
Time to live (TTL) is the amount of time until a document expires in Couchbase Server. Having this property will help user not to clean up DB manually.