### PR TITLE
[dynamodb] Improve endpoint and region config

### DIFF
--- a/dynamodb/conf/dynamodb.properties
+++ b/dynamodb/conf/dynamodb.properties
@@ -68,9 +68,15 @@
 #when testing in HASH_AND_RANG mode.
 #dynamodb.hashKeyValue = <some value of your choice>
 
-# Endpoint to connect to.For best latency, it is recommended 
-# to choose the endpoint which is closer to the client. 
-# Default is us-east-1
+# AWS Region code to connect to:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions 
+# Set this parameter, unless you are using the default value ('us-east-1).
+#dynamodb.region = us-east-1
+
+# Endpoint to connect to. If not set, the endpoint will be set automatically
+# based on the region and for HTTP connections. When using a non-standard
+# endpoint (such as a proxy), the region parameter is still required to generate
+# the proper message's signature.
 #dynamodb.endpoint = http://dynamodb.us-east-1.amazonaws.com
 
 # Strongly recommended to set to uniform.Refer FAQs in README

--- a/dynamodb/pom.xml
+++ b/dynamodb/pom.xml
@@ -33,7 +33,7 @@ LICENSE file.
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.10.48</version>
+      <version>1.11.812</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
* Upgrade AWS SDK from version 1.10.48 to 1.11.812.

* Introduce a new configuration parameter, dynamodb.region, which
  represents a valid AWS region code (see
  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
  for example). If specifying the region, it is not necessary to specify
  the dynamodb.endpoint parameter.

* Introduce support for non-standard endpoints. Before this commit,
  setting the endpoint to a non-standard one, like a proxy, but
  ultimately connecting to a region different from 'us-east-1' would
  lead to a credential errors due to bad signature:

  ERROR site.ycsb.db.DynamoDBClient
  -com.amazonaws.AmazonServiceException: Credential should be scoped to
  a valid region, not 'us-east-1'.  (Service: AmazonDynamoDBv2; Status
  Code: 400; Error Code: InvalidSignatureException;

  With this commit, if using a proxy as an endpoint, by setting also the
  region via dynamodb.region, it will work with no error.

* Set TCP Keep-Alive to true. Even it makes sense to be used by YCSB, it
  apparently doesn't improve performance notably given the connection
  reuse that the DynamoDB client is doing.

* Update the example config file with the endpoint and region parameters
  and behavior.