### PR TITLE
Read ResultSet was not iterated correctly.

### DIFF
--- a/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
+++ b/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
@@ -151,11 +151,11 @@ public class PostgreNoSQLDBClient extends DB {
 
       if (result != null) {
         if (fields == null){
-          while (resultSet.next()){
+          do{
             String field = resultSet.getString(2);
             String value = resultSet.getString(3);
             result.put(field, new StringByteIterator(value));
-          }
+          }while (resultSet.next());
         } else {
           for (String field : fields) {
             String value = resultSet.getString(field);


### PR DESCRIPTION
The first ResultSet.next() call to test if the ResultSet was empty moved the cursor without adding the resulting row to the YCSB result callback.