### PR TITLE
[rocksdb] change mvn build target

### DIFF
--- a/rocksdb/README.md
+++ b/rocksdb/README.md
@@ -26,7 +26,7 @@ Clone the YCSB git repository and compile:
 
     git clone https://github.com/brianfrankcooper/YCSB.git
     cd YCSB
-    mvn clean package
+    mvn -pl site.ycsb:rocksdb-binding -am clean package
 
 ### 2. Run YCSB
 


### PR DESCRIPTION
change mvn build target to just build rocksdb-binding. This also makes the build command to be consistent with these for other bindings.