### PR TITLE
Change the write policy to REPLACE_ONLY

### DIFF
--- a/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
+++ b/aerospike/src/main/java/com/yahoo/ycsb/db/AerospikeClient.java
@@ -57,7 +57,7 @@ public class AerospikeClient extends com.yahoo.ycsb.DB {
   @Override
   public void init() throws DBException {
     insertPolicy.recordExistsAction = RecordExistsAction.CREATE_ONLY;
-    updatePolicy.recordExistsAction = RecordExistsAction.UPDATE_ONLY;
+    updatePolicy.recordExistsAction = RecordExistsAction.REPLACE_ONLY;
 
     Properties props = getProperties();
 


### PR DESCRIPTION
The original Aerospike interface layer was created when the REPLACE_ONLY option was not available.  This provides a policy more in line with the policies that other databases have implemented their interface layers.