### PR TITLE
export totalHistogram for optional HdrHistogram

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
@@ -19,6 +19,7 @@ package com.yahoo.ycsb.measurements;
 
 import com.yahoo.ycsb.measurements.exporter.MeasurementsExporter;
 import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramIterationValue;
 import org.HdrHistogram.HistogramLogWriter;
 import org.HdrHistogram.Recorder;
 
@@ -40,6 +41,7 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
   // we need one log per measurement histogram
   private final PrintStream log;
   private final HistogramLogWriter histogramLogWriter;
+  private final boolean 
 
   private final Recorder histogram;
   private Histogram totalHistogram;
@@ -112,6 +114,18 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
     }
 
     exportStatusCounts(exporter);
+
+    // also export totalHistogram
+    for (HistogramIterationValue v : totalHistogram.recordedValues()) {
+      int value;
+      if (v.getValueIteratedTo() > (long)Integer.MAX_VALUE) {
+        value = Integer.MAX_VALUE;
+      } else {
+        value = (int)v.getValueIteratedTo();
+      }
+
+      exporter.write(getName(), Integer.toString(value), (double)v.getCountAtValueIteratedTo());
+    }
   }
 
   /**


### PR DESCRIPTION
Try to make HdrHistogram  on par with Histogram in the export output. This PR is specifically addressing the issue: https://github.com/brianfrankcooper/YCSB/issues/976