### PR TITLE
[jdbc] Assorted cleanup/fixes around batching and supporting different databases

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/DBWrapper.java
+++ b/core/src/main/java/com/yahoo/ycsb/DBWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010 Yahoo! Inc. All rights reserved.
+ * Copyright (c) 2010 Yahoo! Inc., 2016 YCSB contributors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -184,7 +184,7 @@ public class DBWrapper extends DB
   private void measure(String op, Status result, long intendedStartTimeNanos,
       long startTimeNanos, long endTimeNanos) {
     String measurementName = op;
-    if (result != Status.OK) {
+    if (result == null || !result.isOk()) {
       if (this.reportLatencyForEachError ||
           this.latencyTrackedErrors.contains(result.getName())) {
         measurementName = op + "-" + result.getName();

--- a/core/src/main/java/com/yahoo/ycsb/Status.java
+++ b/core/src/main/java/com/yahoo/ycsb/Status.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 YCSB contributors All rights reserved.
+ * Copyright (c) 2016 YCSB contributors All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You
@@ -77,6 +77,14 @@ public class Status {
     } else if (!name.equals(other.name))
       return false;
     return true;
+  }
+
+  /**
+   * Is {@code this} a passing state for the operation: {@link Status#OK} or {@link Status#BATCHED_OK}.
+   * @return true if the operation is successful, false otherwise
+   */
+  public boolean isOk() {
+    return this == OK || this == BATCHED_OK;
   }
 
   public static final Status OK = new Status("OK", "The operation completed successfully.");

--- a/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/CoreWorkload.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 
 
@@ -590,7 +591,7 @@ public class CoreWorkload extends Workload {
     int numOfRetries = 0;
     do {
       status = db.insert(table, dbkey, values);
-      if (status == Status.OK) {
+      if (null != status && status.isOk()) {
         break;
       }
       // Retry if configured. Without retrying, the load process will fail
@@ -614,7 +615,7 @@ public class CoreWorkload extends Workload {
       }
     } while (true);
 
-    return (status == Status.OK);
+    return null != status && status.isOk();
   }
 
   /**

--- a/core/src/test/java/com/yahoo/ycsb/TestStatus.java
+++ b/core/src/test/java/com/yahoo/ycsb/TestStatus.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test class for {@link Status}.
+ */
+public class TestStatus {
+
+  @Test
+  public void testAcceptableStatus() {
+    assertTrue(Status.OK.isOk());
+    assertTrue(Status.BATCHED_OK.isOk());
+    assertFalse(Status.BAD_REQUEST.isOk());
+    assertFalse(Status.ERROR.isOk());
+    assertFalse(Status.FORBIDDEN.isOk());
+    assertFalse(Status.NOT_FOUND.isOk());
+    assertFalse(Status.NOT_IMPLEMENTED.isOk());
+    assertFalse(Status.SERVICE_UNAVAILABLE.isOk());
+    assertFalse(Status.UNEXPECTED_STATE.isOk());
+  }
+}

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -101,6 +101,8 @@ db.passwd=admin								# Password for the connection.
 db.batchsize=1000             # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
 jdbc.fetchsize=10							# The JDBC fetch size hinted to the driver.
 jdbc.autocommit=true						# The JDBC connection auto-commit property for the driver.
+jdbc.batchupdateapi=false     # Use addBatch()/executeBatch() JDBC methods instead of executeUpdate() for writes (default: false)
+db.batchsize=1000             # The number of rows to be batched before commit (or executeBatch() when jdbc.batchupdateapi=true)
 ```
 
 Please refer to https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties for all other YCSB core properties.

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/StatementType.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/StatementType.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc., 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.db;
+
+/**
+ * The statement type for the prepared statements.
+ */
+public class StatementType {
+
+  enum Type {
+    INSERT(1), DELETE(2), READ(3), UPDATE(4), SCAN(5);
+
+    private final int internalType;
+
+    private Type(int type) {
+      internalType = type;
+    }
+
+    int getHashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + internalType;
+      return result;
+    }
+  }
+
+  private Type type;
+  private int shardIndex;
+  private int numFields;
+  private String tableName;
+  private String fieldString;
+
+  public StatementType(Type type, String tableName, int numFields, String fieldString, int shardIndex) {
+    this.type = type;
+    this.tableName = tableName;
+    this.numFields = numFields;
+    this.fieldString = fieldString;
+    this.shardIndex = shardIndex;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public String getFieldString() {
+    return fieldString;
+  }
+
+  public int getNumFields() {
+    return numFields;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + numFields + 100 * shardIndex;
+    result = prime * result + ((tableName == null) ? 0 : tableName.hashCode());
+    result = prime * result + ((type == null) ? 0 : type.getHashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    StatementType other = (StatementType) obj;
+    if (numFields != other.numFields) {
+      return false;
+    }
+    if (shardIndex != other.shardIndex) {
+      return false;
+    }
+    if (tableName == null) {
+      if (other.tableName != null) {
+        return false;
+      }
+    } else if (!tableName.equals(other.tableName)) {
+      return false;
+    }
+    if (type != other.type) {
+      return false;
+    }
+    if (!fieldString.equals(other.fieldString)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/DBFlavor.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.db.flavors;
+
+import com.yahoo.ycsb.db.StatementType;
+
+/**
+ * DBFlavor captures minor differences in syntax and behavior among JDBC implementations and SQL
+ * dialects. This class also acts as a factory to instantiate concrete flavors based on the JDBC URL.
+ */
+public abstract class DBFlavor {
+
+  enum DBName {
+    DEFAULT,
+    PHOENIX
+  }
+
+  private final DBName dbName;
+
+  public DBFlavor(DBName dbName) {
+    this.dbName = dbName;
+  }
+
+  public static DBFlavor fromJdbcUrl(String url) {
+    if (url.startsWith("jdbc:phoenix")) {
+      return new PhoenixDBFlavor();
+    }
+    return new DefaultDBFlavor();
+  }
+
+  /**
+   * Create and return a SQL statement for inserting data.
+   */
+  public abstract String createInsertStatement(StatementType insertType, String key);
+
+  /**
+   * Create and return a SQL statement for reading data.
+   */
+  public abstract String createReadStatement(StatementType readType, String key);
+
+  /**
+   * Create and return a SQL statement for deleting data.
+   */
+  public abstract String createDeleteStatement(StatementType deleteType, String key);
+
+  /**
+   * Create and return a SQL statement for updating data.
+   */
+  public abstract String createUpdateStatement(StatementType updateType, String key);
+
+  /**
+   * Create and return a SQL statement for scanning data.
+   */
+  public abstract String createScanStatement(StatementType scanType, String key);
+}

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/DefaultDBFlavor.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/DefaultDBFlavor.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.db.flavors;
+
+import com.yahoo.ycsb.db.JdbcDBClient;
+import com.yahoo.ycsb.db.StatementType;
+
+/**
+ * A default flavor for relational databases.
+ */
+public class DefaultDBFlavor extends DBFlavor {
+  public DefaultDBFlavor() {
+    super(DBName.DEFAULT);
+  }
+  public DefaultDBFlavor(DBName dbName) {
+    super(dbName);
+  }
+
+  @Override
+  public String createInsertStatement(StatementType insertType, String key) {
+    StringBuilder insert = new StringBuilder("INSERT INTO ");
+    insert.append(insertType.getTableName());
+    insert.append(" (" + JdbcDBClient.PRIMARY_KEY + "," + insertType.getFieldString() + ")");
+    insert.append(" VALUES(?");
+    for (int i = 0; i < insertType.getNumFields(); i++) {
+      insert.append(",?");
+    }
+    insert.append(")");
+    return insert.toString();
+  }
+
+  @Override
+  public String createReadStatement(StatementType readType, String key) {
+    StringBuilder read = new StringBuilder("SELECT * FROM ");
+    read.append(readType.getTableName());
+    read.append(" WHERE ");
+    read.append(JdbcDBClient.PRIMARY_KEY);
+    read.append(" = ");
+    read.append("?");
+    return read.toString();
+  }
+
+  @Override
+  public String createDeleteStatement(StatementType deleteType, String key) {
+    StringBuilder delete = new StringBuilder("DELETE FROM ");
+    delete.append(deleteType.getTableName());
+    delete.append(" WHERE ");
+    delete.append(JdbcDBClient.PRIMARY_KEY);
+    delete.append(" = ?");
+    return delete.toString();
+  }
+
+  @Override
+  public String createUpdateStatement(StatementType updateType, String key) {
+    String[] fieldKeys = updateType.getFieldString().split(",");
+    StringBuilder update = new StringBuilder("UPDATE ");
+    update.append(updateType.getTableName());
+    update.append(" SET ");
+    for (int i = 0; i < fieldKeys.length; i++) {
+      update.append(fieldKeys[i]);
+      update.append("=?");
+      if (i < fieldKeys.length - 1) {
+        update.append(", ");
+      }
+    }
+    update.append(" WHERE ");
+    update.append(JdbcDBClient.PRIMARY_KEY);
+    update.append(" = ?");
+    return update.toString();
+  }
+
+  @Override
+  public String createScanStatement(StatementType scanType, String key) {
+    StringBuilder select = new StringBuilder("SELECT * FROM ");
+    select.append(scanType.getTableName());
+    select.append(" WHERE ");
+    select.append(JdbcDBClient.PRIMARY_KEY);
+    select.append(" >= ?");
+    select.append(" ORDER BY ");
+    select.append(JdbcDBClient.PRIMARY_KEY);
+    select.append(" LIMIT ?");
+    return select.toString();
+  }
+}

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/PhoenixDBFlavor.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/PhoenixDBFlavor.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package com.yahoo.ycsb.db.flavors;
+
+import com.yahoo.ycsb.db.JdbcDBClient;
+import com.yahoo.ycsb.db.StatementType;
+
+/**
+ * Database flavor for Apache Phoenix. Captures syntax differences used by Phoenix.
+ */
+public class PhoenixDBFlavor extends DefaultDBFlavor {
+  public PhoenixDBFlavor() {
+    super(DBName.PHOENIX);
+  }
+
+  @Override
+  public String createInsertStatement(StatementType insertType, String key) {
+    // Phoenix uses UPSERT syntax
+    StringBuilder insert = new StringBuilder("UPSERT INTO ");
+    insert.append(insertType.getTableName());
+    insert.append(" (" + JdbcDBClient.PRIMARY_KEY + "," + insertType.getFieldString() + ")");
+    insert.append(" VALUES(?");
+    for (int i = 0; i < insertType.getNumFields(); i++) {
+      insert.append(",?");
+    }
+    insert.append(")");
+    return insert.toString();
+  }
+
+  @Override
+  public String createUpdateStatement(StatementType updateType, String key) {
+    // Phoenix doesn't have UPDATE semantics, just re-use UPSERT VALUES on the specific columns
+    String[] fieldKeys = updateType.getFieldString().split(",");
+    StringBuilder update = new StringBuilder("UPSERT INTO ");
+    update.append(updateType.getTableName());
+    update.append(" (");
+    // Each column to update
+    for (int i = 0; i < fieldKeys.length; i++) {
+      update.append(fieldKeys[i]).append(",");
+    }
+    // And then set the primary key column
+    update.append(JdbcDBClient.PRIMARY_KEY).append(") VALUES(");
+    // Add an unbound param for each column to update
+    for (int i = 0; i < fieldKeys.length; i++) {
+      update.append("?, ");
+    }
+    // Then the primary key column's value
+    update.append("?)");
+    return update.toString();
+  }
+}

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/package-info.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/flavors/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+/**
+ * This package contains a collection of database-specific overrides. This accounts for the variance
+ * that can be present where JDBC does not explicitly define what a database must do or when a
+ * database has a non-standard SQL implementation.
+ */
+package com.yahoo.ycsb.db.flavors;


### PR DESCRIPTION
A couple of things included in this PR. Happy to split them out if that is preferred. I just came across all of these in some recent testing.

* Builds on @enis's commit which didn't make it upstream. Implements a "flavor" for Apache Phoenix (which only provides `UPSERT` to write data, no `INSERT`)
* Some basic cleanup of JdbcDBClient (rip out all of the flavors logic into their own files)
* De-couples batching APIs and autocommit. Again, trying to support Phoenix better, but not break JDBC semantics.
* Finally, fixes an issue with the existing batching support where the CoreWorkload treated `Status.BATCHED_OK` as an error (not the same as `Status.OK`)