### PR TITLE
[kudu] Support range partitioning

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -356,6 +356,19 @@ public class CoreWorkload extends Workload {
 
   private Measurements measurements = Measurements.getMeasurements();
 
+  public static String buildKeyName(long keynum, int zeropadding, boolean orderedinserts) {
+    if (!orderedinserts) {
+      keynum = Utils.hash(keynum);
+    }
+    String value = Long.toString(keynum);
+    int fill = zeropadding - value.length();
+    String prekey = "user";
+    for (int i = 0; i < fill; i++) {
+      prekey += '0';
+    }
+    return prekey + value;
+  }
+
   protected static NumberGenerator getFieldLengthGenerator(Properties p) throws WorkloadException {
     NumberGenerator fieldlengthgenerator;
     String fieldlengthdistribution = p.getProperty(
@@ -514,19 +527,6 @@ public class CoreWorkload extends Workload {
         INSERTION_RETRY_INTERVAL, INSERTION_RETRY_INTERVAL_DEFAULT));
   }
 
-  protected String buildKeyName(long keynum) {
-    if (!orderedinserts) {
-      keynum = Utils.hash(keynum);
-    }
-    String value = Long.toString(keynum);
-    int fill = zeropadding - value.length();
-    String prekey = "user";
-    for (int i = 0; i < fill; i++) {
-      prekey += '0';
-    }
-    return prekey + value;
-  }
-
   /**
    * Builds a value for a randomly chosen field.
    */
@@ -592,7 +592,7 @@ public class CoreWorkload extends Workload {
   @Override
   public boolean doInsert(DB db, Object threadstate) {
     int keynum = keysequence.nextValue().intValue();
-    String dbkey = buildKeyName(keynum);
+    String dbkey = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
     HashMap<String, ByteIterator> values = buildValues(dbkey);
 
     Status status;
@@ -703,7 +703,7 @@ public class CoreWorkload extends Workload {
     // choose a random key
     long keynum = nextKeynum();
 
-    String keyname = buildKeyName(keynum);
+    String keyname = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
     HashSet<String> fields = null;
 
@@ -730,7 +730,7 @@ public class CoreWorkload extends Workload {
     // choose a random key
     long keynum = nextKeynum();
 
-    String keyname = buildKeyName(keynum);
+    String keyname = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
     HashSet<String> fields = null;
 
@@ -777,7 +777,7 @@ public class CoreWorkload extends Workload {
     // choose a random key
     long keynum = nextKeynum();
 
-    String startkeyname = buildKeyName(keynum);
+    String startkeyname = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
     // choose a random scan length
     int len = scanlength.nextValue().intValue();
@@ -799,7 +799,7 @@ public class CoreWorkload extends Workload {
     // choose a random key
     long keynum = nextKeynum();
 
-    String keyname = buildKeyName(keynum);
+    String keyname = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
     HashMap<String, ByteIterator> values;
 
@@ -819,7 +819,7 @@ public class CoreWorkload extends Workload {
     long keynum = transactioninsertkeysequence.nextValue();
 
     try {
-      String dbkey = buildKeyName(keynum);
+      String dbkey = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
 
       HashMap<String, ByteIterator> values = buildValues(dbkey);
       db.insert(table, dbkey, values);

--- a/kudu/README.md
+++ b/kudu/README.md
@@ -41,6 +41,8 @@ Additional configurations:
   default is true.
 * `kudu_block_size`: The data block size used to configure columns. The default
   is 4096 bytes.
+* `kudu_partition_schema`: The partition schema used to create table. It could be
+  'hashPartition' or 'rangePartition', the default is 'hashPartition'.
 
 Then, you can run the workload:
 

--- a/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
@@ -40,6 +40,8 @@ import java.util.Vector;
 
 import static site.ycsb.Client.DEFAULT_RECORD_COUNT;
 import static site.ycsb.Client.RECORD_COUNT_PROPERTY;
+import static site.ycsb.workloads.CoreWorkload.INSERT_ORDER_PROPERTY;
+import static site.ycsb.workloads.CoreWorkload.INSERT_ORDER_PROPERTY_DEFAULT;
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY_DEFAULT;
 import static site.ycsb.workloads.CoreWorkload.ZERO_PADDING_PROPERTY;
@@ -214,8 +216,8 @@ public class KuduYCSBClient extends site.ycsb.DB {
         hashPartitionColumns.add(KEY);
         builder.addHashPartitions(hashPartitionColumns, numTablets);
       } else if (partitionSchema.equals("rangePartition")) {
-        if (prop.getProperty(CoreWorkload.INSERT_ORDER_PROPERTY, CoreWorkload.INSERT_ORDER_PROPERTY_DEFAULT)
-            .compareTo("ordered") != 0) {
+        if (!orderedinserts) {
+          // We need to use ordered keys to determine how to split range partitions.
           throw new DBException("Must specify `insertorder=ordered` if using rangePartition schema.");
         }
 
@@ -239,9 +241,9 @@ public class KuduYCSBClient extends site.ycsb.DB {
             ++upperNum;
           }
           PartialRow lower = schema.newPartialRow();
-          lower.addString(KEY, CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts));
+          lower.addString(KEY, CoreWorkload.buildKeyName(lowerNum, zeropadding, orderedinserts));
           PartialRow upper = schema.newPartialRow();
-          upper.addString(KEY, CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts));
+          upper.addString(KEY, CoreWorkload.buildKeyName(upperNum, zeropadding, orderedinserts));
           builder.addRangePartition(lower, upper);
         }
       } else {

--- a/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
@@ -38,12 +38,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
 
-import static com.yahoo.ycsb.Client.DEFAULT_RECORD_COUNT;
-import static com.yahoo.ycsb.Client.RECORD_COUNT_PROPERTY;
-import static com.yahoo.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
-import static com.yahoo.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY_DEFAULT;
-import static com.yahoo.ycsb.workloads.CoreWorkload.ZERO_PADDING_PROPERTY;
-import static com.yahoo.ycsb.workloads.CoreWorkload.ZERO_PADDING_PROPERTY_DEFAULT;
+import static site.ycsb.Client.DEFAULT_RECORD_COUNT;
+import static site.ycsb.Client.RECORD_COUNT_PROPERTY;
+import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
+import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY_DEFAULT;
+import static site.ycsb.workloads.CoreWorkload.ZERO_PADDING_PROPERTY;
+import static site.ycsb.workloads.CoreWorkload.ZERO_PADDING_PROPERTY_DEFAULT;
 import static org.apache.kudu.Type.STRING;
 import static org.apache.kudu.client.KuduPredicate.ComparisonOp.EQUAL;
 import static org.apache.kudu.client.KuduPredicate.ComparisonOp.GREATER_EQUAL;


### PR DESCRIPTION
Kudu binding only support hash partitioning now, this patch provide another type of partitioning: range partitioning, it can be configured in `kudu_partition_schema`.