### PR TITLE
Remove 'incubating' from references to Apache Geode

### DIFF
--- a/geode/src/main/java/com/yahoo/ycsb/db/GeodeClient.java
+++ b/geode/src/main/java/com/yahoo/ycsb/db/GeodeClient.java
@@ -48,7 +48,7 @@ import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 
 /**
- * Apache Geode (incubating) client for the YCSB benchmark.<br />
+ * Apache Geode client for the YCSB benchmark.<br />
  * <p>By default acts as a Geode client and tries to connect
  * to Geode cache server running on localhost with default
  * cache server port. Hostname and port of a Geode cacheServer

--- a/geode/src/main/java/com/yahoo/ycsb/db/package-info.java
+++ b/geode/src/main/java/com/yahoo/ycsb/db/package-info.java
@@ -16,6 +16,6 @@
  */
 
 /**
- * YCSB binding for <a href="https://geode.incubator.apache.org/">Apache Geode (incubating)</a>.
+ * YCSB binding for <a href="https://geode.apache.org/">Apache Geode</a>.
  */
 package com.yahoo.ycsb.db;


### PR DESCRIPTION
Apache Geode is not in incubating state. References to this were removed from README with a previous commit but not from the code. 