### PR TITLE
[kudu] Close clients on cleanup

### DIFF
--- a/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
@@ -223,6 +223,7 @@ public class KuduYCSBClient extends site.ycsb.DB {
   public void cleanup() throws DBException {
     try {
       this.session.close();
+      this.client.close();
     } catch (Exception e) {
       throw new DBException("Couldn't cleanup the session", e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ LICENSE file.
     <hypertable.version>0.9.5.6</hypertable.version>
     <ignite.version>2.7.6</ignite.version>
     <infinispan.version>7.2.2.Final</infinispan.version>
-    <kudu.version>1.6.0</kudu.version>
+    <kudu.version>1.11.1</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>
     <!--<mapkeeper.version>1.0</mapkeeper.version>-->
     <mongodb.version>3.11.0</mongodb.version>


### PR DESCRIPTION
This patch makes sure clients are closed properly on cleanup.

I also updated to the latest client version (1.11.1).