### PR TITLE
[scripts, core] cleanup bindings

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -55,7 +55,6 @@ infinispan-cs:com.yahoo.ycsb.db.InfinispanRemoteClient
 infinispan:com.yahoo.ycsb.db.InfinispanClient
 jdbc:com.yahoo.ycsb.db.JdbcDBClient
 kudu:com.yahoo.ycsb.db.KuduYCSBClient
-mapkeeper:com.yahoo.ycsb.db.MapKeeperClient
 memcached:com.yahoo.ycsb.db.MemcachedClient
 mongodb:com.yahoo.ycsb.db.MongoDbClient
 mongodb-async:com.yahoo.ycsb.db.AsyncMongoDbClient
@@ -69,5 +68,4 @@ s3:com.yahoo.ycsb.db.S3Client
 solr:com.yahoo.ycsb.db.solr.SolrClient
 solr6:com.yahoo.ycsb.db.solr6.SolrClient
 tarantool:com.yahoo.ycsb.db.TarantoolClient
-voldemort:com.yahoo.ycsb.db.VoldemortClient
 

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -80,7 +80,6 @@ DATABASES = {
     "infinispan"   : "com.yahoo.ycsb.db.InfinispanClient",
     "jdbc"         : "com.yahoo.ycsb.db.JdbcDBClient",
     "kudu"         : "com.yahoo.ycsb.db.KuduYCSBClient",
-    "mapkeeper"    : "com.yahoo.ycsb.db.MapKeeperClient",
     "memcached"    : "com.yahoo.ycsb.db.MemcachedClient",
     "mongodb"      : "com.yahoo.ycsb.db.MongoDbClient",
     "mongodb-async": "com.yahoo.ycsb.db.AsyncMongoDbClient",
@@ -94,7 +93,6 @@ DATABASES = {
     "solr"         : "com.yahoo.ycsb.db.solr.SolrClient",
     "solr6"        : "com.yahoo.ycsb.db.solr6.SolrClient",
     "tarantool"    : "com.yahoo.ycsb.db.TarantoolClient",
-    "voldemort"    : "com.yahoo.ycsb.db.VoldemortClient"
 }
 
 OPTIONS = {

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -91,6 +91,11 @@ LICENSE file.
     </dependency>
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
+      <artifactId>azuretablestorage-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.ycsb</groupId>
       <artifactId>dynamodb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,19 +109,19 @@ LICENSE file.
     <!-- our internals -->
     <module>core</module>
     <module>binding-parent</module>
+    <module>distribution</module>
     <!-- all the datastore bindings, lex sorted please -->
     <module>accumulo</module>
     <module>aerospike</module>
     <module>arangodb</module>
     <module>arangodb3</module>
     <module>asynchbase</module>
+    <module>azuredocumentdb</module>
     <module>azuretablestorage</module>
     <module>cassandra</module>
     <module>cloudspanner</module>
     <module>couchbase</module>
     <module>couchbase2</module>
-    <module>distribution</module>
-    <module>azuredocumentdb</module>
     <module>dynamodb</module>
     <module>elasticsearch</module>
     <module>elasticsearch5</module>


### PR DESCRIPTION
* remove mapkeeper and voldemort from command help, since we don't build them
* fix ordering of modules in root pom

closes #328