### PR TITLE
[jdbc] Add support for SQL:2008 FETCH FIRST n ROWS ONLY for Scans

### DIFF
--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -82,10 +82,11 @@ public class JdbcDBClient extends DB {
   /** The field name prefix in the table. */
   public static final String COLUMN_PREFIX = "FIELD";
 
-  /** Use SQL:2008 FETCH FIRST for Scan. */
-  private boolean ansiFetchFirst = false;
-  
-  private boolean sqlserver = false;
+  /** SQL:2008 standard: FETCH FIRST n ROWS after the ORDER BY. */
+  private boolean sqlansiScans = false;
+  /** SQL Server before 2012: TOP n after the SELECT. */
+  private boolean sqlserverScans = false;
+
   private List<Connection> conns;
   private boolean initialized = false;
   private Properties props;
@@ -187,7 +188,7 @@ public class JdbcDBClient extends DB {
     String passwd = props.getProperty(CONNECTION_PASSWD, DEFAULT_PROP);
     String driver = props.getProperty(DRIVER_CLASS);
 
-  
+
 
     this.jdbcFetchSize = getIntProperty(props, JDBC_FETCH_SIZE);
     this.batchSize = getIntProperty(props, DB_BATCH_SIZE);
@@ -196,9 +197,23 @@ public class JdbcDBClient extends DB {
     this.batchUpdates = getBoolProperty(props, JDBC_BATCH_UPDATES, false);
 
     try {
+//  The SQL Syntax for Scan depends on the DB engine
+//  - SQL:2008 standard: FETCH FIRST n ROWS after the ORDER BY
+//  - SQL Server before 2012: TOP n after the SELECT
+//  - others (MySQL,MariaDB, PostgreSQL before 8.4)
+//  TODO: check product name and version rather than driver name
       if (driver != null) {
         if (driver.contains("sqlserver")) {
-          sqlserver = true;
+          sqlserverScans = true;
+          sqlansiScans = false;
+        }
+        if (driver.contains("oracle")) {
+          sqlserverScans = false;
+          sqlansiScans = true;
+        }
+        if (driver.contains("postgres")) {
+          sqlserverScans = false;
+          sqlansiScans = true;
         }
         Class.forName(driver);
       }
@@ -311,7 +326,7 @@ public class JdbcDBClient extends DB {
 
   private PreparedStatement createAndCacheScanStatement(StatementType scanType, String key)
       throws SQLException {
-    String select = dbFlavor.createScanStatement(scanType, key, sqlserver);
+    String select = dbFlavor.createScanStatement(scanType, key, sqlserverScans, sqlansiScans);
     PreparedStatement scanStatement = getShardConnectionByKey(key).prepareStatement(select);
     if (this.jdbcFetchSize > 0) {
       scanStatement.setFetchSize(this.jdbcFetchSize);
@@ -360,9 +375,11 @@ public class JdbcDBClient extends DB {
       if (scanStatement == null) {
         scanStatement = createAndCacheScanStatement(type, startKey);
       }
-      if (sqlserver) {
+      // SQL Server TOP syntax is at first
+      if (sqlserverScans) {
         scanStatement.setInt(1, recordcount);
         scanStatement.setString(2, startKey);
+      // FETCH FIRST and LIMIT are at the end
       } else {
         scanStatement.setString(1, startKey);
         scanStatement.setInt(2, recordcount);

--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -82,6 +82,9 @@ public class JdbcDBClient extends DB {
   /** The field name prefix in the table. */
   public static final String COLUMN_PREFIX = "FIELD";
 
+  /** Use SQL:2008 FETCH FIRST for Scan. */
+  private boolean ansiFetchFirst = false;
+  
   private boolean sqlserver = false;
   private List<Connection> conns;
   private boolean initialized = false;

--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -184,9 +184,7 @@ public class JdbcDBClient extends DB {
     String passwd = props.getProperty(CONNECTION_PASSWD, DEFAULT_PROP);
     String driver = props.getProperty(DRIVER_CLASS);
 
-    if (driver.contains("sqlserver")) {
-      sqlserver = true;
-    }
+  
 
     this.jdbcFetchSize = getIntProperty(props, JDBC_FETCH_SIZE);
     this.batchSize = getIntProperty(props, DB_BATCH_SIZE);
@@ -196,6 +194,9 @@ public class JdbcDBClient extends DB {
 
     try {
       if (driver != null) {
+        if (driver.contains("sqlserver")) {
+          sqlserver = true;
+        }
         Class.forName(driver);
       }
       int shardCount = 0;

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
@@ -66,5 +66,5 @@ public abstract class DBFlavor {
    * Create and return a SQL statement for scanning data.
    */
   public abstract String createScanStatement(StatementType scanType, String key,
-                                             boolean sqlserver, boolean ansiFetchFirst);
+                                             boolean sqlserverScans, boolean sqlansiScans);
 }

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
@@ -65,5 +65,6 @@ public abstract class DBFlavor {
   /**
    * Create and return a SQL statement for scanning data.
    */
-  public abstract String createScanStatement(StatementType scanType, String key, boolean sqlserver);
+  public abstract String createScanStatement(StatementType scanType, String key,
+                                             boolean sqlserver, boolean ansiFetchFirst);
 }

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DefaultDBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DefaultDBFlavor.java
@@ -84,7 +84,7 @@ public class DefaultDBFlavor extends DBFlavor {
   }
 
   @Override
-  public String createScanStatement(StatementType scanType, String key, boolean sqlserver) {
+  public String createScanStatement(StatementType scanType, String key, boolean sqlserver, boolean ansiFetchFirst) {
     StringBuilder select;
     if (sqlserver) {
       select = new StringBuilder("SELECT TOP (?) * FROM ");
@@ -98,7 +98,11 @@ public class DefaultDBFlavor extends DBFlavor {
     select.append(" ORDER BY ");
     select.append(JdbcDBClient.PRIMARY_KEY);
     if (!sqlserver) {
-      select.append(" LIMIT ?");
+      if (ansiFetchFirst) {
+        select.append(" FETCH FIRST ? ROWS ONLY");
+      } else {
+        select.append(" LIMIT ?");
+      }
     }
     return select.toString();
   }

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DefaultDBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DefaultDBFlavor.java
@@ -84,9 +84,9 @@ public class DefaultDBFlavor extends DBFlavor {
   }
 
   @Override
-  public String createScanStatement(StatementType scanType, String key, boolean sqlserver, boolean ansiFetchFirst) {
+  public String createScanStatement(StatementType scanType, String key, boolean sqlserverScans, boolean sqlansiScans) {
     StringBuilder select;
-    if (sqlserver) {
+    if (sqlserverScans) {
       select = new StringBuilder("SELECT TOP (?) * FROM ");
     } else {
       select = new StringBuilder("SELECT * FROM ");
@@ -97,8 +97,8 @@ public class DefaultDBFlavor extends DBFlavor {
     select.append(" >= ?");
     select.append(" ORDER BY ");
     select.append(JdbcDBClient.PRIMARY_KEY);
-    if (!sqlserver) {
-      if (ansiFetchFirst) {
+    if (!sqlserverScans) {
+      if (sqlansiScans) {
         select.append(" FETCH FIRST ? ROWS ONLY");
       } else {
         select.append(" LIMIT ?");


### PR DESCRIPTION
Currently, the JDBC interface implements the Scan with:

- SELECT TOP for SQL Server
- ORDER BY ... LIMIT for others

Today, most databases use the ORDER BY ... FETCH FIRST ... ROWS which is the SQL standard since 2008. 
See [Markus Winand matrix](https://www.slideshare.net/MarkusWinand/modern-sql/120)

In this PR I kept the "sqlserver" boolean but renamed it "sqlserverScans" as it is used only for scans. And I added a "sqlansiScans" for the FETCH FIRST syntax.

For compatibility, I kept it at false, and enable it only when the driver contains "oracle" or "postgres" as these are the common databases supporting the SQL ANSI syntax. But actually only SQLite, MySQL and MariaDB need to use this LIMIT syntax in current versions.

In the future, it is probably better to check the product and version once connected. Or maybe try the 3 syntaxes at connection by parsing a simple query and chose the first one with no error.