### PR TITLE
[travis] get travis back to happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 
 install: mvn install -q -DskipTests=true
@@ -31,7 +30,8 @@ script: mvn test -q
 # Services to start for tests.
 services:
   - mongodb
-  - riak
+# temporarily disable riak. failing, docs offline.
+#  - riak
 
 
 # Use the Container based infrastructure.

--- a/asynchbase/pom.xml
+++ b/asynchbase/pom.xml
@@ -119,4 +119,17 @@ LICENSE file.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.20</version>
+        <configuration>
+          <argLine>-Xms4096m -Xms4096m</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -34,6 +34,9 @@ LICENSE file.
     <!-- For integration tests using ANT -->
     <integ.http.port>9400</integ.http.port>
     <integ.transport.port>9500</integ.transport.port>
+
+    <!-- If tests are skipped, skip ES spin up -->
+    <es.skip>${skipTests}</es.skip>
   </properties>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,26 @@ LICENSE file.
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.1.0</version>
+                </requireMavenVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>


### PR DESCRIPTION
* remove oracle jdk7 per travis-ci/travis-ci#7884
* stop ES test cluster spin-up during the install phase
* temporarily remove the riak service on travis
  - currently fails w/o details
  - http://docs.basho.com/ fails to load, so I can't spin up a test node locally.