### PR TITLE
Some mesurement typo ammendments

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/Measurements.java
@@ -133,8 +133,9 @@ public class Measurements {
           new OneMeasurementHistogram("Bucket" + name, props));
     case HDRHISTOGRAM_AND_RAW:
       return new TwoInOneMeasurement(name,
-          new OneMeasurementHdrHistogram("Hdr" + name, props),
-          new OneMeasurementRaw("Raw" + name, props));
+          new OneMeasurementRaw("Raw" + name, props), // Raw first, to timestamp requests
+          new OneMeasurementHdrHistogram("Hdr" + name, props)
+      );
     case TIMESERIES:
       return new OneMeasurementTimeSeries(name, props);
     case RAW:

--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurement.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurement.java
@@ -32,6 +32,7 @@ public abstract class OneMeasurement {
 
   private final String name;
   private final ConcurrentHashMap<Status, AtomicInteger> returncodes;
+  protected final long startTime;
 
   public String getName() {
     return name;
@@ -43,6 +44,7 @@ public abstract class OneMeasurement {
   public OneMeasurement(String name) {
     this.name = name;
     this.returncodes = new ConcurrentHashMap<>();
+    this.startTime = System.currentTimeMillis();
   }
 
   public abstract void measure(int latency);

--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHdrHistogram.java
@@ -95,6 +95,11 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
    */
   @Override
   public void exportMeasurements(MeasurementsExporter exporter) throws IOException {
+    long totalDurationMs = System.currentTimeMillis() - startTime;
+    // avoid division by zero
+    if (totalDurationMs == 0) { 
+      totalDurationMs = 1; 
+    }
     // accumulate the last interval which was not caught by status thread
     Histogram intervalHistogram = getIntervalHistogramAndAccumulate();
     if (histogramLogWriter != null) {
@@ -103,6 +108,8 @@ public class OneMeasurementHdrHistogram extends OneMeasurement {
       log.close();
     }
     exporter.write(getName(), "Operations", totalHistogram.getTotalCount());
+    float rps = totalHistogram.getTotalCount() / ((float)totalDurationMs / 1000);
+    exporter.write(getName(), "Throughput(ops/s)", rps);
     exporter.write(getName(), "AverageLatency(us)", totalHistogram.getMean());
     exporter.write(getName(), "MinLatency(us)", totalHistogram.getMinValue());
     exporter.write(getName(), "MaxLatency(us)", totalHistogram.getMaxValue());

--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHistogram.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementHistogram.java
@@ -112,9 +112,16 @@ public class OneMeasurementHistogram extends OneMeasurement {
 
   @Override
   public void exportMeasurements(MeasurementsExporter exporter) throws IOException {
+    long totalDurationMs = System.currentTimeMillis() - startTime;
+    // avoid division by zero
+    if (totalDurationMs == 0) { 
+      totalDurationMs = 1; 
+    }
     double mean = totallatency / ((double) operations);
     double variance = totalsquaredlatency / ((double) operations) - (mean * mean);
     exporter.write(getName(), "Operations", operations);
+    float rps = operations / ((float) totalDurationMs / 1000);
+    exporter.write(getName(), "Throughput(ops/s)", rps);
     exporter.write(getName(), "AverageLatency(us)", mean);
     exporter.write(getName(), "LatencyVariance(us)", variance);
     exporter.write(getName(), "MinLatency(us)", min);

--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementRaw.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementRaw.java
@@ -141,9 +141,13 @@ public class OneMeasurementRaw extends OneMeasurement {
   @Override
   public void exportMeasurements(MeasurementsExporter exporter)
       throws IOException {
+    long totalDurationMs = System.currentTimeMillis() - startTime;
+    // avoid division by zero
+    if (totalDurationMs == 0) { 
+      totalDurationMs = 1; 
+    }
     // Output raw data points first then print out a summary of percentiles to
     // stdout.
-
     outputStream.println(getName() +
         " latency raw data: op, timestamp(ms), latency(us)");
     for (RawDataPoint point : measurements) {
@@ -157,6 +161,8 @@ public class OneMeasurementRaw extends OneMeasurement {
 
     int totalOps = measurements.size();
     exporter.write(getName(), "Total Operations", totalOps);
+    float rps = totalOps / ((float)totalDurationMs / 1000);
+    exporter.write(getName(), "Throughput(ops/s)", rps);
     if (totalOps > 0 && !noSummaryStats) {
       exporter.write(getName(),
           "Below is a summary of latency in microseconds:", -1);

--- a/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementTimeSeries.java
+++ b/core/src/main/java/com/yahoo/ycsb/measurements/OneMeasurementTimeSeries.java
@@ -117,8 +117,14 @@ public class OneMeasurementTimeSeries extends OneMeasurement {
   @Override
   public void exportMeasurements(MeasurementsExporter exporter) throws IOException {
     checkEndOfUnit(true);
-
+    long totalDurationMs = System.currentTimeMillis() - startTime;
+    // avoid division by zero
+    if (totalDurationMs == 0) { 
+      totalDurationMs = 1; 
+    }
     exporter.write(getName(), "Operations", operations);
+    float rps = operations / ((float)totalDurationMs / 1000);
+    exporter.write(getName(), "Throughput(ops/s)", rps);
     exporter.write(getName(), "AverageLatency(us)", (((double) totallatency) / ((double) operations)));
     exporter.write(getName(), "MinLatency(us)", min);
     exporter.write(getName(), "MaxLatency(us)", max);

--- a/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
+++ b/core/src/test/java/com/yahoo/ycsb/measurements/exporter/TestMeasurementsExporter.java
@@ -52,7 +52,7 @@ public class TestMeasurementsExporter {
         JsonNode  json = mapper.readTree(out.toString("UTF-8"));
         assertTrue(json.isArray());
         assertEquals(json.get(0).get("measurement").asText(), "Operations");
-        assertEquals(json.get(4).get("measurement").asText(), "MaxLatency(us)");
-        assertEquals(json.get(11).get("measurement").asText(), "4");
+        assertEquals(json.get(5).get("measurement").asText(), "MaxLatency(us)");
+        assertEquals(json.get(12).get("measurement").asText(), "4");
     }
 }


### PR DESCRIPTION
Add throughput calculation for each measurement.

Optimize Raw+Hdr measurement to first use raw (for more accurate timestamping)