### PR TITLE
[geode] Ensure geode client will work with v1.3 by removing references to internal classes

### DIFF
--- a/geode/README.md
+++ b/geode/README.md
@@ -17,11 +17,11 @@ LICENSE file.
 
 ## Quick Start
 
-This section describes how to run YCSB on Apache Geode (incubating).
+This section describes how to run YCSB on Apache Geode.
 
 ### Get Apache Geode
 
-You can download Geode from http://geode.incubator.apache.org/releases/
+You can download Geode from https://geode.apache.org/releases/
 
 #### Start Geode Cluster
 
@@ -63,6 +63,10 @@ In the default mode, ycsb geode driver will connect as a client to the geode
 cluster. To make the ycsb driver a peer member of the distributed system
 use the property
 `-p geode.topology=p2p -p geode.locator=host[port]`
+
+YCSB uses geode 1.2.0, which should be compatible with all later
+versions of the geode server. To make YCSB run with a different version of the
+geode client, you can change the geode.version property in pom.xml.
 
 Note:
 For update workloads, please use the property `-p writeallfields=true`

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ LICENSE file.
     <accumulo.1.7.version>1.7.3</accumulo.1.7.version>
     <accumulo.1.8.version>1.8.1</accumulo.1.8.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <geode.version>1.2.0</geode.version>
+    <geode.version>1.3.0</geode.version>
     <azuredocumentdb.version>1.8.1</azuredocumentdb.version>
     <googlebigtable.version>0.9.7</googlebigtable.version>
     <infinispan.version>7.2.2.Final</infinispan.version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@ LICENSE file.
     <couchbase.version>1.4.10</couchbase.version>
     <couchbase2.version>2.3.1</couchbase2.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
-    <geode.version>1.3.0</geode.version>
+    <geode.version>1.2.0</geode.version>
     <googlebigtable.version>0.9.7</googlebigtable.version>
     <hbase098.version>0.98.14-hadoop2</hbase098.version>
     <hbase10.version>1.0.2</hbase10.version>


### PR DESCRIPTION
Geode 1.3 changed some of it's internals. The geode binding was using an
internal Geode class which means it won't compile against later versions
of geode.