### PR TITLE
[travis] drop deprecated oracle JDKs, add openjdk versions for jdk8 and jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@
 language: java
 
 jdk:
+  - openjdk8
+  - openjdk11
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk10
   - oraclejdk11
 
 addons:


### PR DESCRIPTION
we'll try running openjdk an oraclejdk in parallel for a bit, and we don't see any differences just switch to openjdk entirely.