### PR TITLE
[jdbc] support JDBC option to rewrite batch statement to multi-row in…

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -106,3 +106,25 @@ db.batchsize=1000             # The number of rows to be batched before commit (
 ```
 
 Please refer to https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties for all other YCSB core properties.
+
+## JDBC Parameter to Improve Insert Performance
+
+Some JDBC drivers support re-writing batched insert statements into multi-row insert statements. This technique can yield order of magnitude improvement in insert statement performance. To enable this feature:
+- **db.batchsize** must be greater than 0.  The magniute of the improvement can be adjusted by varying **batchsize**. Start with a small number and increase at small increments until diminishing return in the improvement is observed. 
+- set **jdbc.batchupdateapi=true** to enable batching.
+- set JDBC driver specific connection parameter in **db.url** to enable the rewrite as shown in the examples below:
+  * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html)
+
+    ```
+db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true
+```
+  * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters)
+
+    ```
+db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true
+```
+
+
+
+
+

--- a/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/com/yahoo/ycsb/db/JdbcDBClient.java
@@ -421,7 +421,8 @@ public class JdbcDBClient extends DB {
           if (++numRowsInBatch % batchSize == 0) {
             int[] results = insertStatement.executeBatch();
             for (int r : results) {
-              if (r != 1) {
+              // Acceptable values are 1 and SUCCESS_NO_INFO (-2) from reWriteBatchedInserts=true
+              if (r != 1 && r != -2) { 
                 return Status.ERROR;
               }
             }


### PR DESCRIPTION
batch statement int[] results = insertStatement.executeBatch() returns 1 for successful completion. when the batch statement is re-written to multi-row insert, SUCCESS_NO_INFO (-2) is returned instead. This change expands allowable results values to be 1 AND -2

Comparison of CockroachDB, MariaDB, Postgres was run to validate batchrewrite does provide performance improvements.  **NOTE**:  No attempts have been made to get optimal performance of each databases.  Relative performance gains from each technique -- no batch, batch, batch rewritten to multi-row inserts -- are demonstrated.   

All tests were performed on the same single MacBook
- CockroachDB v2.1.0-alpha.20180730 runs default serializable isolation with 3 way replicas.
- MariaDB 10.3.8-MariaDB Homebrew runs default REPEATABLE-READ
- Postgres 10.5 runs default read committed

Below summarizes Throughput(ops/sec) loading 100,000 rows.

database | nobatch | batch | batchrewrite
-- | -- | -- | --
cockraochdb | 339 | 495 | 3859
mariadb | 998 | 563 | 4154
postgres | 2137 | 8140 | 9254


- CockroachDB

```
cockroach sql --insecure -e "truncate usertable"

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=false -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar >  cockraochdb.nobatch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar > cockraochdb.batch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar  > cockraochdb.batchrewrite.log
```

- MariaDB

```
mysql -u root -D ycsb -e "truncate usertable"

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=com.mysql.jdbc.Driver -p db.url="jdbc:mysql://localhost/ycsb" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=false -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/mysql-connector-java-5.1.47.jar > mariadb.nobatch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=com.mysql.jdbc.Driver -p db.url="jdbc:mysql://localhost/ycsb" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/mysql-connector-java-5.1.47.jar > mariadb.batch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=com.mysql.jdbc.Driver -p db.url="jdbc:mysql://localhost/ycsb?rewriteBatchedStatements=true" -p db.user=root -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/mysql-connector-java-5.1.47.jar > mariadb.batchrewrite.log 
```

- Postgres

```
psql -U postgres -c "truncate usertable"

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1/?autoReconnect=true&sslmode=disable&ssl=false" -p db.user=postgres -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=false -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar > postgres.nobatch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1/?autoReconnect=true&sslmode=disable&ssl=false" -p db.user=postgres -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar > postgres.batch.log

bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1/?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true" -p db.user=postgres -p db.passwd="" -p db.batchsize=1000  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=1000 -p recordcount=100000 -cp ~/Downloads/postgresql-42.2.4.jar > postgres.batchrewrite.log
```

Logs of each runs below:

[cockraochdb.batch.log](https://github.com/brianfrankcooper/YCSB/files/2320715/cockraochdb.batch.log)
[cockraochdb.batchrewrite.log](https://github.com/brianfrankcooper/YCSB/files/2320716/cockraochdb.batchrewrite.log)
[cockraochdb.nobatch.log](https://github.com/brianfrankcooper/YCSB/files/2320717/cockraochdb.nobatch.log)
[mariadb.batch.log](https://github.com/brianfrankcooper/YCSB/files/2320718/mariadb.batch.log)
[mariadb.batchrewrite.log](https://github.com/brianfrankcooper/YCSB/files/2320719/mariadb.batchrewrite.log)
[mariadb.nobatch.log](https://github.com/brianfrankcooper/YCSB/files/2320720/mariadb.nobatch.log)
[postgres.batch.log](https://github.com/brianfrankcooper/YCSB/files/2320721/postgres.batch.log)
[postgres.batchrewrite.log](https://github.com/brianfrankcooper/YCSB/files/2320722/postgres.batchrewrite.log)
[postgres.nobatch.log](https://github.com/brianfrankcooper/YCSB/files/2320723/postgres.nobatch.log)
