### PR TITLE
updates to cloudspanner

### DIFF
--- a/cloudspanner/src/main/java/com/yahoo/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/com/yahoo/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -169,7 +169,7 @@ public class CloudSpannerClient extends DB {
     Runtime.getRuntime().addShutdownHook(new Thread("spannerShutdown") {
         @Override
         public void run() {
-          spanner.closeAsync();
+          spanner.close();
         }
       });
     return spanner;

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@ LICENSE file.
     <arangodb.version>2.7.3</arangodb.version>
     <arangodb3.version>4.1.7</arangodb3.version>
     <azurestorage.version>4.0.0</azurestorage.version>
-    <cloudspanner.version>0.9.3-beta</cloudspanner.version>
+    <cloudspanner.version>0.20.3-beta</cloudspanner.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Updated version of Google Cloud Spanner client to more recent version (0.20.3-beta) and fixed associated breaking change (closeAsync -> close).