### PR TITLE
[build] update group id to site.ycsb

### DIFF
--- a/accumulo1.6/README.md
+++ b/accumulo1.6/README.md
@@ -34,7 +34,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:accumulo1.6-binding -am clean package
+    mvn -pl site.ycsb:accumulo1.6-binding -am clean package
 
 ### 3. Create the Accumulo table
 

--- a/accumulo1.6/pom.xml
+++ b/accumulo1.6/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -54,7 +54,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/accumulo1.7/README.md
+++ b/accumulo1.7/README.md
@@ -34,7 +34,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:accumulo1.7-binding -am clean package
+    mvn -pl site.ycsb:accumulo1.7-binding -am clean package
 
 ### 3. Create the Accumulo table
 

--- a/accumulo1.7/pom.xml
+++ b/accumulo1.7/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -54,7 +54,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/accumulo1.8/README.md
+++ b/accumulo1.8/README.md
@@ -34,7 +34,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:accumulo1.8-binding -am clean package
+    mvn -pl site.ycsb:accumulo1.8-binding -am clean package
 
 ### 3. Create the Accumulo table
 

--- a/accumulo1.8/pom.xml
+++ b/accumulo1.8/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -54,7 +54,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/aerospike/README.md
+++ b/aerospike/README.md
@@ -29,7 +29,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:aerospike-binding -am clean package
+    mvn -pl site.ycsb:aerospike-binding -am clean package
 
 ### 4. Provide Aerospike Connection Parameters
 

