### PR TITLE
[ignite] Updates ignite to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ LICENSE file.
     <hbase14.version>1.4.2</hbase14.version>
     <hbase20.version>2.0.0</hbase20.version>
     <hypertable.version>0.9.5.6</hypertable.version>
-    <ignite.version>2.7.0</ignite.version>
+    <ignite.version>2.7.6</ignite.version>
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>1.6.0</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>


### PR DESCRIPTION
Reference: https://ignite.apache.org/download.cgi 

Without this patch, benchmarking fails for the latest version of Apache Ignite.