### PR TITLE
Update README.md

### DIFF
--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -859,7 +859,7 @@ public final class Client {
       }
       if (threadcount > opcount){
         threadcount = opcount;
-        System.println("Warning: the threadcount is bigger than recordcount, the threadcount will be recordcount!");
+        System.out.println("Warning: the threadcount is bigger than recordcount, the threadcount will be recordcount!");
       }
       for (int threadid = 0; threadid < threadcount; threadid++) {
         DB db;

--- a/core/src/main/java/com/yahoo/ycsb/Client.java
+++ b/core/src/main/java/com/yahoo/ycsb/Client.java
@@ -857,7 +857,10 @@ public final class Client {
           opcount = Integer.parseInt(props.getProperty(RECORD_COUNT_PROPERTY, DEFAULT_RECORD_COUNT));
         }
       }
-
+      if (threadcount > opcount){
+        threadcount = opcount;
+        System.println("Warning: the threadcount is bigger than recordcount, the threadcount will be recordcount!");
+      }
       for (int threadid = 0; threadid < threadcount; threadid++) {
         DB db;
         try {

--- a/hbase12/README.md
+++ b/hbase12/README.md
@@ -23,5 +23,5 @@ See `hbase098/README.md` for a quickstart to setup HBase for load testing and co
 ## Configuration Options
 In addition to those options available for the `hbase098` binding, the following options are available for the `hbase12` binding:
 
-* `durability`: Whether or not writes should be appended to the WAL. Bypassing the WAL can improve throughput but data cannot be recovered in the event of a crash. The default is true.
+* `durability`: Whether or not writes should be appended to the WAL. Bypassing the WAL can improve throughput but data cannot be recovered in the event of a crash. The default is true.  We can set it to flase by option '-p durability=SKIP_WAL'.
 


### PR DESCRIPTION
https://github.com/brianfrankcooper/YCSB/issues/1212

The YCSB readme is as the following, which is a little misleading.Because we can't use '-p durability=false' to disable durability. Instead it worked when I used '-p durability=SKIP_WAL'. The readme should be written more clearly.

durability: Whether or not writes should be appended to the WAL. Bypassing the WAL can improve throughput but data cannot be recovered in the event of a crash. The default is true.