### PR TITLE
[core] Address another issue from #981 by adding "measurement.histogr…

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHistogram.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHistogram.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 public class OneMeasurementHistogram extends OneMeasurement {
   public static final String BUCKETS = "histogram.buckets";
   public static final String BUCKETS_DEFAULT = "1000";
+  public static final String VERBOSE_PROPERTY = "measurement.histogram.verbose";
 
   /**
    * Specify the range of latencies to track in the histogram.
@@ -64,6 +65,11 @@ public class OneMeasurementHistogram extends OneMeasurement {
    */
   private double totalsquaredlatency;
 
+  /**
+   * Whether or not to emit the histogram buckets.
+   */
+  private final boolean verbose;
+  
   //keep a windowed version of these stats for printing status
   private long windowoperations;
   private long windowtotallatency;
@@ -74,6 +80,7 @@ public class OneMeasurementHistogram extends OneMeasurement {
   public OneMeasurementHistogram(String name, Properties props) {
     super(name);
     buckets = Integer.parseInt(props.getProperty(BUCKETS, BUCKETS_DEFAULT));
+    verbose = Boolean.valueOf(props.getProperty(VERBOSE_PROPERTY, String.valueOf(false)));
     histogram = new long[buckets];
     histogramoverflow = 0;
     operations = 0;
@@ -136,10 +143,13 @@ public class OneMeasurementHistogram extends OneMeasurement {
 
     exportStatusCounts(exporter);
 
-    for (int i = 0; i < buckets; i++) {
-      exporter.write(getName(), Integer.toString(i), histogram[i]);
+    if (verbose) {
+      for (int i = 0; i < buckets; i++) {
+        exporter.write(getName(), Integer.toString(i), histogram[i]);
+      }
+      
+      exporter.write(getName(), ">" + buckets, histogramoverflow);
     }
-    exporter.write(getName(), ">" + buckets, histogramoverflow);
   }
 
   @Override

--- a/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
+++ b/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
@@ -18,6 +18,8 @@ package com.yahoo.ycsb.measurements.exporter;
 
 import com.yahoo.ycsb.generator.ZipfianGenerator;
 import com.yahoo.ycsb.measurements.Measurements;
+import com.yahoo.ycsb.measurements.OneMeasurementHistogram;
+
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.testng.annotations.Test;
@@ -34,6 +36,7 @@ public class TestMeasurementsExporter {
     public void testJSONArrayMeasurementsExporter() throws IOException {
         Properties props = new Properties();
         props.put(Measurements.MEASUREMENT_TYPE_PROPERTY, "histogram");
+        props.put(OneMeasurementHistogram.VERBOSE_PROPERTY, "true");
         Measurements mm = new Measurements(props);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         JSONArrayMeasurementsExporter export = new JSONArrayMeasurementsExporter(out);

--- a/workloads/workload_template
+++ b/workloads/workload_template
@@ -133,6 +133,10 @@ measurementtype=histogram
 # a new output file will be created.
 #measurement.raw.output_file = /tmp/your_output_file_for_this_run
 
+# Whether or not to emit individual histogram buckets when measuring
+# using histograms.
+# measurement.histogram.verbose = false
+
 # JVM Reporting.
 #
 # Measure JVM information over time including GC counts, max and min memory


### PR DESCRIPTION
…am.verbose" as

a configuration option to print out the histogram buckets and default to NOT printing
out the buckets.