### PR TITLE
[rocksdb] add rocksdb.optionsfile property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@ LICENSE file.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <redis.version>2.9.0</redis.version>
     <riak.version>2.0.5</riak.version>
-    <rocksdb.version>5.11.3</rocksdb.version>
+    <rocksdb.version>6.2.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>
     <solr.version>5.5.3</solr.version>
     <solr6.version>6.4.1</solr6.version>

--- a/rocksdb/README.md
+++ b/rocksdb/README.md
@@ -42,4 +42,10 @@ Then, run the workload:
 
 * ```rocksdb.dir``` - (required) A path to a folder to hold the RocksDB data files.
     * EX. ```/tmp/ycsb-rocksdb-data```
+* ```rocksdb.optionsfile``` - A path to a [RocksDB options file](https://github.com/facebook/rocksdb/wiki/RocksDB-Options-File).
+    * EX. ```ycsb-rocksdb-options.ini```
 
+## Note on RocksDB Options
+
+If `rocksdb.optionsfile` is given, YCSB will apply all [RocksDB options](https://github.com/facebook/rocksdb/wiki/Setup-Options-and-Basic-Tuning) exactly as specified in the options file.
+Otherwise, YCSB will try to set reasonable defaults.

--- a/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBOptionsFileTest.java
+++ b/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBOptionsFileTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.rocksdb;
+
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.*;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class RocksDBOptionsFileTest {
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private RocksDBClient instance;
+
+  @Test
+  public void loadOptionsFromFile() throws Exception {
+    final String optionsPath = RocksDBClient.class.getClassLoader().getResource("testcase.ini").getPath();
+    final String dbPath = tmpFolder.getRoot().getAbsolutePath();
+
+    initDbWithOptionsFile(dbPath, optionsPath);
+    checkOptions(dbPath);
+  }
+
+  private void initDbWithOptionsFile(final String dbPath, final String optionsPath) throws Exception {
+    instance = new RocksDBClient();
+
+    final Properties properties = new Properties();
+    properties.setProperty(RocksDBClient.PROPERTY_ROCKSDB_DIR, dbPath);
+    properties.setProperty(RocksDBClient.PROPERTY_ROCKSDB_OPTIONS_FILE, optionsPath);
+    instance.setProperties(properties);
+
+    instance.init();
+    instance.cleanup();
+  }
+
+  private void checkOptions(final String dbPath) throws Exception {
+    final List<ColumnFamilyDescriptor> cfDescriptors = new ArrayList<>();
+    final DBOptions dbOptions = new DBOptions();
+
+    RocksDB.loadLibrary();
+    OptionsUtil.loadLatestOptions(dbPath, Env.getDefault(), dbOptions, cfDescriptors);
+
+    try {
+      assertEquals(dbOptions.walSizeLimitMB(), 42);
+
+      // the two CFs should be "default" and "usertable"
+      assertEquals(cfDescriptors.size(), 2);
+      assertEquals(cfDescriptors.get(0).getOptions().ttl(), 42);
+      assertEquals(cfDescriptors.get(1).getOptions().ttl(), 42);
+    }
+    finally {
+      dbOptions.close();
+    }
+  }
+};

--- a/rocksdb/src/test/resources/testcase.ini
+++ b/rocksdb/src/test/resources/testcase.ini
@@ -1,0 +1,23 @@
+#
+# This file is only for testing the rocksdb.optionsfile property in YCSB.
+# The values are chosen for being extremely unlikely to match defaults.
+#
+
+[Version]
+  rocksdb_version=6.2.2
+  options_file_version=1.1
+
+[DBOptions]
+  WAL_size_limit_MB=42
+  create_if_missing=true
+  create_missing_column_families=true
+
+[CFOptions "default"]
+  ttl=42
+
+[TableOptions/BlockBasedTable "default"]
+
+[CFOptions "usertable"]
+  ttl=42
+
+[TableOptions/BlockBasedTable "usertable"]


### PR DESCRIPTION
This adds support to run RocksDB with a custom [options file](https://github.com/facebook/rocksdb/wiki/RocksDB-Options-File).

This also updates the RocksDB Maven artifact version to the latest (6.2.2).
