### PR TITLE
[core] make it possible to use zero operation count again. (#1382)

### DIFF
--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -418,7 +418,7 @@ public final class Client {
           opcount = Integer.parseInt(props.getProperty(RECORD_COUNT_PROPERTY, DEFAULT_RECORD_COUNT));
         }
       }
-      if (threadcount > opcount){
+      if (threadcount > opcount && opcount > 0){
         threadcount = opcount;
         System.out.println("Warning: the threadcount is bigger than recordcount, the threadcount will be recordcount!");
       }


### PR DESCRIPTION
Solving https://github.com/brianfrankcooper/YCSB/issues/1382

Previously, if you defined maxexecutiontime and not defined operationcount
parameter (or set operationcount=0), then you were able to run YCSB for a
given period of time and measure the number of operations you get during
the load test.

Since #1323 was merged, it it not possible to use operationcount=0, as
the thread count will be set to 0 in this case and no client thread will
be created. This PR makes it possible to use operationcount=0 again.