### PR TITLE
[s3] S3Client could not estimate read perfomance correctly (#994)

### DIFF
--- a/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
+++ b/s3/src/main/java/com/yahoo/ycsb/db/S3Client.java
@@ -429,7 +429,11 @@ public class S3Client extends DB {
       // writing the stream to bytes and to results
       int sizeOfFile = (int)objectAndMetadata.getValue().getContentLength();
       byte[] inputStreamToByte = new byte[sizeOfFile];
-      objectData.read(inputStreamToByte, 0, sizeOfFile);
+      int len;
+      int offset = 0;
+      while ((len = objectData.read(inputStreamToByte, offset, sizeOfFile - offset)) > 0) {
+        offset += len;
+      }
       result.put(key, new ByteArrayByteIterator(inputStreamToByte));
       objectData.close();
       objectAndMetadata.getKey().close();


### PR DESCRIPTION
The S3Client does not read the whole object.

The problem is in the call "objectData.read(inputStreamToByte, 0, sizeOfFile)" inside readFromStorage method. This call is returning only the beginning of the object if the object is long enough.