### PR TITLE
[kudu] Update Kudu binding to 1.1.0, use slf4j for logging, improve table partitioning

### DIFF
--- a/kudu/README.md
+++ b/kudu/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2015 YCSB contributors. All rights reserved.
+Copyright (c) 2015-2016 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You

--- a/kudu/README.md
+++ b/kudu/README.md
@@ -17,25 +17,30 @@ LICENSE file.
 
 # Kudu bindings for YCSB
 
-[Kudu](http://getkudu.io) is a storage engine that enables fast analytics on fast data.
+[Apache Kudu](https://kudu.apache.org) is a storage engine that enables fast
+analytics on fast data.
 
 ## Benchmarking Kudu
 
-Use the following command line to load the initial data into an existing Kudu cluster with default
-configurations.
+Use the following command line to load the initial data into an existing Kudu
+cluster with default configurations.
 
 ```
 bin/ycsb load kudu -P workloads/workloada
 ```
 
 Additional configurations:
-* `kudu_master_addresses`: The master's address. The default configuration expects a master on localhost.
-* `kudu_pre_split_num_tablets`: The number of tablets (or partitions) to create for the table. The default
-uses 4 tablets. A good rule of thumb is to use 5 per tablet server.
-* `kudu_table_num_replicas`: The number of replicas that each tablet will have. The default is 3. Should
-only be configured to use 1 instead, for single node tests.
-* `kudu_sync_ops`: If the client should wait after every write operation. The default is true.
-* `kudu_block_size`: The data block size used to configure columns. The default is 4096 bytes.
+* `kudu_master_addresses`: The master's address. The default configuration
+  expects a master on localhost.
+* `kudu_pre_split_num_tablets`: The number of tablets (or partitions) to create
+  for the table. The default uses 4 tablets. A good rule of thumb is to use 5
+  per tablet server.
+* `kudu_table_num_replicas`: The number of replicas that each tablet will have.
+  The default is 3. Should only be configured to use 1 instead, for single node tests.
+* `kudu_sync_ops`: If the client should wait after every write operation. The
+  default is true.
+* `kudu_block_size`: The data block size used to configure columns. The default
+  is 4096 bytes.
 
 Then, you can run the workload:
 
@@ -45,12 +50,12 @@ bin/ycsb run kudu -P workloads/workloada
 
 ## Using a previous client version
 
-If you wish to use a different Kudu client version than the one shipped with YCSB, you can specify on the
-command line with `-Dkudu.version=x`. For example:
+If you wish to use a different Kudu client version than the one shipped with
+YCSB, you can specify on the command line with `-Dkudu.version=x`. For example:
 
 ```
-mvn -pl com.yahoo.ycsb:kudu-binding -am package -DskipTests -Dkudu.version=0.7.1
+mvn -pl com.yahoo.ycsb:kudu-binding -am package -DskipTests -Dkudu.version=1.0.1
 ```
 
-Note that prior to 1.0, Kudu doesn't guarantee wire or API compability between versions and only the latest
-one is officially supported.
+Note that only versions since 1.0 are supported, since Kudu did not guarantee
+wire or API compatibility prior to 1.0.

--- a/kudu/pom.xml
+++ b/kudu/pom.xml
@@ -31,7 +31,7 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>org.kududb</groupId>
+      <groupId>org.apache.kudu</groupId>
       <artifactId>kudu-client</artifactId>
       <version>${kudu.version}</version>
     </dependency>
@@ -42,17 +42,4 @@ LICENSE file.
       <scope>provided</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>cloudera-repo</id>
-      <name>Cloudera Releases</name>
-      <url>https://repository.cloudera.com/artifactory/cloudera-repos</url>
-    </repository>
-  </repositories>
 </project>

--- a/kudu/pom.xml
+++ b/kudu/pom.xml
@@ -41,5 +41,15 @@ LICENSE file.
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.21</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.21</version>
+    </dependency>
   </dependencies>
 </project>

--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 YCSB contributors. All rights reserved.
+ * Copyright (c) 2015-2016 YCSB contributors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You

--- a/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/KuduYCSBClient.java
@@ -23,9 +23,9 @@ import com.yahoo.ycsb.DBException;
 import com.yahoo.ycsb.Status;
 import com.yahoo.ycsb.StringByteIterator;
 import com.yahoo.ycsb.workloads.CoreWorkload;
-import org.kududb.ColumnSchema;
-import org.kududb.Schema;
-import org.kududb.client.*;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.client.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -34,25 +34,25 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
-import static org.kududb.Type.STRING;
+import static org.apache.kudu.Type.STRING;
 
 /**
  * Kudu client for YCSB framework. Example to load: <blockquote>
- * 
+ *
  * <pre>
  * <code>
- * $ ./bin/ycsb load kudu -P workloads/workloada -threads 5 
+ * $ ./bin/ycsb load kudu -P workloads/workloada -threads 5
  * </code>
  * </pre>
- * 
+ *
  * </blockquote> Example to run:  <blockquote>
- * 
+ *
  * <pre>
  * <code>
  * ./bin/ycsb run kudu -P workloads/workloada -p kudu_sync_ops=true -threads 5
  * </code>
  * </pre>
- * 
+ *
  * </blockquote>
  */
 public class KuduYCSBClient extends com.yahoo.ycsb.DB {
@@ -64,8 +64,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
   private static final String SYNC_OPS_OPT = "kudu_sync_ops";
   private static final String DEBUG_OPT = "kudu_debug";
   private static final String PRINT_ROW_ERRORS_OPT = "kudu_print_row_errors";
-  private static final String PRE_SPLIT_NUM_TABLETS_OPT =
-      "kudu_pre_split_num_tablets";
+  private static final String PRE_SPLIT_NUM_TABLETS_OPT = "kudu_pre_split_num_tablets";
   private static final String TABLE_NUM_REPLICAS = "kudu_table_num_replicas";
   private static final String BLOCK_SIZE_OPT = "kudu_block_size";
   private static final String MASTER_ADDRESSES_OPT = "kudu_master_addresses";
@@ -175,7 +174,7 @@ public class KuduYCSBClient extends com.yahoo.ycsb.DB {
     try {
       client.createTable(tableName, schema, builder);
     } catch (Exception e) {
-      if (!e.getMessage().contains("ALREADY_PRESENT")) {
+      if (!e.getMessage().contains("already exists")) {
         throw new DBException("Couldn't create the table", e);
       }
     }

--- a/kudu/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -1,5 +1,5 @@
-/*
- * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+/**
+ * Copyright (c) 2015-2016 YCSB contributors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You

--- a/kudu/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/kudu/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -16,7 +16,7 @@
  */
 
 /**
- * The YCSB binding for <a href="http://getkudu.io/">Kudu</a>.
+ * The YCSB binding for <a href="http://kudu.apache.org/">Apache Kudu</a>.
  */
 package com.yahoo.ycsb.db;
 

--- a/kudu/src/main/resources/log4j.properties
+++ b/kudu/src/main/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Root logger option
+log4j.rootLogger=DEBUG, stderr
+
+log4j.logger.com.stumbleupon.async=WARN
+log4j.logger.org.apache.kudu=WARN
+
+# Direct log messages to stderr
+log4j.appender.stderr = org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout = org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.ConversionPattern = [%p] %d{HH:mm:ss.SSS} (%F:%L) %m%n

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@ LICENSE file.
     <geode.version>1.0.0-incubating.M3</geode.version>
     <googlebigtable.version>0.2.3</googlebigtable.version>
     <infinispan.version>7.2.2.Final</infinispan.version>
-    <kudu.version>0.9.0</kudu.version>
+    <kudu.version>1.1.0</kudu.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>3.0.3</mongodb.version>


### PR DESCRIPTION
This updates Kudu to the latest released client version, improves table partitioning, and switches debug logging to use slf4j.  Further details are in the commit messages.