### PR TITLE
[mongodb] correct placement of xml header on logback configs.

### DIFF
--- a/mongodb/src/main/resources/logback.xml
+++ b/mongodb/src/main/resources/logback.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- 
 Copyright (c) 2016 YCSB contributors. All rights reserved.
 
@@ -14,7 +15,6 @@ implied. See the License for the specific language governing
 permissions and limitations under the License. See accompanying
 LICENSE file.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>


### PR DESCRIPTION
closes #798