### PR TITLE
[geode] Correcting the org.apache.geode.pdx.PdxSerializationException by sett…

### DIFF
--- a/geode/src/main/java/com/yahoo/ycsb/db/GeodeClient.java
+++ b/geode/src/main/java/com/yahoo/ycsb/db/GeodeClient.java
@@ -130,6 +130,7 @@ public class GeodeClient extends DB {
     } else if (locator != null) {
       ccf.addPoolLocator(locator.getHost().getCanonicalHostName(), locator.getPort());
     }
+    ccf.setPdxReadSerialized(true);
     cache = ccf.create();
   }
 


### PR DESCRIPTION
Setting the pdx read serialized to true in ycsb geode client to handle the org.apache.geode.pdx.PdxSerializationException.

The erroneous stack is as follows


org.apache.geode.cache.client.ServerOperationException: remote server on ampool-105(49920:loner):57486:9a05a493: org.apache.geode.pdx.PdxSerializationException: Could not create an instance of a class __GEMFIRE_JSON
at org.apache.geode.cache.client.internal.OpExecutorImpl.handleException(OpExecutorImpl.java:681)
at org.apache.geode.cache.client.internal.OpExecutorImpl.handleException(OpExecutorImpl.java:623)
at org.apache.geode.cache.client.internal.OpExecutorImpl.execute(OpExecutorImpl.java:167)
at org.apache.geode.cache.client.internal.OpExecutorImpl.execute(OpExecutorImpl.java:115)
at org.apache.geode.cache.client.internal.PoolImpl.execute(PoolImpl.java:737)
at org.apache.geode.cache.client.internal.GetOp.execute(GetOp.java:92)
at org.apache.geode.cache.client.internal.ServerRegionProxy.get(ServerRegionProxy.java:125)
at org.apache.geode.internal.cache.LocalRegion.findObjectInSystem(LocalRegion.java:2828)
at org.apache.geode.internal.cache.LocalRegion.nonTxnFindObject(LocalRegion.java:1479)
at org.apache.geode.internal.cache.LocalRegionDataView.findObject(LocalRegionDataView.java:175)
at org.apache.geode.internal.cache.LocalRegion.get(LocalRegion.java:1363)
at org.apache.geode.internal.cache.LocalRegion.get(LocalRegion.java:1296)
at org.apache.geode.internal.cache.LocalRegion.get(LocalRegion.java:1282)
at org.apache.geode.internal.cache.AbstractRegion.get(AbstractRegion.java:280)
at com.yahoo.ycsb.db.GeodeClient.read(GeodeClient.java:140)
at com.yahoo.ycsb.DBWrapper.read(DBWrapper.java:151)
at com.yahoo.ycsb.workloads.CoreWorkload.doTransactionRead(CoreWorkload.java:708)
at com.yahoo.ycsb.workloads.CoreWorkload.doTransaction(CoreWorkload.java:630)
at com.yahoo.ycsb.ClientThread.run(Client.java:458)
at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.geode.pdx.PdxSerializationException: Could not create an instance of a class __GEMFIRE_JSON
