### PR TITLE
[core][timeseries] Fix timestamp generation when one tag with cardinality one.

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/workloads/TimeSeriesWorkload.java
+++ b/core/src/main/java/com/yahoo/ycsb/workloads/TimeSeriesWorkload.java
@@ -1252,7 +1252,7 @@ public class TimeSeriesWorkload extends Workload {
         boolean tagRollover = false;
         for (int i = tagCardinality.length - 1; i >= 0; --i) {
           if (tagCardinality[i] <= 1) {
-            // nothing to increment here
+            tagRollover = true; // Only one tag so needs roll over.
             continue;
           }
           

--- a/core/src/test/java/com/yahoo/ycsb/workloads/TestTimeSeriesWorkload.java
+++ b/core/src/test/java/com/yahoo/ycsb/workloads/TestTimeSeriesWorkload.java
@@ -128,6 +128,33 @@ public class TestTimeSeriesWorkload {
     final MockDB db = new MockDB();
     wl.doInsert(db, null);
   }
+
+  @Test
+  public void insertOneKeyOneTagCardinalityOne() throws Exception {
+    final Properties p = getUTProperties();
+    p.put(CoreWorkload.FIELD_COUNT_PROPERTY, "1");
+    p.put(TimeSeriesWorkload.TAG_COUNT_PROPERTY, "1");
+    p.put(TimeSeriesWorkload.TAG_CARDINALITY_PROPERTY, "1");
+    final TimeSeriesWorkload wl = getWorkload(p, true);
+    final Object threadState = wl.initThread(p, 0, 1);
+
+    final MockDB db = new MockDB();
+    for (int i = 0; i < 74; i++) {
+      assertTrue(wl.doInsert(db, threadState));
+    }
+    assertEquals(db.keys.size(), 74);
+    assertEquals(db.values.size(), 74);
+    long timestamp = 1451606400;
+    for (int i = 0; i < db.keys.size(); i++) {
+      assertEquals(db.keys.get(i), "AAAA");
+      assertEquals(db.values.get(i).get("AA").toString(), "AAAA");
+      assertEquals(Utils.bytesToLong(db.values.get(i).get(
+          TimeSeriesWorkload.TIMESTAMP_KEY_PROPERTY_DEFAULT).toArray()), timestamp);
+      assertTrue(((NumericByteIterator) db.values.get(i)
+          .get(TimeSeriesWorkload.VALUE_KEY_PROPERTY_DEFAULT)).isFloatingPoint());
+      timestamp += 60;
+    }
+  }
   
   @Test
   public void insertOneKeyTwoTagsLowCardinality() throws Exception {


### PR DESCRIPTION
When the TimeSeriesWorkload was run with fieldcount=1 and tagcount=1 and tagcardinality=1 the data generated always had the same timestamp. This commit fixes this behavior by forcing a tag rollover when there is only one tag.