### PR TITLE
[core] Fix ycsb.sh and ycsb.bat missing core dependencies

### DIFF
--- a/bin/ycsb.bat
+++ b/bin/ycsb.bat
@@ -144,7 +144,11 @@ GOTO classpathComplete
 
 :gotSource
 @REM Check for some basic libraries to see if the source has been built.
-IF EXIST "%YCSB_HOME%\%BINDING_DIR%\target\*.jar" GOTO gotJars
+IF EXIST "%YCSB_HOME%\core\target\dependency\*.jar" (
+  IF EXIST "%YCSB_HOME%\%BINDING_DIR%\target\*.jar" (
+    GOTO gotJars
+  )
+)
 
 @REM Call mvn to build source checkout.
 IF "%BINDING_NAME%" == "basic" GOTO buildCore
@@ -155,7 +159,7 @@ SET MVN_PROJECT=core
 :gotMvnProject
 
 ECHO [WARN] YCSB libraries not found.  Attempting to build...
-CALL mvn -pl com.yahoo.ycsb:%MVN_PROJECT% -am package -DskipTests
+CALL mvn -Psource-run -pl com.yahoo.ycsb:%MVN_PROJECT% -am package -DskipTests
 IF %ERRORLEVEL% NEQ 0 (
   ECHO [ERROR] Error trying to build project. Exiting.
   GOTO exit
@@ -164,6 +168,11 @@ IF %ERRORLEVEL% NEQ 0 (
 :gotJars
 @REM Core libraries
 FOR %%F IN (%YCSB_HOME%\core\target\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Core dependency libraries
+FOR %%F IN (%YCSB_HOME%\core\target\dependency\*.jar) DO (
   SET CLASSPATH=!CLASSPATH!;%%F%
 )
 

--- a/bin/ycsb.sh
+++ b/bin/ycsb.sh
@@ -167,28 +167,31 @@ if $DISTRIBUTION; then
 # Source checkout
 else
   # Check for some basic libraries to see if the source has been built.
-  for f in "$YCSB_HOME"/"$BINDING_DIR"/target/*.jar ; do
-
+  if ! ls "$YCSB_HOME"/core/target/*.jar 1> /dev/null 2>&1 || \
+     ! ls "$YCSB_HOME"/"$BINDING_DIR"/target/*.jar 1>/dev/null 2>&1; then
     # Call mvn to build source checkout.
-    if [ ! -e "$f" ] ; then
-      if [ "$BINDING_NAME" = "basic" ] ; then
-        MVN_PROJECT=core
-      else
-        MVN_PROJECT="$BINDING_DIR"-binding
-      fi
-
-      echo "[WARN] YCSB libraries not found.  Attempting to build..."
-      mvn -pl com.yahoo.ycsb:"$MVN_PROJECT" -am package -DskipTests
-      if [ "$?" -ne 0 ] ; then
-        echo "[ERROR] Error trying to build project. Exiting."
-        exit 1;
-      fi
+    if [ "$BINDING_NAME" = "basic" ] ; then
+      MVN_PROJECT=core
+    else
+      MVN_PROJECT="$BINDING_DIR"-binding
     fi
 
-  done
+    echo "[WARN] YCSB libraries not found.  Attempting to build..."
+    if mvn -Psource-run -pl com.yahoo.ycsb:"$MVN_PROJECT" -am package -DskipTests; then
+      echo "[ERROR] Error trying to build project. Exiting."
+      exit 1;
+    fi
+  fi
 
   # Core libraries
   for f in "$YCSB_HOME"/core/target/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
+  done
+
+  # Core dependency libraries
+  for f in "$YCSB_HOME"/core/target/dependency/*.jar ; do
     if [ -r "$f" ] ; then
       CLASSPATH="$CLASSPATH:$f"
     fi
@@ -199,7 +202,6 @@ else
   if [ "x$CLASSPATH_CONF" != "x" ]; then
     CLASSPATH="$CLASSPATH$CLASSPATH_CONF"
   fi
-
 
   # Database libraries
   for f in "$YCSB_HOME"/"$BINDING_DIR"/target/*.jar ; do

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,6 +60,7 @@ LICENSE file.
       <version>2.1.4</version>
     </dependency>
   </dependencies>
+
   <build>
     <resources>
       <resource>
@@ -68,4 +69,31 @@ LICENSE file.
       </resource>
     </resources>
   </build>
+  
+  <profiles>
+    <profile>
+      <!-- Build profile when running via yscb.sh or yscb.bat-->
+      <id>source-run</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>stage-dependencies</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Fixes #877.

I don't know if this is the best way to solve this. Basically the core module's parent was root before. I made it binding parent so that it will pickup the necessary assembly plugin and create the lib directory. I'm not really familiar with Maven module parents and dependencies. 