### PR TITLE
[cloudspanner bigtable] update client library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@ LICENSE file.
     <azuredocumentdb.version>1.8.1</azuredocumentdb.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>0.24.0-beta</cloudspanner.version>
+    <cloudspanner.version>0.36.0-beta</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
     <couchbase2.version>2.3.1</couchbase2.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
     <foundationdb.version>5.2.5</foundationdb.version>
     <geode.version>1.2.0</geode.version>
-    <googlebigtable.version>1.3.0</googlebigtable.version>
+    <googlebigtable.version>1.4.0</googlebigtable.version>
     <hbase098.version>0.98.14-hadoop2</hbase098.version>
     <hbase10.version>1.0.2</hbase10.version>
     <hbase12.version>1.2.5</hbase12.version>


### PR DESCRIPTION
tested successfully current code with updated spanner/bigtable library in order to be more compatible with other more updated google cloud components and confirm it works with 0.16.0 YCSB.

used following settings:
./bin/ycsb load cloudspanner -P workloads/workloada -P cloudspanner.properties -p recordcount=1000
./bin/ycsb run cloudspanner -P workloads/workloada -P cloudspanner.properties -p operationcount=1000

table = usertable
zeropadding = 12

cloudspanner.instance = ycsb-instance
cloudspanner.database = ycsb-database

cloudspanner.readmode = query
cloudspanner.boundedstaleness = 0
cloudspanner.batchinserts = 1

./bin/ycsb load googlebigtable -P workloads/workloada -P googlebigtable.properties -p recordcount=1000
./bin/ycsb run googlebigtable -P workloads/workloada -P googlebigtable.properties -p operationcount=1000

columnfamily=cf
google.bigtable.project.id=firestore-benchmark-tests
google.bigtable.instance.id=ycsb-instance
google.bigtable.auth.service.account.enable=true
google.bigtable.auth.json.keyfile=serviceAccountKey.bt.json
debug=false