### PR TITLE
Adding the ability to connect to Cassandra using SSL connections.

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -76,6 +76,9 @@ For keyspace `ycsb`, table `usertable`:
 * `cassandra.coreconnections`
   * Defaults for max and core connections can be found here: https://datastax.github.io/java-driver/2.1.8/features/pooling/#pool-size. Cassandra 2.0.X falls under protocol V2, Cassandra 2.1+ falls under protocol V3.
 * `cassandra.connecttimeoutmillis`
+* `cassandra.useSSL`
+  * Default value is false.
+  - To connect with SSL set this value to true.
 * `cassandra.readtimeoutmillis`
   * Defaults for connect and read timeouts can be found here: https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/SocketOptions.html.
 * `cassandra.tracing`

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -113,7 +113,10 @@ public class CassandraCQLClient extends DB {
 
   public static final String TRACING_PROPERTY = "cassandra.tracing";
   public static final String TRACING_PROPERTY_DEFAULT = "false";
-  
+
+  public static final String USE_SSL_CONNECTION = "cassandra.useSSL";
+  private static final String DEFAULT_USE_SSL_CONNECTION = "false";
+
   /**
    * Count the number of times initialized to teardown on the last
    * {@link #cleanup()}.
@@ -148,7 +151,7 @@ public class CassandraCQLClient extends DB {
         debug =
             Boolean.parseBoolean(getProperties().getProperty("debug", "false"));
         trace = Boolean.valueOf(getProperties().getProperty(TRACING_PROPERTY, TRACING_PROPERTY_DEFAULT));
-        
+
         String host = getProperties().getProperty(HOSTS_PROPERTY);
         if (host == null) {
           throw new DBException(String.format(
@@ -171,9 +174,17 @@ public class CassandraCQLClient extends DB {
             getProperties().getProperty(WRITE_CONSISTENCY_LEVEL_PROPERTY,
                 WRITE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
 
+        Boolean useSSL = Boolean.parseBoolean(getProperties().getProperty(USE_SSL_CONNECTION,
+            DEFAULT_USE_SSL_CONNECTION));
+
         if ((username != null) && !username.isEmpty()) {
-          cluster = Cluster.builder().withCredentials(username, password)
-              .withPort(Integer.valueOf(port)).addContactPoints(hosts).build();
+          if (useSSL) {
+            cluster = Cluster.builder().withCredentials(username, password)
+                       .withPort(Integer.valueOf(port)).addContactPoints(hosts).withSSL().build();
+          } else {
+            cluster = Cluster.builder().withCredentials(username, password)
+                       .withPort(Integer.valueOf(port)).addContactPoints(hosts).build();
+          }
         } else {
           cluster = Cluster.builder().withPort(Integer.valueOf(port))
               .addContactPoints(hosts).build();

--- a/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/com/yahoo/ycsb/db/CassandraCQLClient.java
@@ -178,13 +178,12 @@ public class CassandraCQLClient extends DB {
             DEFAULT_USE_SSL_CONNECTION));
 
         if ((username != null) && !username.isEmpty()) {
+          Cluster.Builder clusterBuilder = Cluster.builder().withCredentials(username, password)
+              .withPort(Integer.valueOf(port)).addContactPoints(hosts);
           if (useSSL) {
-            cluster = Cluster.builder().withCredentials(username, password)
-                       .withPort(Integer.valueOf(port)).addContactPoints(hosts).withSSL().build();
-          } else {
-            cluster = Cluster.builder().withCredentials(username, password)
-                       .withPort(Integer.valueOf(port)).addContactPoints(hosts).build();
-          }
+            clusterBuilder = clusterBuilder.withSSL();
+          } 
+          cluster = clusterBuilder.build();
         } else {
           cluster = Cluster.builder().withPort(Integer.valueOf(port))
               .addContactPoints(hosts).build();


### PR DESCRIPTION
Small change to add a new flag called useSSL.  It flag adds the ability to use secure connections. The default is "false" which is how the current driver connects.  Personally I think the default should be secure connections but I dont want to break compatibility.