### PR TITLE
Port ycsb to Python3 and also make it Python2 compatible

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -16,6 +16,7 @@
 # LICENSE file.
 #
 
+from __future__ import print_function
 import errno
 import fnmatch
 import io
@@ -28,7 +29,7 @@ try:
     mod = __import__('argparse')
     import argparse
 except ImportError:
-    print >> sys.stderr, '[ERROR] argparse not found. Try installing it via "pip".'
+    print('[ERROR] argparse not found. Try installing it via "pip".', file=sys.stderr)
     exit(1)
 
 BASE_URL = "https://github.com/brianfrankcooper/YCSB/tree/master/"
@@ -116,27 +117,27 @@ OPTIONS = {
 }
 
 def usage():
-    output = io.BytesIO()
-    print >> output, "%s command database [options]" % sys.argv[0]
+    output = io.StringIO()
+    print(u"%s command database [options]" % sys.argv[0], file=output)
 
-    print >> output, "\nCommands:"
+    print(u"\nCommands:", file=output)
     for command in sorted(COMMANDS.keys()):
-        print >> output, "    %s %s" % (command.ljust(14),
-                                        COMMANDS[command]["description"])
+        print(u"    %s %s" % (command.ljust(14),
+                                        COMMANDS[command]["description"]), file=output)
 
-    print >> output, "\nDatabases:"
+    print(u"\nDatabases:", file=output)
     for db in sorted(DATABASES.keys()):
-        print >> output, "    %s %s" % (db.ljust(14), BASE_URL +
-                                        db.split("-")[0])
+        print(u"    %s %s" % (db.ljust(14), BASE_URL +
+                                        db.split("-")[0]), file=output)
 
-    print >> output, "\nOptions:"
+    print(u"\nOptions:", file=output)
     for option in sorted(OPTIONS.keys()):
-        print >> output, "    %s %s" % (option.ljust(14), OPTIONS[option])
+        print(u"    %s %s" % (option.ljust(14), OPTIONS[option]), file=output)
 
-    print >> output, """\nWorkload Files:
+    print(u"""\nWorkload Files:
     There are various predefined workloads under workloads/ directory.
     See https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties
-    for the list of workload properties."""
+    for the list of workload properties.""", file=output)
 
     return output.getvalue()
 
@@ -172,18 +173,18 @@ def check_output(*popenargs, **kwargs):
         if cmd is None:
             cmd = popenargs[0]
         error = subprocess.CalledProcessError(retcode, cmd)
-        error.output = output
+        error.output = output.decode()
         raise error
-    return output
+    return output.decode()
 
 def debug(message):
-    print >> sys.stderr, "[DEBUG] ", message
+    print("[DEBUG] ", message, file=sys.stderr)
 
 def warn(message):
-    print >> sys.stderr, "[WARN] ", message
+    print("[WARN] ", message, file=sys.stderr)
 
 def error(message):
-    print >> sys.stderr, "[ERROR] ", message
+    print("[ERROR] ", message, file=sys.stderr)
 
 def find_jars(dir, glob='*.jar'):
     jars = []
@@ -220,7 +221,7 @@ def get_classpath_from_maven(module):
         # the last module will be the datastore binding
         line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
         return line[0][len("classpath="):]
-    except subprocess.CalledProcessError, err:
+    except subprocess.CalledProcessError as err:
         error("Attempting to generate a classpath from Maven failed "
               "with return code '" + str(err.returncode) + "'. The output from "
               "Maven follows, try running "
@@ -311,7 +312,7 @@ def main():
                      main_classname, "-db", db_classname] + remaining)
     if command:
         ycsb_command.append(command)
-    print >> sys.stderr, " ".join(ycsb_command)
+    print(" ".join(ycsb_command), file=sys.stderr)
     try:
         return subprocess.call(ycsb_command)
     except OSError as e:


### PR DESCRIPTION
Python2 has reached EOL, so we should port the ycsb to Python3.
The modification also makes the ycsb Python2 compatible.