### PR TITLE
[arangodb] Updated ArangoDB binding (Java driver 3.1.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@ LICENSE file.
     <aerospike.version>3.1.2</aerospike.version>
     <solr.version>5.5.3</solr.version>
     <solr6.version>6.4.1</solr6.version>
-    <arangodb.version>2.7.3</arangodb.version>
+    <arangodb.version>3.1.4</arangodb.version>
     <arangodb3.version>4.1.7</arangodb3.version>
     <azurestorage.version>4.0.0</azurestorage.version>
   </properties>


### PR DESCRIPTION
Updated arangodb-java-driver to 3.1.4. This version is only compatible with ArangoDB 3.1.0 and above.

This allows a better comparison between the http java-driver and the vst (VelocyStream) java-driver which is used within binding `arangodb3`.