### PR TITLE
[core] Fixed absence of dependencies when running after building.

### DIFF
--- a/bin/ycsb.bat
+++ b/bin/ycsb.bat
@@ -1,5 +1,5 @@
 @REM
-@REM Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+@REM Copyright (c) 2012 - 2018 YCSB contributors. All rights reserved.
 @REM
 @REM Licensed under the Apache License, Version 2.0 (the "License"); you
 @REM may not use this file except in compliance with the License. You
@@ -175,6 +175,11 @@ IF %ERRORLEVEL% NEQ 0 (
 :gotJars
 @REM Core libraries
 FOR %%F IN (%YCSB_HOME%\core\target\*.jar) DO (
+  SET CLASSPATH=!CLASSPATH!;%%F%
+)
+
+@REM Core dependency libraries
+FOR %%F IN (%YCSB_HOME%\core\target\dependency\*.jar) DO (
   SET CLASSPATH=!CLASSPATH!;%%F%
 )
 

--- a/bin/ycsb.sh
+++ b/bin/ycsb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+# Copyright (c) 2012 - 2018 YCSB contributors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License. You
@@ -206,6 +206,13 @@ else
 
   # Core libraries
   for f in "$YCSB_HOME"/core/target/*.jar ; do
+    if [ -r "$f" ] ; then
+      CLASSPATH="$CLASSPATH:$f"
+    fi
+  done
+
+  # Core dependency libraries
+  for f in "$YCSB_HOME"/core/target/dependency/*.jar ; do
     if [ -r "$f" ] ; then
       CLASSPATH="$CLASSPATH:$f"
     fi

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2018 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -61,6 +61,24 @@ LICENSE file.
     </dependency>
   </dependencies>
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>stage-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
     <resources>
       <resource>
         <directory>src/main/resources</directory>


### PR DESCRIPTION
Solves the problem mentioned in #1105.

As I am on a Unix machine the changes to the `ycsb.bat` file are not tested. 
I just copied the few lines above and changed the directory to look for the dependencies.