### PR TITLE
Update README and sample config file for jdbc

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -54,10 +54,10 @@ Key take aways:
 YCSB has a utility to help create your SQL table. NOTE: It does not support all databases flavors, if it does not work for you, you will have to create your table manually with the schema given above. An example usage of the utility:
 
 ```sh
-java -cp YCSB_HOME/jdbc-binding/lib/jdbc-binding-0.4.0.jar:mysql-connector-java-5.1.37-bin.jar com.yahoo.ycsb.db.JdbcDBCreateTable -P testworkload -P db.properties -n usertable
+java -cp YCSB_HOME/jdbc-binding/lib/jdbc-binding-0.4.0.jar:mysql-connector-java-5.1.37-bin.jar com.yahoo.ycsb.db.JdbcDBCreateTable -P db.properties -n usertable
 ```
 
-Hint: you need to include your Driver jar in the classpath as well as specify your loading options via a workload file, JDBC connection information, and a table name with ```-n```. 
+Hint: you need to include your Driver jar in the classpath as well as specify JDBC connection information via a properties file, and a table name with ```-n```. 
 
 Simply executing the JdbcDBCreateTable class without any other parameters will print out usage information.
 

--- a/jdbc/src/main/conf/db.properties
+++ b/jdbc/src/main/conf/db.properties
@@ -15,7 +15,7 @@
 
 # Properties file that contains database connection information.
 
-jdbc.driver=org.h2.Driver
+db.driver=org.h2.Driver
 # jdbc.fetchsize=20
 db.url=jdbc:h2:tcp://foo.com:9092/~/h2/ycsb
 db.user=sa

--- a/jdbc/src/main/conf/h2.properties
+++ b/jdbc/src/main/conf/h2.properties
@@ -15,7 +15,7 @@
 
 # Properties file that contains database connection information.
 
-jdbc.driver=org.h2.Driver
+db.driver=org.h2.Driver
 db.url=jdbc:h2:tcp://foo.com:9092/~/h2/ycsb
 db.user=sa
 db.passwd=


### PR DESCRIPTION
I was going through jdbc bindings (for integration with cockroachdb) and found some inconsistencies:
1. The README mentions that a workload file can be supplied to com.yahoo.ycsb.db.JdbcDBCreateTable. However there's nothing in the class which makes use of it. I assume it's unnecessary.
2. Update the property key for jdbc driver from "jdbc.driver" to "db.driver" according to JdbcDBClient.DRIVER_CLASS.