### PR TITLE
Fixed Postgresnosql read operation missing tuple.

### DIFF
--- a/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
+++ b/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
@@ -151,11 +151,11 @@ public class PostgreNoSQLDBClient extends DB {
 
       if (result != null) {
         if (fields == null){
-          while (resultSet.next()){
-            String field = resultSet.getString(2);
-            String value = resultSet.getString(3);
+          do{
+            String field = resultSet.getString(1);
+            String value = resultSet.getString(2);
             result.put(field, new StringByteIterator(value));
-          }
+          }while (resultSet.next());
         } else {
           for (String field : fields) {
             String value = resultSet.getString(field);


### PR DESCRIPTION
This patch fixes two bugs in the Postgresnosql benchmark read operation.
First, the offset accessed from the ResultSet of a read operation were incorrect, the possitions 2 and 3 were accessed when it should be 1 and 2.
Secondly, after a read operation, the ResultSet.next() was moving the cursor without adding the result to the YCSB map.