### PR TITLE
[spanner] chore: updates spanner client lib to 2.0.1

### DIFF
--- a/cloudspanner/pom.xml
+++ b/cloudspanner/pom.xml
@@ -48,6 +48,17 @@ LICENSE file.
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-api</artifactId>
+      <version>0.23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-traceviewer</artifactId>
+      <version>0.23.0</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ LICENSE file.
     <azurecosmos.version>2.2.3</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>0.36.0-beta</cloudspanner.version>
+    <cloudspanner.version>2.0.1</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>


### PR DESCRIPTION
We were using a very old version of the cloud spanner client libraries. This PR updates to the latest version (2.0.1).