### PR TITLE
Update Bigtable client version to 1.3.0 (latest).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ LICENSE file.
     <couchbase2.version>2.3.1</couchbase2.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
     <geode.version>1.2.0</geode.version>
-    <googlebigtable.version>1.0.0</googlebigtable.version>
+    <googlebigtable.version>1.3.0</googlebigtable.version>
     <hbase098.version>0.98.14-hadoop2</hbase098.version>
     <hbase10.version>1.0.2</hbase10.version>
     <hbase12.version>1.2.5</hbase12.version>


### PR DESCRIPTION
@sduskis, @igorbernstein2 — please review and let me know if you have any thoughts on this.