### PR TITLE
[hbase20] fix package in bindings

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -54,7 +54,7 @@ hbase098:com.yahoo.ycsb.db.HBaseClient
 hbase10:com.yahoo.ycsb.db.HBaseClient10
 hbase12:com.yahoo.ycsb.db.hbase12.HBaseClient12
 hbase14:com.yahoo.ycsb.db.hbase14.HBaseClient14
-hbase20:com.yahoo.ycsb.db.hbase14.HBaseClient20
+hbase20:com.yahoo.ycsb.db.hbase20.HBaseClient20
 hypertable:com.yahoo.ycsb.db.HypertableClient
 ignite:com.yahoo.ycsb.db.ignite.IgniteClient
 ignite-sql:com.yahoo.ycsb.db.ignite.IgniteSqlClient


### PR DESCRIPTION
Was set to `com.yahoo.ycsb.db.hbase14` package instead of `com.yahoo.ycsb.db.hbase20`.