### PR TITLE
[cassandra] Increase Cassandra test timeout and add logging for test failures

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -57,6 +57,12 @@ LICENSE file.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -54,6 +54,9 @@ import java.util.Set;
  * Integration tests for the Cassandra client
  */
 public class CassandraCQLClientTest {
+  // Change the default Cassandra timeout from 10s to 120s for slow CI machines
+  private final static long timeout = 120000L;
+
   private final static String TABLE = "usertable";
   private final static String HOST = "localhost";
   private final static int PORT = 9142;
@@ -63,7 +66,8 @@ public class CassandraCQLClientTest {
   private Session session;
 
   @ClassRule
-  public static CassandraCQLUnit cassandraUnit = new CassandraCQLUnit(new ClassPathCQLDataSet("ycsb.cql", "ycsb"));
+  public static CassandraCQLUnit cassandraUnit = new CassandraCQLUnit(
+    new ClassPathCQLDataSet("ycsb.cql", "ycsb"), null, timeout);
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
Added slf4j-simple so we can see what is happening during the Cassandra tests and get an idea why it fails. The timeout was increased from 10 seconds to 120 seconds. I tried 60 seconds but on Docker it still failed. Bumping up to 120 seems to have worked.

Fixes #495 