### PR TITLE
[travis] drop unsupported oracle JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ language: java
 jdk:
   - openjdk8
   - openjdk11
-  - oraclejdk8
   - oraclejdk11
 
 addons:


### PR DESCRIPTION
Travis' jdk installer has started failing when setting up oracle jdk8:

```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
install-jdk.sh 2019-05-02
Expected feature release number in range of 9 to 13, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
Your build has been stopped.
```