### PR TITLE
[jdbc] Use `TEXT` for fields instead of VARCHAR

### DIFF
--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <br>
  * This interface expects a schema <key> <field1> <field2> <field3> ... All
- * attributes are of type VARCHAR. All accesses are through the primary key.
+ * attributes are of type TEXT. All accesses are through the primary key.
  * Therefore, only one index on the primary key is needed.
  */
 public class JdbcDBClient extends DB {

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBCreateTable.java
@@ -73,7 +73,7 @@ public final class JdbcDBCreateTable {
       for (int idx = 0; idx < fieldcount; idx++) {
         sql.append(", FIELD");
         sql.append(idx);
-        sql.append(" VARCHAR");
+        sql.append(" TEXT");
       }
       sql.append(");");
 


### PR DESCRIPTION
Supersedes PR #797. Updated JavaDocs