### PR TITLE
[jdbc, solr] Fix JDBC checkstyle and skip Solr 5.x with JDK 9

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -161,7 +161,6 @@ LICENSE file.
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@ LICENSE file.
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>checkstyle</groupId>
+        <groupId>com.puppycrawl.tools</groupId>
         <artifactId>checkstyle</artifactId>
-        <version>5.0</version>
+        <version>7.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.jdom</groupId>
@@ -145,7 +145,7 @@ LICENSE file.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.16</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -18,31 +18,36 @@ LICENSE file.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.yahoo.ycsb</groupId>
-		<artifactId>binding-parent</artifactId>
-		<version>0.12.0-SNAPSHOT</version>
-		<relativePath>../binding-parent</relativePath>
-	</parent>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.yahoo.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.12.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
 
-	<artifactId>solr-binding</artifactId>
-	<name>Solr Binding</name>
-	<packaging>jar</packaging>
+  <artifactId>solr-binding</artifactId>
+  <name>Solr Binding</name>
+  <packaging>jar</packaging>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
-			<artifactId>core</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.solr</groupId>
-			<artifactId>solr-solrj</artifactId>
-			<version>${solr.version}</version>
-		</dependency>
+  <properties>
+    <!-- Tests do not run on jdk9 -->
+    <skipJDK9Tests>true</skipJDK9Tests>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.solr</groupId>
+      <artifactId>solr-solrj</artifactId>
+      <version>${solr.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
@@ -55,5 +60,5 @@ LICENSE file.
       <version>${solr.version}</version>
       <scope>test</scope>
     </dependency>
-	</dependencies>
+  </dependencies>
 </project>


### PR DESCRIPTION
Checkstyle redundant throws is unreliable and is removed from newest version of checkstyle.
* https://github.com/checkstyle/checkstyle/issues/5#issuecomment-52593242
* Updated checkstyle and removed redundant throws from checkstyle.xml

Solr 5.x doesn't work with JDK 9.
* Skip the tests on JDK 9
* solr pom.xml had spaces and tabs.
* Solr 6.x supports JDK 9 - PR #716 

Relates to #705 