### PR TITLE
[cassandra-cql] Cassandra PreparedStatements... again

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -81,3 +81,7 @@ For keyspace `ycsb`, table `usertable`:
 * `cassandra.tracing`
   * Default is false
   * https://docs.datastax.com/en/cql/3.3/cql/cql_reference/tracing_r.html
+  
+* `readallfields`
+  * Default is true
+  * If you set `updateproportion>0`, please make sure `readallfileds=false`

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -389,11 +389,7 @@ public class CassandraCQLClient extends DB {
 
       for (ColumnDefinitions.Definition def : cd) {
         ByteBuffer val = row.getBytesUnsafe(def.getName());
-        if (val != null) {
-          result.put(def.getName(), new ByteArrayByteIterator(val.array()));
-        } else {
-          result.put(def.getName(), null);
-        }
+        result.put(def.getName(), val == null ? null : new ByteArrayByteIterator(val.array()));
       }
 
       return Status.OK;
@@ -476,11 +472,7 @@ public class CassandraCQLClient extends DB {
 
         for (ColumnDefinitions.Definition def : cd) {
           ByteBuffer val = row.getBytesUnsafe(def.getName());
-          if (val != null) {
-            tuple.put(def.getName(), new ByteArrayByteIterator(val.array()));
-          } else {
-            tuple.put(def.getName(), null);
-          }
+          tuple.put(def.getName(), val == null ? null : new ByteArrayByteIterator(val.array()));
         }
 
         result.add(tuple);

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -566,20 +566,15 @@ public class CassandraCQLClient extends DB {
   public Status delete(String table, String key) {
 
     try {
-      Statement stmt;
-
-      stmt = QueryBuilder.delete().from(table)
-          .where(QueryBuilder.eq(YCSB_KEY, key));
-      stmt.setConsistencyLevel(writeConsistencyLevel);
 
       if (debug) {
-        System.out.println(stmt.toString());
+        System.out.println(deleteStatement.getQueryString());
       }
       if (trace) {
-        stmt.enableTracing();
+        deleteStatement.enableTracing();
       }
       
-      session.execute(stmt);
+      session.execute(deleteStatement.bind(key));
 
       return Status.OK;
     } catch (Exception e) {

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -249,6 +249,9 @@ public class CassandraCQLClient extends DB {
             .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker()))
             .limit(1);
 
+        if (debug) {
+          System.out.printf("Preparing '%s'\n", selectOne.getQueryString());
+        }
         if (!singleSelectStatements.containsKey(field)) {
           PreparedStatement preparedSelect = session.prepare(selectOne);
           preparedSelect.setConsistencyLevel(readConsistencyLevel);
@@ -259,6 +262,9 @@ public class CassandraCQLClient extends DB {
         String initialScanStmt = QueryBuilder.select(field).from(table).toString();
         String scanOneStmt = getScanQueryString().replaceFirst("_",
             initialScanStmt.substring(0, initialScanStmt.length()-1));
+        if (debug) {
+          System.out.printf("Preparing '%s'\n", scanOneStmt);
+        }
         if (!singleScanStatements.containsKey(field)) {
           PreparedStatement preparedScan = session.prepare(scanOneStmt);
           preparedScan.setConsistencyLevel(readConsistencyLevel);
@@ -273,12 +279,17 @@ public class CassandraCQLClient extends DB {
     }
 
     // Prepare insert and update all
+    if (debug) {
+      System.out.printf("Preparing '%s'\n", is.getQueryString());
+    }
     insertStatement = session.prepare(is);
     insertStatement.setConsistencyLevel(writeConsistencyLevel);
 
     // Select All
     String ss = QueryBuilder.select().all().from(table)
             .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker())).getQueryString();
+    if (debug) {
+      System.out.printf("Preparing '%s'\n", ss);
     }
     selectStatement = session.prepare(ss);
     selectStatement.setConsistencyLevel(readConsistencyLevel);
@@ -287,12 +298,18 @@ public class CassandraCQLClient extends DB {
     String initialStmt = QueryBuilder.select().all().from(table).toString();
     String scanStmt = getScanQueryString().replaceFirst("_",
         initialStmt.substring(0, initialStmt.length()-1));
+    if (debug) {
+      System.out.printf("Preparing '%s'\n", scanStmt);
+    }
     scanStatement = session.prepare(scanStmt);
     scanStatement.setConsistencyLevel(readConsistencyLevel);
 
     // Delete on key statement
     String ds = QueryBuilder.delete().from(table)
         .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker())).toString();
+    if (debug) {
+      System.out.printf("Preparing '%s'\n", ds);
+    }
     deleteStatement = session.prepare(ds);
     deleteStatement.setConsistencyLevel(writeConsistencyLevel);
   }

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -452,7 +452,7 @@ public class CassandraCQLClient extends DB {
         ps = possibleStatements.get(statementHash);
       }
 
-      final BoundStatement bs = ps.bind(YCSB_KEY, startkey, recordcount);
+      final BoundStatement bs = ps.bind(startkey, recordcount);
 
       if (debug) {
         System.out.println(bs.preparedStatement().getQueryString());

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -252,6 +252,16 @@ public class CassandraCQLClient extends DB {
       // Insert and Update statement
       is.value(field, QueryBuilder.bindMarker());
 
+      // Update - single
+      Insert updateOneStmt = QueryBuilder.insertInto(table)
+          .values(
+              new String[] {YCSB_KEY, field},
+              new Object[] {QueryBuilder.bindMarker(), QueryBuilder.bindMarker()});
+
+      if (!updateStatements.containsKey(field)) {
+        updateStatements.put(field, prepare(updateOneStmt.getQueryString(), false));
+      }
+
       // Select and Scan few statements
       if (!readallfields) {
         // Select - single
@@ -270,16 +280,6 @@ public class CassandraCQLClient extends DB {
 
         if (!singleScanStatements.containsKey(field)) {
           singleScanStatements.put(field, prepare(scanOneStmt, true));
-        }
-
-        // Update - single
-        Insert updateOneStmt = QueryBuilder.insertInto(table)
-            .values(
-                new String[] {YCSB_KEY, field},
-                new Object[] {QueryBuilder.bindMarker(), QueryBuilder.bindMarker()});
-
-        if (!updateStatements.containsKey(field)) {
-          updateStatements.put(field, prepare(updateOneStmt.getQueryString(), false));
         }
 
         // Select and Scan many statements

--- a/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -35,10 +35,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -83,7 +80,6 @@ public class CassandraCQLClientTest {
     client.init();
 
     buildStatements();
-
   }
 
   private void buildStatements() {
@@ -112,7 +108,6 @@ public class CassandraCQLClientTest {
       Truncate truncate = QueryBuilder.truncate(TABLE);
       preparedTruncate = session.prepare(truncate);
     }
-
   }
 
   @After
@@ -128,7 +123,7 @@ public class CassandraCQLClientTest {
   @After
   public void clearTable() throws Exception {
     // Clear the table so that each test starts fresh.
-    if (cassandraUnit != null) {
+    if (cassandraUnit != null && cassandraUnit.getSession() != null) {
       cassandraUnit.getSession().execute(preparedTruncate.bind());
     }
   }
@@ -225,5 +220,29 @@ public class CassandraCQLClientTest {
     assertThat(rs.isExhausted(), is(true));
     assertThat(row.getString("field0"), is("value1"));
     assertThat(row.getString("field1"), is("value2"));
+  }
+
+  @Test
+  public void testScanAllPasses() throws Exception {
+    Set fields = null; // All the fields
+    Vector<HashMap<String, ByteIterator>> result = new Vector<>();
+    Status status = client.scan(TABLE, "non-existent", 1, fields, result);
+    assertThat(status, is(Status.OK));
+  }
+
+  @Test
+  public void testScanOnePasses() throws Exception {
+    Set fields = Sets.newHashSet("field1");
+    Vector<HashMap<String, ByteIterator>> result = new Vector<>();
+    Status status = client.scan(TABLE, "non-existent", 1, fields, result);
+    assertThat(status, is(Status.OK));
+  }
+
+  @Test
+  public void testScanMultiPasses() throws Exception {
+    Set fields = Sets.newHashSet("field1", "field2");
+    Vector<HashMap<String, ByteIterator>> result = new Vector<>();
+    Status status = client.scan(TABLE, "non-existent", 1, fields, result);
+    assertThat(status, is(Status.OK));
   }
 }

--- a/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra/src/test/java/com/yahoo/ycsb/db/CassandraCQLClientTest.java
@@ -130,7 +130,7 @@ public class CassandraCQLClientTest {
 
   @Test
   public void testReadMissingRow() throws Exception {
-    final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
+    final Map<String, ByteIterator> result = new HashMap<>();
     final Status status = client.read(TABLE, "Missing row", null, result);
     assertThat(result.size(), is(0));
     assertThat(status, is(Status.NOT_FOUND));
@@ -152,13 +152,13 @@ public class CassandraCQLClientTest {
   public void testRead() throws Exception {
     insertRow("value1", "value2");
 
-    final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
+    final Map<String, ByteIterator> result = new HashMap<>();
     final Status status = client.read(TABLE, DEFAULT_ROW_KEY, null, result);
     assertThat(status, is(Status.OK));
     assertThat(result.entrySet(), hasSize(11));
     assertThat(result, hasEntry("field2", null));
 
-    final HashMap<String, String> strResult = new HashMap<String, String>();
+    final Map<String, String> strResult = new HashMap<>();
     for (final Map.Entry<String, ByteIterator> e : result.entrySet()) {
       if (e.getValue() != null) {
         strResult.put(e.getKey(), e.getValue().toString());
@@ -173,7 +173,7 @@ public class CassandraCQLClientTest {
   public void testReadSingleColumn() throws Exception {
     insertRow("value1", "value2");
 
-    final HashMap<String, ByteIterator> result = new HashMap<String, ByteIterator>();
+    final Map<String, ByteIterator> result = new HashMap<>();
     final Set<String> fields = Sets.newHashSet("field1");
     final Status status = client.read(TABLE, DEFAULT_ROW_KEY, fields, result);
     assertThat(status, is(Status.OK));
@@ -185,7 +185,7 @@ public class CassandraCQLClientTest {
   @Test
   public void testUpdateOne() throws Exception {
     final String key = "key";
-    final HashMap<String, String> input = new HashMap<String, String>();
+    final Map<String, String> input = new HashMap<>();
     input.put("field0", "value1");
 
     final Status status = client.insert(TABLE, key, StringByteIterator.getByteIteratorMap(input));
@@ -204,7 +204,7 @@ public class CassandraCQLClientTest {
   @Test
   public void testUpdateTwo() throws Exception {
     final String key = "key";
-    final Map<String, String> input = new HashMap<String, String>();
+    final Map<String, String> input = new HashMap<>();
     input.put("field0", "value1");
     input.put("field1", "value2");
 


### PR DESCRIPTION
Requesting to pull changes from #929 which include some commits from #98 and addresses #458. 

Reviews are welcome. 

**Client**

- [X] `insert`
- [X] `update` (Correct me if I am wrong, `insert` is basically an `update` with just one key-value?)
- [X] `delete`
- [X] `scan` (one)
- [x] `read` (one)
- [X] <strike>`scan` (many)</strike>
- [X] <strike>`read` (many)</strike>

**Unit Tests**  
Assuming these should also use PreparedStatements

- [x] `insertRow`
- [x] `testUpdate` 
- [x] `testRead`