### PR TITLE
[travis] Travis CI add oraclejdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@
 language: java
 
 jdk:
+  - oraclejdk9
   - oraclejdk8
   - openjdk7
 

--- a/accumulo/pom.xml
+++ b/accumulo/pom.xml
@@ -44,6 +44,12 @@ LICENSE file.
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>

--- a/hbase098/pom.xml
+++ b/hbase098/pom.xml
@@ -33,6 +33,12 @@ LICENSE file.
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
       <version>${hbase098.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@ LICENSE file.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.7.0</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -65,6 +65,12 @@ LICENSE file.
       <artifactId>solr-test-framework</artifactId>
       <version>${solr.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/solr6/pom.xml
+++ b/solr6/pom.xml
@@ -65,6 +65,12 @@ LICENSE file.
       <artifactId>solr-test-framework</artifactId>
       <version>${solr6.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Relates to #705 

I had to also:
* upgrade the `maven-compiler-plugin` to 3.6.2 or later
  * https://cwiki.apache.org/confluence/display/MAVEN/Java+9+-+Jigsaw
* Exclude `jdk.tools` from all Hadoop dependencies (especially transitive)
  * avoids `Could not find artifact jdk.tools:jdk.tools:jar:1.6 at specified path /usr/lib/jvm/java-9-oracle/../lib/tools.jar`