### PR TITLE
[cassandra] Update CassandraCQLClient to use PreparedStatement for better performance

### DIFF
--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -232,6 +232,14 @@ public class CassandraCQLClient extends DB {
     }
   }
 
+  /**
+   * Return a {@code PreparedStatement} for the given query from cache. If none is found, create
+   * a new one in cache and return it.
+   *
+   * @param query
+   *          The query to retrieve the {@code PreparedStatement} for
+   * @return The {@code PreparedStatement} for the query
+   */
   private PreparedStatement getPreparedStatement(String query) {
     PreparedStatement stmt = stmts.get(query);
     if (stmt == null) {

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -28,7 +28,6 @@ import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
@@ -268,7 +267,7 @@ public class CassandraCQLClient extends DB {
   public Status read(String table, String key, Set<String> fields,
       Map<String, ByteIterator> result) {
     try {
-      Statement stmt;
+      BoundStatement stmt;
       Select.Builder selectBuilder;
 
       if (fields == null) {
@@ -286,7 +285,7 @@ public class CassandraCQLClient extends DB {
       stmt.setConsistencyLevel(readConsistencyLevel);
 
       if (debug) {
-        System.out.println(((BoundStatement)stmt).preparedStatement().getQueryString());
+        System.out.println(stmt.preparedStatement().getQueryString());
       }
       if (trace) {
         stmt.enableTracing();
@@ -346,7 +345,7 @@ public class CassandraCQLClient extends DB {
       Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
 
     try {
-      Statement stmt;
+      BoundStatement stmt;
       Select.Builder selectBuilder;
 
       if (fields == null) {
@@ -358,11 +357,11 @@ public class CassandraCQLClient extends DB {
         }
       }
 
-      stmt = selectBuilder.from(table);
+      Select selectStmt = selectBuilder.from(table);
 
       // The statement builder is not setup right for tokens.
       // So, we need to build it manually.
-      String initialStmt = stmt.toString();
+      String initialStmt = selectStmt.toString();
       StringBuilder scanStmt = new StringBuilder();
       scanStmt.append(initialStmt.substring(0, initialStmt.length() - 1));
       scanStmt.append(" WHERE ");
@@ -378,7 +377,7 @@ public class CassandraCQLClient extends DB {
       stmt.setConsistencyLevel(readConsistencyLevel);
 
       if (debug) {
-        System.out.println(((BoundStatement)stmt).preparedStatement().getQueryString());
+        System.out.println(stmt.preparedStatement().getQueryString());
       }
       if (trace) {
         stmt.enableTracing();
@@ -450,12 +449,12 @@ public class CassandraCQLClient extends DB {
       updateStmt.where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker()));
       vars.add(key);
 
-      Statement stmt = getPreparedStatement(updateStmt.toString())
-                       .bind(vars.toArray(new Object[vars.size()]));
+      BoundStatement stmt = getPreparedStatement(updateStmt.toString())
+                            .bind(vars.toArray(new Object[vars.size()]));
       stmt.setConsistencyLevel(writeConsistencyLevel);
 
       if (debug) {
-        System.out.println(((BoundStatement)stmt).preparedStatement().getQueryString());
+        System.out.println(stmt.preparedStatement().getQueryString());
       }
       if (trace) {
         stmt.enableTracing();
@@ -506,12 +505,12 @@ public class CassandraCQLClient extends DB {
         vars.add(value);
       }
 
-      Statement stmt = getPreparedStatement(insertStmt.toString())
-                       .bind(vars.toArray(new Object[vars.size()]));
+      BoundStatement stmt = getPreparedStatement(insertStmt.toString())
+                            .bind(vars.toArray(new Object[vars.size()]));
       stmt.setConsistencyLevel(writeConsistencyLevel);
 
       if (debug) {
-        System.out.println(((BoundStatement)stmt).preparedStatement().getQueryString());
+        System.out.println(stmt.preparedStatement().getQueryString());
       }
       if (trace) {
         stmt.enableTracing();
@@ -540,7 +539,7 @@ public class CassandraCQLClient extends DB {
   public Status delete(String table, String key) {
 
     try {
-      Statement stmt;
+      BoundStatement stmt;
 
       stmt = getPreparedStatement(QueryBuilder.delete().from(table)
                                   .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker()))
@@ -548,7 +547,7 @@ public class CassandraCQLClient extends DB {
       stmt.setConsistencyLevel(writeConsistencyLevel);
 
       if (debug) {
-        System.out.println(((BoundStatement)stmt).preparedStatement().getQueryString());
+        System.out.println(stmt.preparedStatement().getQueryString());
       }
       if (trace) {
         stmt.enableTracing();

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.MessageFormatter;
 
 /**
  * Cassandra 2.x CQL client.
@@ -209,7 +210,7 @@ public class CassandraCQLClient extends DB {
         }
 
         Metadata metadata = cluster.getMetadata();
-        logger.error("Connected to cluster: {}\n",
+        logger.info("Connected to cluster: {}\n",
             metadata.getClusterName());
 
         for (Host discoveredHost : metadata.getAllHosts()) {
@@ -329,8 +330,7 @@ public class CassandraCQLClient extends DB {
       return Status.OK;
 
     } catch (Exception e) {
-      e.printStackTrace();
-      logger.error("Error reading key: {}", key);
+      logger.error(MessageFormatter.format("Error reading key: {}", key).getMessage(), e);
       return Status.ERROR;
     }
 
@@ -433,8 +433,8 @@ public class CassandraCQLClient extends DB {
       return Status.OK;
 
     } catch (Exception e) {
-      e.printStackTrace();
-      logger.error("Error scanning with startkey: {}", startkey);
+      logger.error(
+          MessageFormatter.format("Error scanning with startkey: {}", startkey).getMessage(), e);
       return Status.ERROR;
     }
 
@@ -506,7 +506,7 @@ public class CassandraCQLClient extends DB {
 
       return Status.OK;
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error(MessageFormatter.format("Error updating key: {}", key).getMessage(), e);
     }
 
     return Status.ERROR;
@@ -577,7 +577,7 @@ public class CassandraCQLClient extends DB {
 
       return Status.OK;
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error(MessageFormatter.format("Error inserting key: {}", key).getMessage(), e);
     }
 
     return Status.ERROR;
@@ -620,8 +620,7 @@ public class CassandraCQLClient extends DB {
 
       return Status.OK;
     } catch (Exception e) {
-      e.printStackTrace();
-      logger.error("Error deleting key: {}", key);
+      logger.error(MessageFormatter.format("Error deleting key: {}", key).getMessage(), e);
     }
 
     return Status.ERROR;

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -214,9 +214,9 @@ public class CassandraCQLClient extends DB {
             metadata.getClusterName());
 
         for (Host discoveredHost : metadata.getAllHosts()) {
-          logger.info("Datacenter: {}; Host: {}; Rack: {}\n", new Object[] {
+          logger.info("Datacenter: {}; Host: {}; Rack: {}\n",
               discoveredHost.getDatacenter(), discoveredHost.getAddress(),
-              discoveredHost.getRack() });
+              discoveredHost.getRack());
         }
 
         session = cluster.connect(keyspace);


### PR DESCRIPTION
Addressing issue #458. The PreparedStatement is created and cached following the same approach as in JdbcDBClient. Here are the numbers before and after the use of PreparedStatement:

Apache Cassandra version: 3.11.1, replication_factor = 3, QUORUM consistency level
Server: 3-node Google Cloud Platform (GCP) n1-standard-16 machine, 16 VCPU's, 60GB memory, 2 x 375 GB direct attached SSD
YCSB parameter: recordcount=1000000, operationcount=10000000, maxexecutiontime=90

**Before:**
Workload   : Throughput(ops/sec) - OpType & AverageLatency(us)
workload a : 64956.256567473 - [READ]: 4282.700504426243 [UPDATE]: 3346.0443676539962
workload b : 63345.63794747335 - [READ]: 3949.758514786955 [UPDATE]: 3189.5031351661996
workload c : 64365.03672249063 - [READ]: 3849.324261325788
workload d : 66134.2080457653 - [READ]: 3777.5643821626963 [INSERT]: 3162.619993576045
workload e : 7939.354223757893 - [INSERT]: 16607.25331648768 [SCAN]: 31967.764074558985
workload f : 42042.92384862897 - [READ]: 4218.613333769682 [READ-MODIFY-WRITE]: 7568.5240789843865 [UPDATE]: 3351.4569375155224

**After:**
Workload   : Throughput(ops/sec) - OpType & AverageLatency(us)
workload a : 74710.34153952844 - [READ]: 3762.9415808058598 [UPDATE]: 2873.006871596396
workload b : 70607.19238937287 - [READ]: 3542.8850799849365 [UPDATE]: 2852.0433860133608
workload c : 72872.62719944527 - [READ]: 3399.9530996221742
workload d : 80464.90059049785 - [READ]: 3111.0480158195774 [INSERT]: 2492.7417853628635
workload e : 8376.560197625033 - [INSERT]: 15429.41884128906 [SCAN]: 30362.55064932235
workload f : 43846.903949293024 - [READ]: 4074.0924531425676 [READ-MODIFY-WRITE]: 7230.656645026845 [UPDATE]: 3152.440234449529

Also changed the update() method to use Cassandra UPDATE statement. While it may not matter to YCSB, there are subtle semantic and on-disk differences between INSERT and UPDATE statements so changing to use the statement type that matches the action taken.

Suggestions and comments are welcome.