--- a/aerospike/pom.xml
+++ b/aerospike/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${aerospike.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/arangodb/pom.xml
+++ b/arangodb/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -37,7 +37,7 @@ LICENSE file.
       <version>${arangodb.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/asynchbase/pom.xml
+++ b/asynchbase/pom.xml
@@ -16,7 +16,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -39,7 +39,7 @@ LICENSE file.
     </dependency>
     
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/azurecosmos/pom.xml
+++ b/azurecosmos/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -55,7 +55,7 @@ LICENSE file.
     <version>1.2.17</version>
   </dependency>
   <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     <scope>provided</scope>

--- a/azuretablestorage/README.md
+++ b/azuretablestorage/README.md
@@ -30,7 +30,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:azuretablestorage-binding -am clean package
+    mvn -pl site.ycsb:azuretablestorage-binding -am clean package
 
 ### 4. Provide Azure Storage parameters
     

--- a/azuretablestorage/pom.xml
+++ b/azuretablestorage/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -32,7 +32,7 @@ LICENSE file.
 
     <dependencies>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -214,9 +214,9 @@ def is_distribution():
 # Given module is full module name eg. 'core' or 'couchbase-binding'
 def get_classpath_from_maven(module):
     try:
-        debug("Running 'mvn -pl com.yahoo.ycsb:" + module + " -am package -DskipTests "
+        debug("Running 'mvn -pl site.ycsb:" + module + " -am package -DskipTests "
               "dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true'")
-        mvn_output = check_output(["mvn", "-pl", "com.yahoo.ycsb:" + module,
+        mvn_output = check_output(["mvn", "-pl", "site.ycsb:" + module,
                                    "-am", "package", "-DskipTests",
                                    "dependency:build-classpath",
                                    "-DincludeScope=compile",

--- a/bin/ycsb.bat
+++ b/bin/ycsb.bat
@@ -178,7 +178,7 @@ SET MVN_PROJECT=core
 :gotMvnProject
 
 ECHO [WARN] YCSB libraries not found.  Attempting to build...
-CALL mvn -Psource-run -pl com.yahoo.ycsb:%MVN_PROJECT% -am package -DskipTests
+CALL mvn -Psource-run -pl site.ycsb:%MVN_PROJECT% -am package -DskipTests
 IF %ERRORLEVEL% NEQ 0 (
   ECHO [ERROR] Error trying to build project. Exiting.
   GOTO exit

--- a/bin/ycsb.sh
+++ b/bin/ycsb.sh
@@ -202,7 +202,7 @@ else
     fi
 
     echo "[WARN] YCSB libraries not found.  Attempting to build..."
-    if mvn -Psource-run -pl com.yahoo.ycsb:"$MVN_PROJECT" -am package -DskipTests; then
+    if mvn -Psource-run -pl site.ycsb:"$MVN_PROJECT" -am package -DskipTests; then
       echo "[ERROR] Error trying to build project. Exiting."
       exit 1;
     fi

--- a/binding-parent/datastore-specific-descriptor/pom.xml
+++ b/binding-parent/datastore-specific-descriptor/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>root</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
@@ -35,7 +35,7 @@ LICENSE file.
   </description>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
+++ b/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
@@ -67,7 +67,7 @@ LICENSE file.
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <includes>
-        <include>com.yahoo.ycsb:core</include>
+        <include>site.ycsb:core</include>
       </includes>
       <scope>provided</scope>
       <useTransitiveFiltering>true</useTransitiveFiltering>

--- a/binding-parent/pom.xml
+++ b/binding-parent/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>root</artifactId>
     <version>0.17.0-SNAPSHOT</version>
   </parent>
@@ -53,7 +53,7 @@ LICENSE file.
           <version>${maven.assembly.version}</version>
           <dependencies>
             <dependency>
-              <groupId>com.yahoo.ycsb</groupId>
+              <groupId>site.ycsb</groupId>
               <artifactId>datastore-specific-descriptor</artifactId>
               <version>${project.version}</version>
             </dependency>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -44,7 +44,7 @@ LICENSE file.
       <version>${cassandra.cql.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/cloudspanner/pom.xml
+++ b/cloudspanner/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -43,7 +43,7 @@ LICENSE file.
     </dependency>
     
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>root</artifactId>
     <version>0.17.0-SNAPSHOT</version>
   </parent>

--- a/couchbase/pom.xml
+++ b/couchbase/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -37,7 +37,7 @@ LICENSE file.
             <version>${couchbase.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/couchbase2/pom.xml
+++ b/couchbase2/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -38,7 +38,7 @@ LICENSE file.
             <version>${couchbase2.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/crail/README.md
+++ b/crail/README.md
@@ -31,7 +31,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:crail-binding -am clean package
+    mvn -pl site.ycsb:crail-binding -am clean package
 
 ### 4. Provide Crail Connection Parameters
 

--- a/crail/pom.xml
+++ b/crail/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -56,7 +56,7 @@ LICENSE file.
       <version>${crail.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>root</artifactId>
     <version>0.17.0-SNAPSHOT</version>
   </parent>
@@ -35,259 +35,259 @@ LICENSE file.
   </description>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>accumulo1.6-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>accumulo1.7-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>accumulo1.8-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>aerospike-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>arangodb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>asynchbase-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>cassandra-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>cloudspanner-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>couchbase-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>couchbase2-binding</artifactId>
       <version>${project.version}</version>
 		</dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>crail-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>azurecosmos-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>azuretablestorage-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>dynamodb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>elasticsearch-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>elasticsearch5-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>foundationdb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>geode-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>googledatastore-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>googlebigtable-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>griddb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase098-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase10-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase12-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase14-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase20-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hypertable-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>ignite-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>infinispan-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>jdbc-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>kudu-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>memcached-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>maprdb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>maprjsondb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>mongodb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>nosqldb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>orientdb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>postgrenosql-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>rados-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>redis-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>rest-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>riak-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>rocksdb-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>s3-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>solr-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>solr6-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>tarantool-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>tablestore-binding</artifactId>
         <version>${project.version}</version>
     </dependency>
 <!--
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>voldemort-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
 -->
     <dependency>
-       <groupId>com.yahoo.ycsb</groupId>
+       <groupId>site.ycsb</groupId>
        <artifactId>voltdb-binding</artifactId>
        <version>${project.version}</version>
      </dependency>

--- a/distribution/src/main/assembly/distribution.xml
+++ b/distribution/src/main/assembly/distribution.xml
@@ -59,7 +59,7 @@ LICENSE file.
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <includes>
-        <include>com.yahoo.ycsb:core</include>
+        <include>site.ycsb:core</include>
       </includes>
       <scope>runtime</scope>
       <useProjectArtifact>false</useProjectArtifact>
@@ -73,11 +73,11 @@ LICENSE file.
       <useAllReactorProjects>true</useAllReactorProjects>
       <includeSubModules>true</includeSubModules>
       <excludes>
-        <exclude>com.yahoo.ycsb:core</exclude>
-        <exclude>com.yahoo.ycsb:binding-parent</exclude>
-        <exclude>com.yahoo.ycsb:datastore-specific-descriptor</exclude>
-        <exclude>com.yahoo.ycsb:ycsb</exclude>
-        <exclude>com.yahoo.ycsb:root</exclude>
+        <exclude>site.ycsb:core</exclude>
+        <exclude>site.ycsb:binding-parent</exclude>
+        <exclude>site.ycsb:datastore-specific-descriptor</exclude>
+        <exclude>site.ycsb:ycsb</exclude>
+        <exclude>site.ycsb:root</exclude>
       </excludes>
       <sources>
         <fileSets>

--- a/dynamodb/pom.xml
+++ b/dynamodb/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -41,7 +41,7 @@ LICENSE file.
       <version>1.2.17</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -40,7 +40,7 @@ LICENSE file.
             <version>4.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -147,7 +147,7 @@ LICENSE file.
       <version>4.4.0</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/foundationdb/pom.xml
+++ b/foundationdb/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -37,7 +37,7 @@ LICENSE file.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${geode.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/googlebigtable/pom.xml
+++ b/googlebigtable/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -37,7 +37,7 @@ LICENSE file.
     </dependency>
     
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/googledatastore/pom.xml
+++ b/googledatastore/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -41,7 +41,7 @@ LICENSE file.
       <version>1.2.17</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/griddb/README.md
+++ b/griddb/README.md
@@ -43,7 +43,7 @@ Clone the YCSB source code from git repository:
 
 Run following command
 
-    $ mvn -pl com.yahoo.ycsb:griddb-binding -am clean package
+    $ mvn -pl site.ycsb:griddb-binding -am clean package
 
 Then, some jar files are created in:
 

--- a/griddb/pom.xml
+++ b/griddb/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -32,7 +32,7 @@ LICENSE file.
 
     <dependencies>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/hbase098/pom.xml
+++ b/hbase098/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -41,7 +41,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/hbase10/pom.xml
+++ b/hbase10/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -46,7 +46,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/hbase12/pom.xml
+++ b/hbase12/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -41,7 +41,7 @@ LICENSE file.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase10-binding</artifactId>
       <version>${project.version}</version>
       <!-- Should match all compile scoped dependencies -->
@@ -53,7 +53,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/hbase14/pom.xml
+++ b/hbase14/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -39,7 +39,7 @@ LICENSE file.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase10-binding</artifactId>
       <version>${project.version}</version>
       <!-- Should match all compile scoped dependencies -->
@@ -51,7 +51,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/hbase20/pom.xml
+++ b/hbase20/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -39,7 +39,7 @@ LICENSE file.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>hbase10-binding</artifactId>
       <version>${project.version}</version>
       <!-- Should match all compile scoped dependencies -->
@@ -51,7 +51,7 @@ LICENSE file.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/hypertable/pom.xml
+++ b/hypertable/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -32,7 +32,7 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/ignite/README.md
+++ b/ignite/README.md
@@ -25,7 +25,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:ignite-binding -am clean package
+    mvn -pl site.ycsb:ignite-binding -am clean package
 
 ### 2. Start Apache Ignite
 1.1 Download latest binary [Apache Ignite release](https://ignite.apache.org/download.cgi#binaries)

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -22,7 +22,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -58,7 +58,7 @@ LICENSE file.
     </dependency>
 
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -42,7 +42,7 @@ LICENSE file.
       <version>${infinispan.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${openjpa.jdbc.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/kudu/README.md
+++ b/kudu/README.md
@@ -54,7 +54,7 @@ If you wish to use a different Kudu client version than the one shipped with
 YCSB, you can specify on the command line with `-Dkudu.version=x`. For example:
 
 ```
-mvn -pl com.yahoo.ycsb:kudu-binding -am package -DskipTests -Dkudu.version=1.0.1
+mvn -pl site.ycsb:kudu-binding -am package -DskipTests -Dkudu.version=1.0.1
 ```
 
 Note that only versions since 1.0 are supported, since Kudu did not guarantee

--- a/kudu/pom.xml
+++ b/kudu/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${kudu.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/mapkeeper/pom.xml
+++ b/mapkeeper/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
        <version>${mapkeeper.version}</version>
      </dependency>
      <dependency>
-       <groupId>com.yahoo.ycsb</groupId>
+       <groupId>site.ycsb</groupId>
        <artifactId>core</artifactId>
        <version>${project.version}</version>
        <scope>provided</scope>

--- a/maprdb/pom.xml
+++ b/maprdb/pom.xml
@@ -13,7 +13,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.yahoo.ycsb</groupId>
+		<groupId>site.ycsb</groupId>
 		<artifactId>binding-parent</artifactId>
 		<version>0.17.0-SNAPSHOT</version>
 		<relativePath>../binding-parent</relativePath>
@@ -40,7 +40,7 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
+			<groupId>site.ycsb</groupId>
 			<artifactId>core</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
@@ -51,7 +51,7 @@
 			<version>${maprhbase.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
+			<groupId>site.ycsb</groupId>
 			<artifactId>hbase10-binding</artifactId>
 			<version>${project.version}</version>
 			<!-- Should match all compile scoped dependencies -->

--- a/maprjsondb/pom.xml
+++ b/maprjsondb/pom.xml
@@ -13,7 +13,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.yahoo.ycsb</groupId>
+		<groupId>site.ycsb</groupId>
 		<artifactId>binding-parent</artifactId>
 		<version>0.17.0-SNAPSHOT</version>
 		<relativePath>../binding-parent</relativePath>
@@ -40,7 +40,7 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
+			<groupId>site.ycsb</groupId>
 			<artifactId>core</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -39,7 +39,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:memcached-binding -am clean package
+    mvn -pl site.ycsb:memcached-binding -am clean package
 
 ## 4. Load data and run tests
 

--- a/memcached/pom.xml
+++ b/memcached/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>1.2.17</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -42,7 +42,7 @@ LICENSE file.
       <version>${mongodb.async.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/nosqldb/pom.xml
+++ b/nosqldb/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>3.0.5</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/orientdb/pom.xml
+++ b/orientdb/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -42,7 +42,7 @@ LICENSE file.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.yahoo.ycsb</groupId>
+  <groupId>site.ycsb</groupId>
   <artifactId>root</artifactId>
   <version>0.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/postgrenosql/pom.xml
+++ b/postgrenosql/pom.xml
@@ -18,7 +18,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -30,7 +30,7 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/rados/README.md
+++ b/rados/README.md
@@ -37,11 +37,11 @@ Git clone YCSB and compile:
 
 You can compile only RADOS-binding, EG:
 
-    mvn -pl com.yahoo.ycsb:rados-binding -am clean package
+    mvn -pl site.ycsb:rados-binding -am clean package
 
 You can skip the test, EG:
 
-    mvn -pl com.yahoo.ycsb:rados-binding -am clean package -DskipTests
+    mvn -pl site.ycsb:rados-binding -am clean package -DskipTests
 
 ### 4. Configuration Parameters
 

--- a/rados/pom.xml
+++ b/rados/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${rados.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/redis/README.md
+++ b/redis/README.md
@@ -29,7 +29,7 @@ Git clone YCSB and compile:
 
     git clone http://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:redis-binding -am clean package
+    mvn -pl site.ycsb:redis-binding -am clean package
 
 ### 4. Provide Redis Connection Parameters
     

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${redis.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/rest/README.md
+++ b/rest/README.md
@@ -30,7 +30,7 @@ Clone the YCSB git repository and compile:
 
     git clone git://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:rest-binding -am clean package
+    mvn -pl site.ycsb:rest-binding -am clean package
 
 ### 2. Set Up an HTTP Web Service
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -12,7 +12,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -37,7 +37,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/riak/pom.xml
+++ b/riak/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -38,7 +38,7 @@ LICENSE file.
       <version>2.0.5</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/rocksdb/pom.xml
+++ b/rocksdb/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -36,7 +36,7 @@ LICENSE file.
       <version>${rocksdb.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/s3/pom.xml
+++ b/s3/pom.xml
@@ -17,7 +17,7 @@ LICENSE file.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -35,7 +35,7 @@ LICENSE file.
     </dependency>
 
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/solr/README.md
+++ b/solr/README.md
@@ -25,7 +25,7 @@ Clone the YCSB git repository and compile:
 
     git clone git://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:solr-binding -am clean package
+    mvn -pl site.ycsb:solr-binding -am clean package
 
 ### 2. Set Up Solr
 

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -39,7 +39,7 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/solr6/README.md
+++ b/solr6/README.md
@@ -25,7 +25,7 @@ Clone the YCSB git repository and compile:
 
     git clone git://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn -pl com.yahoo.ycsb:solr6-binding -am clean package
+    mvn -pl site.ycsb:solr6-binding -am clean package
 
 ### 2. Set Up Solr
 

--- a/solr6/pom.xml
+++ b/solr6/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -39,7 +39,7 @@ LICENSE file.
 
   <dependencies>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/tablestore/pom.xml
+++ b/tablestore/pom.xml
@@ -19,7 +19,7 @@ LICENSE file.
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.yahoo.ycsb</groupId>
+        <groupId>site.ycsb</groupId>
         <artifactId>binding-parent</artifactId>
         <version>0.17.0-SNAPSHOT</version>
         <relativePath>../binding-parent</relativePath>
@@ -30,7 +30,7 @@ LICENSE file.
 
     <dependencies>
         <dependency>
-            <groupId>com.yahoo.ycsb</groupId>
+            <groupId>site.ycsb</groupId>
             <artifactId>core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/tarantool/pom.xml
+++ b/tarantool/pom.xml
@@ -21,7 +21,7 @@ LICENSE file.
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent/</relativePath>
@@ -38,7 +38,7 @@ LICENSE file.
       <version>${tarantool.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.ycsb</groupId>
+      <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/voldemort/pom.xml
+++ b/voldemort/pom.xml
@@ -20,7 +20,7 @@ LICENSE file.
 	
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.yahoo.ycsb</groupId>
+    <groupId>site.ycsb</groupId>
     <artifactId>binding-parent</artifactId>
     <version>0.17.0-SNAPSHOT</version>
     <relativePath>../binding-parent</relativePath>
@@ -42,7 +42,7 @@ LICENSE file.
        <version>1.2.16</version>
      </dependency>
      <dependency>
-       <groupId>com.yahoo.ycsb</groupId>
+       <groupId>site.ycsb</groupId>
        <artifactId>core</artifactId>
        <version>${project.version}</version>
        <scope>provided</scope>

--- a/voltdb/pom.xml
+++ b/voltdb/pom.xml
@@ -14,7 +14,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.yahoo.ycsb</groupId>
+		<groupId>site.ycsb</groupId>
 		<artifactId>binding-parent</artifactId>
 		<version>0.17.0-SNAPSHOT</version>
 		<relativePath>../binding-parent</relativePath>
@@ -25,7 +25,7 @@
 	<packaging>jar</packaging>
 	<dependencies>
 		<dependency>
-			<groupId>com.yahoo.ycsb</groupId>
+			<groupId>site.ycsb</groupId>
 			<artifactId>core</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>


### PR DESCRIPTION
This moves all group ids in the project to be "site.ycsb" from "com.yahoo.ycsb." This is necessary if we want to publish artifacts to Maven Central since as a project we're no longer associated with Yahoo! and they control who publishes artifacts within "com.yahoo".

Tested locally with a clean build and running the basicdb to load and run workload a both in the source checkout and the distribution tarball.

Note that this doesn't change java packages (will be a different PR) and it doesn't address the regression on #908 that came up in the 0.16.0 testing on #1265 .