### PR TITLE
[hbase098] document the client side buffering config.

### DIFF
--- a/hbase098/README.md
+++ b/hbase098/README.md
@@ -76,6 +76,7 @@ Following options can be configurable using `-p`.
 * `principal`: If testing need to be done against a secure HBase cluster using Kerberos Keytab, 
   this property can be used to pass the principal in the keytab file.
 * `keytab`: The Kerberos keytab file name and location can be passed through this property.
-* `writebuffersize`: The maximum amount, in bytes, of data to buffer on the client side before a flush is forced. The default is 12MB.
+* `clientbuffering`: Whether or not to use client side buffering and batching of write operations. This can significantly improve performance and defaults to true.
+* `writebuffersize`: The maximum amount, in bytes, of data to buffer on the client side before a flush is forced. The default is 12MB. Only used when `clientbuffering` is true.
 
 Additional HBase settings should be provided in the `hbase-site.xml` file located in your `/HBASE-HOME-DIR/conf` directory. Typically this will be `/etc/hbase/conf`.


### PR DESCRIPTION
for whatever reason, the hbase client property for turning on client side buffering never got properly documented.

to add to the confusion, we do document a config used to tune client side buffering, but that config is ignored unless client side buffering is turned on. Also, it's used in one of our examples. :/