### PR TITLE
[jdbc] Fix README formatting of example connection strings

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -113,16 +113,8 @@ Some JDBC drivers support re-writing batched insert statements into multi-row in
 - **db.batchsize** must be greater than 0.  The magniute of the improvement can be adjusted by varying **batchsize**. Start with a small number and increase at small increments until diminishing return in the improvement is observed. 
 - set **jdbc.batchupdateapi=true** to enable batching.
 - set JDBC driver specific connection parameter in **db.url** to enable the rewrite as shown in the examples below:
-  * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html)
-
-    ```
-db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true
-```
-  * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters)
-
-    ```
-db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true
-```
+  * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html) with `db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true`
+  * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters) with `db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true`
 
 
 


### PR DESCRIPTION
fix formatting issues showing in the re-writing batched insert `db.url` example box