### PR TITLE
[memcached] support binary protocol

### DIFF
--- a/memcached/README.md
+++ b/memcached/README.md
@@ -91,6 +91,10 @@ A sample configuration is provided in
   What to do with failures; this is one of `net.spy.memcached.FailureMode` enum
   values, which are currently: `Redistribute`, `Retry`, or `Cancel`.
 
+- `memcached.protocol`
+  Set to 'binary' to use memcached binary protocol. Set to 'text' or omit this field
+  to use memcached text protocol
+
 You can set properties on the command line via `-p`, e.g.:
 
     ./bin/ycsb load memcached -s -P workloads/workloada \

--- a/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
+++ b/memcached/src/main/java/com/yahoo/ycsb/db/MemcachedClient.java
@@ -98,6 +98,10 @@ public class MemcachedClient extends DB {
   public static final FailureMode FAILURE_MODE_PROPERTY_DEFAULT =
       FailureMode.Redistribute;
 
+  public static final String PROTOCOL_PROPERTY = "memcached.protocol";
+  public static final ConnectionFactoryBuilder.Protocol DEFAULT_PROTOCOL =
+      ConnectionFactoryBuilder.Protocol.TEXT;
+
   /**
    * The MemcachedClient implementation that will be used to communicate
    * with the memcached server.
@@ -141,6 +145,11 @@ public class MemcachedClient extends DB {
 
     connectionFactoryBuilder.setOpTimeout(Integer.parseInt(
         getProperties().getProperty(OP_TIMEOUT_PROPERTY, DEFAULT_OP_TIMEOUT)));
+
+    String protocolString = getProperties().getProperty(PROTOCOL_PROPERTY);
+    connectionFactoryBuilder.setProtocol(
+        protocolString == null ? DEFAULT_PROTOCOL
+                         : ConnectionFactoryBuilder.Protocol.valueOf(protocolString.toUpperCase()));
 
     String failureString = getProperties().getProperty(FAILURE_MODE_PROPERTY);
     connectionFactoryBuilder.setFailureMode(


### PR DESCRIPTION
Adding support for memcached binary protocol as described in
https://github.com/memcached/memcached/blob/master/doc/protocol.txt.

Protocol can be set via memcached.protocol property of YCSB memcached workload. if specified
protocol must be "binary" or "text". If unspecified text version is used.