### PR TITLE
Redis cluster support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ LICENSE file.
     <mongodb.version>3.0.3</mongodb.version>
     <mongodb.async.version>2.0.1</mongodb.async.version>
     <orientdb.version>2.2.10</orientdb.version>
-    <redis.version>2.0.0</redis.version>
+    <redis.version>2.9.0</redis.version>
     <s3.version>1.10.20</s3.version>
     <voldemort.version>0.81</voldemort.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/redis/README.md
+++ b/redis/README.md
@@ -33,12 +33,15 @@ Git clone YCSB and compile:
 
 ### 4. Provide Redis Connection Parameters
     
-Set the host, port, and password (do not redis auth is not turned on) in the 
-workload you plan to run.
+Set host, port, password, and cluster mode in the workload you plan to run. 
 
 - `redis.host`
 - `redis.port`
 - `redis.password`
+  * Don't set the password if redis auth is disabled.
+- `redis.cluster`
+  * Set the cluster parameter to `true` if redis cluster mode is enabled.
+  * Default is `false`.
 
 Or, you can set configs with the shell command, EG:
 


### PR DESCRIPTION
I suggest to integrate support for Redis clusters with this pull request. A new boolean parameter `redis.cluster` is introduced to control if Redis is running in cluster mode or not.