### PR TITLE
[elasticearch] upgrade to version 2.4.0

### DIFF
--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -29,7 +29,7 @@ LICENSE file.
     <name>Elasticsearch Binding</name>
     <packaging>jar</packaging>
     <properties>
-        <elasticsearch-version>2.3.4</elasticsearch-version>
+        <elasticsearch-version>2.4.0</elasticsearch-version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This commit upgrades the Elasticsearch dependency from version 2.3.4 to
version 2.4.0.