### PR TITLE
Cockroach aost

### DIFF
--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -114,6 +114,7 @@ bin/ycsb run jdbc -P workloads/workloada -P db.properties -cp mysql-connector-ja
 ```sh
 db.driver=com.mysql.jdbc.Driver				# The JDBC driver class to use.
 db.url=jdbc:mysql://127.0.0.1:3306/ycsb		# The Database connection URL.
+db.dialect=									# Optional database dialect
 db.user=admin								# User name for the connection.
 db.passwd=admin								# Password for the connection.
 db.batchsize=1000             # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
@@ -134,11 +135,11 @@ Some JDBC drivers support re-writing batched insert statements into multi-row in
   * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html) with `db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true`
   * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters) with `db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true`
 
-## JDBC Parameter to use database specific syntax
+## configuration properties use database specific syntax
 
 Each SQL statement may require database specific variation.  The variation is auto detected by examining `db.url`.  Optionally, `db.dialect` `configuration properties` can be used for supported databases.
 
-`db.url` auto detects the following variations:
+`db.url` is examined for presence of the following keywords: `oracle`, `phoenix`, `postgres`, `sqlserver`.
 
 | Database 		| insert 	| select 	| delete 	| update 	| select ... limit 			|
 | --            | --      	| --		| --		| --		| --						|
@@ -148,7 +149,7 @@ Each SQL statement may require database specific variation.  The variation is au
 | SQL Server    |       	|			|			|			| SELECT TOP (?)			|
 
 
-`db.dialect` is supported for the following databases:
+`db.dialect` is supported for the following databases where auto detection is not sufficient and/or additional control is warranted:
 
 | Database 			| insert 	| select 						| delete 	| update 	| select ... limit 					|
 | --            	| --      	| --							| --		| --		| --								|

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -143,17 +143,17 @@ Each SQL statement may require database specific variation.  The variation is au
 
 | Database 		| insert 	| select 	| delete 	| update 	| select ... limit 			|
 | --            | --      	| --		| --		| --		| --						|
-| Oracle        |       	|			|			|			| FETCH FIRST ? ROWS ONLY	|
-| Postgres      |       	|			|			|			| FETCH FIRST ? ROWS ONLY	|
-| Phoenix       | upsert    |			|			| upsert	|							|
-| SQL Server    |       	|			|			|			| SELECT TOP (?)			|
+| Oracle        |       	|			|			|			| `FETCH FIRST ? ROWS ONLY`	|
+| Postgres      |       	|			|			|			| `FETCH FIRST ? ROWS ONLY`	|
+| Phoenix       | `upsert`  |			|			| `upsert`	|							|
+| SQL Server    |       	|			|			|			| `SELECT TOP (?)`			|
 
 
 `db.dialect` is supported for the following databases where auto detection is not sufficient and/or additional control is warranted:
 
 | Option | Database 			| insert 	| select 						| delete 	| update 	| select ... limit 					|
 | --            	| --       | --      	| --							| --		| --		| --								|
-| db.dialect=jdbc:cockroach[:{time_interval}] | CockroachDB AOST  |       	| select .. as of system time ..|			|			| select .. as of system time ..	|
+| `db.dialect=jdbc:cockroach[:{time_interval}]` | CockroachDB AOST  |       	| `select .. as of system time ..`|			|			| `select .. as of system time ..`	|
 
 
 ### db.dialect=jdbc:cockroach[:{time_interval}]

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -117,11 +117,11 @@ db.url=jdbc:mysql://127.0.0.1:3306/ycsb		# The Database connection URL.
 db.dialect=									# Optional database dialect
 db.user=admin								# User name for the connection.
 db.passwd=admin								# Password for the connection.
-db.batchsize=1000             # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
+db.batchsize=1000                           # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
 jdbc.fetchsize=10							# The JDBC fetch size hinted to the driver.
 jdbc.autocommit=true						# The JDBC connection auto-commit property for the driver.
-jdbc.batchupdateapi=false     # Use addBatch()/executeBatch() JDBC methods instead of executeUpdate() for writes (default: false)
-db.batchsize=1000             # The number of rows to be batched before commit (or executeBatch() when jdbc.batchupdateapi=true)
+jdbc.batchupdateapi=false                   # Use addBatch()/executeBatch() JDBC methods instead of executeUpdate() for writes (default: false)
+db.batchsize=1000                           # The number of rows to be batched before commit (or executeBatch() when jdbc.batchupdateapi=true)
 ```
 
 Please refer to https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties for all other YCSB core properties.
@@ -135,11 +135,11 @@ Some JDBC drivers support re-writing batched insert statements into multi-row in
   * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html) with `db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true`
   * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters) with `db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true`
 
-## configuration properties use database specific syntax
+## Configuration Properties control for database specific SQL syntax
 
 Each SQL statement may require database specific variation.  The variation is auto detected by examining `db.url`.  Optionally, `db.dialect` `configuration properties` can be used for supported databases.
 
-`db.url` is examined for presence of the following keywords: `oracle`, `phoenix`, `postgres`, `sqlserver`.
+`db.url` is examined for presence of the following keywords: `oracle`, `phoenix`, `postgres`, `sqlserver`.  Blank means the default SQL is used.
 
 | Database 		| insert 	| select 	| delete 	| update 	| select ... limit 			|
 | --            | --      	| --		| --		| --		| --						|
@@ -151,9 +151,9 @@ Each SQL statement may require database specific variation.  The variation is au
 
 `db.dialect` is supported for the following databases where auto detection is not sufficient and/or additional control is warranted:
 
-| Database 			| insert 	| select 						| delete 	| update 	| select ... limit 					|
-| --            	| --      	| --							| --		| --		| --								|
-| CockroachDB AOST  |       	| select .. as of system time ..|			|			| select .. as of system time ..	|
+| Option | Database 			| insert 	| select 						| delete 	| update 	| select ... limit 					|
+| --            	| --       | --      	| --							| --		| --		| --								|
+| db.dialect=jdbc:cockroach[:{time_interval}] | CockroachDB AOST  |       	| select .. as of system time ..|			|			| select .. as of system time ..	|
 
 
 ### db.dialect=jdbc:cockroach[:{time_interval}]

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -112,14 +112,14 @@ bin/ycsb run jdbc -P workloads/workloada -P db.properties -cp mysql-connector-ja
 ## Configuration Properties
 
 ```sh
-db.driver=com.mysql.jdbc.Driver				# The JDBC driver class to use.
-db.url=jdbc:mysql://127.0.0.1:3306/ycsb		# The Database connection URL.
-db.dialect=									# Optional database dialect
-db.user=admin					          	# User name for the connection.
-db.passwd=admin								# Password for the connection.
+db.driver=com.mysql.jdbc.Driver             # The JDBC driver class to use.
+db.url=jdbc:mysql://127.0.0.1:3306/ycsb     # The Database connection URL.
+db.dialect=                                 # Optional database dialect
+db.user=admin                               # User name for the connection.
+db.passwd=admin                             # Password for the connection.
 db.batchsize=1000                           # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
-jdbc.fetchsize=10							# The JDBC fetch size hinted to the driver.
-jdbc.autocommit=true						# The JDBC connection auto-commit property for the driver.
+jdbc.fetchsize=10                           # The JDBC fetch size hinted to the driver.
+jdbc.autocommit=true                        # The JDBC connection auto-commit property for the driver.
 jdbc.batchupdateapi=false                   # Use addBatch()/executeBatch() JDBC methods instead of executeUpdate() for writes (default: false)
 db.batchsize=1000                           # The number of rows to be batched before commit (or executeBatch() when jdbc.batchupdateapi=true)
 ```

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -128,8 +128,42 @@ Please refer to https://github.com/brianfrankcooper/YCSB/wiki/Core-Properties fo
 ## JDBC Parameter to Improve Insert Performance
 
 Some JDBC drivers support re-writing batched insert statements into multi-row insert statements. This technique can yield order of magnitude improvement in insert statement performance. To enable this feature:
-- **db.batchsize** must be greater than 0.  The magniute of the improvement can be adjusted by varying **batchsize**. Start with a small number and increase at small increments until diminishing return in the improvement is observed. 
+- **db.batchsize** must be greater than 0.  The magnitude of the improvement can be adjusted by varying **batchsize**. Start with a small number and increase at small increments until diminishing return in the improvement is observed. 
 - set **jdbc.batchupdateapi=true** to enable batching.
 - set JDBC driver specific connection parameter in **db.url** to enable the rewrite as shown in the examples below:
   * MySQL [rewriteBatchedStatements=true](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html) with `db.url=jdbc:mysql://127.0.0.1:3306/ycsb?rewriteBatchedStatements=true`
   * Postgres [reWriteBatchedInserts=true](https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters) with `db.url=jdbc:postgresql://127.0.0.1:5432/ycsb?reWriteBatchedInserts=true`
+
+## JDBC Parameter to use database specific syntax
+
+Each SQL statement may require variation for specific databases.  The variation is autodected by examining `db.url` and `db.dialect` from `Configuration Properties`
+
+`db.url` is used to select the folloing non default setup:
+
+| SQL Statement | Oracle | Postgres | Phoenix | SQL Server |
+| ------------- | -------| ---------| ------- | ---------- |
+| insert        |        |          | upsert  |            |
+| read     	 	|        |          |         |            |
+| delete		|        |          |         |            |
+| update        |        |          |         |            |
+| scan          |        |          |         |            |
+
+`db.dialect` is used to select the folloing non default setup:
+
+| SQL Statement | CockroachDB 						| 
+| ------------- | ----------------------------------| 
+| insert        |             						|
+| read     	 	| select .. as of system time .. 	| 
+| delete		|          						   	| 
+| update        |             						| 
+| scan          | select .. as of system time ..   	|
+
+Examples of `db.dialect`:
+
+```sh
+db.dialect="jdbc:cockroach"											# use as of system time '-5s'
+db.dialect="jdbc:cockroach:-1s"										# use as of system time '-1s'
+db.dialect="jdbc:cockroach:experimental_follower_read_timestamp()"	# use as of system time experimental_follower_read_timestamp() requiring a license key
+```
+
+

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -136,34 +136,40 @@ Some JDBC drivers support re-writing batched insert statements into multi-row in
 
 ## JDBC Parameter to use database specific syntax
 
-Each SQL statement may require variation for specific databases.  The variation is autodected by examining `db.url` and `db.dialect` from `Configuration Properties`
+Each SQL statement may require database specific variation.  The variation is auto detected by examining `db.url`.  Optionally, `db.dialect` `configuration properties` can be used for supported databases.
 
-`db.url` is used to select the folloing non default setup:
+`db.url` auto detects the following variations:
 
-| SQL Statement | Oracle | Postgres | Phoenix | SQL Server |
-| ------------- | -------| ---------| ------- | ---------- |
-| insert        |        |          | upsert  |            |
-| read     	 	|        |          |         |            |
-| delete		|        |          |         |            |
-| update        |        |          |         |            |
-| scan          |        |          |         |            |
+| Database 		| insert 	| select 	| delete 	| update 	| select ... limit 			|
+| --            | --      	| --		| --		| --		| --						|
+| Oracle        |       	|			|			|			| FETCH FIRST ? ROWS ONLY	|
+| Postgres      |       	|			|			|			| FETCH FIRST ? ROWS ONLY	|
+| Phoenix       | upsert    |			|			| upsert	|							|
+| SQL Server    |       	|			|			|			| SELECT TOP (?)			|
 
-`db.dialect` is used to select the folloing non default setup:
 
-| SQL Statement | CockroachDB 						| 
-| ------------- | ----------------------------------| 
-| insert        |             						|
-| read     	 	| select .. as of system time .. 	| 
-| delete		|          						   	| 
-| update        |             						| 
-| scan          | select .. as of system time ..   	|
+`db.dialect` is supported for the following databases:
 
-Examples of `db.dialect`:
+| Database 			| insert 	| select 						| delete 	| update 	| select ... limit 					|
+| --            	| --      	| --							| --		| --		| --								|
+| CockroachDB AOST  |       	| select .. as of system time ..|			|			| select .. as of system time ..	|
 
-```sh
-db.dialect="jdbc:cockroach"											# use as of system time '-5s'
-db.dialect="jdbc:cockroach:-1s"										# use as of system time '-1s'
-db.dialect="jdbc:cockroach:experimental_follower_read_timestamp()"	# use as of system time experimental_follower_read_timestamp() requiring a license key
+
+### db.dialect=jdbc:cockroach[:{time_interval}]
+
+The default `{time_interval}` is `'-5s'`
+
+- use as of system time '-5s'
+```bash
+db.dialect="jdbc:cockroach"											
 ```
 
+- use as of system time '-1s'
+```bash
+db.dialect="jdbc:cockroach:-1s"										
+```
 
+- use as of system time experimental_follower_read_timestamp() requiring a license key
+```bash
+db.dialect="jdbc:cockroach:experimental_follower_read_timestamp()"	
+```

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -115,7 +115,7 @@ bin/ycsb run jdbc -P workloads/workloada -P db.properties -cp mysql-connector-ja
 db.driver=com.mysql.jdbc.Driver				# The JDBC driver class to use.
 db.url=jdbc:mysql://127.0.0.1:3306/ycsb		# The Database connection URL.
 db.dialect=									# Optional database dialect
-db.user=admin								# User name for the connection.
+db.user=admin					          	# User name for the connection.
 db.passwd=admin								# Password for the connection.
 db.batchsize=1000                           # The batch size for doing batched inserts. Defaults to 0. Set to >0 to use batching.
 jdbc.fetchsize=10							# The JDBC fetch size hinted to the driver.

--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -47,6 +47,9 @@ public class JdbcDBClient extends DB {
   /** The class to use as the jdbc driver. */
   public static final String DRIVER_CLASS = "db.driver";
 
+  /** The class to use as the jdbc driver. */
+  public static final String DB_DIALECT = "db.dialect";
+
   /** The URL to connect to the database. */
   public static final String CONNECTION_URL = "db.url";
 
@@ -187,6 +190,7 @@ public class JdbcDBClient extends DB {
     String user = props.getProperty(CONNECTION_USER, DEFAULT_PROP);
     String passwd = props.getProperty(CONNECTION_PASSWD, DEFAULT_PROP);
     String driver = props.getProperty(DRIVER_CLASS);
+    String dialect = props.getProperty(DB_DIALECT);
 
     this.jdbcFetchSize = getIntProperty(props, JDBC_FETCH_SIZE);
     this.batchSize = getIntProperty(props, DB_BATCH_SIZE);
@@ -239,7 +243,12 @@ public class JdbcDBClient extends DB {
 
       cachedStatements = new ConcurrentHashMap<StatementType, PreparedStatement>();
 
-      this.dbFlavor = DBFlavor.fromJdbcUrl(urlArr[0]);
+      if (dialect == null) {
+        this.dbFlavor = DBFlavor.fromJdbcUrl(urlArr[0]);
+      } else {
+        this.dbFlavor = DBFlavor.fromJdbcUrl(dialect);
+        System.out.println("Using database dialect: " + dialect);
+      }
     } catch (ClassNotFoundException e) {
       System.err.println("Error in initializing the JDBS driver: " + e);
       throw new DBException(e);

--- a/jdbc/src/main/java/site/ycsb/db/flavors/CockroachDBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/CockroachDBFlavor.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package site.ycsb.db.flavors;
+
+import site.ycsb.db.JdbcDBClient;
+import site.ycsb.db.StatementType;
+
+/**
+ * Database flavor for CockroachDB. Captures syntax differences used by CockroachDB as of system time.
+ */
+public class CockroachDBFlavor extends DefaultDBFlavor {
+  private String aost;
+
+  public CockroachDBFlavor() {
+    super(DBName.COCKROACH);
+    this.aost="'-5s'";
+  }
+  public CockroachDBFlavor(String aost) {
+    super(DBName.COCKROACH);    
+    this.aost = aost;
+  }
+
+  @Override
+  public String createReadStatement(StatementType readType, String key) {
+    StringBuilder read = new StringBuilder("SELECT * FROM ");
+    read.append(readType.getTableName());
+    read.append(" AS OF SYSTEM TIME " + this.aost);
+    read.append(" WHERE ");
+    read.append(JdbcDBClient.PRIMARY_KEY);
+    read.append(" = ");
+    read.append("?");
+    System.err.println("CockroachDB: " + read.toString());
+    return read.toString();
+  }
+
+  @Override
+  public  String createScanStatement(StatementType scanType, String key,
+                                     boolean sqlserverScans, boolean sqlansiScans) {
+    StringBuilder select = new StringBuilder("SELECT * FROM ");
+    select.append(scanType.getTableName());
+    select.append(" AS OF SYSTEM TIME " + this.aost);
+    select.append(" WHERE ");
+    select.append(JdbcDBClient.PRIMARY_KEY);
+    select.append(" >= ?");
+    select.append(" ORDER BY ");
+    select.append(JdbcDBClient.PRIMARY_KEY);
+    select.append(" LIMIT ?");
+    System.err.println("CockroachDB: " + select.toString());
+    return select.toString();
+  }
+}

--- a/jdbc/src/main/java/site/ycsb/db/flavors/CockroachDBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/CockroachDBFlavor.java
@@ -43,7 +43,7 @@ public class CockroachDBFlavor extends DefaultDBFlavor {
     read.append(JdbcDBClient.PRIMARY_KEY);
     read.append(" = ");
     read.append("?");
-    System.err.println("CockroachDB: " + read.toString());
+    System.out.println("CockroachDB: " + read.toString());
     return read.toString();
   }
 
@@ -59,7 +59,7 @@ public class CockroachDBFlavor extends DefaultDBFlavor {
     select.append(" ORDER BY ");
     select.append(JdbcDBClient.PRIMARY_KEY);
     select.append(" LIMIT ?");
-    System.err.println("CockroachDB: " + select.toString());
+    System.out.println("CockroachDB: " + select.toString());
     return select.toString();
   }
 }

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
@@ -41,7 +41,7 @@ public abstract class DBFlavor {
       return new PhoenixDBFlavor();
     } else if (url.startsWith("jdbc:cockroach")) {
       final String[] urlArr = url.split(":");
-      System.err.println("CockroachDB: Using AOST");
+      System.out.println("CockroachDB: Using AOST");
       if (urlArr.length <=2) {
         return new CockroachDBFlavor();
       } else {

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
@@ -26,6 +26,7 @@ public abstract class DBFlavor {
 
   enum DBName {
     DEFAULT,
+    COCKROACH,
     PHOENIX
   }
 
@@ -38,6 +39,14 @@ public abstract class DBFlavor {
   public static DBFlavor fromJdbcUrl(String url) {
     if (url.startsWith("jdbc:phoenix")) {
       return new PhoenixDBFlavor();
+    } else if (url.startsWith("jdbc:cockroach")) {
+      final String[] urlArr = url.split(":");
+      System.err.println("CockroachDB: Using AOST");
+      if (urlArr.length <=2) {
+        return new CockroachDBFlavor();
+      } else {
+        return new CockroachDBFlavor(urlArr[2]);
+      }
     }
     return new DefaultDBFlavor();
   }

--- a/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
+++ b/jdbc/src/main/java/site/ycsb/db/flavors/DBFlavor.java
@@ -47,8 +47,10 @@ public abstract class DBFlavor {
       } else {
         return new CockroachDBFlavor(urlArr[2]);
       }
+    } else {
+      System.out.println("Unsupported DBFlavor: " + url + ". Using default");      
+      return new DefaultDBFlavor();
     }
-    return new DefaultDBFlavor();
   }
 
   /**


### PR DESCRIPTION
Solves https://github.com/brianfrankcooper/YCSB/issues/1460, https://github.com/brianfrankcooper/YCSB/issues/1465, and https://github.com/brianfrankcooper/YCSB/issues/1466


add support for ` -p db.dialect=jdbc:cockroach[:{time interval}]`
- the default `time_interval` is `'-5s'`

## Build 

```bash
export YCSB_VER=0.18.0-SNAPSHOT
export YCSB=~/ycsb-jdbc-binding-$YCSB_VER
mvn -pl site.ycsb:jdbc-binding -am clean package
```

## Install
```bash
gzip -dc jdbc/target/ycsb-jdbc-binding-$YCSB_VER.tar.gz | tar -C ~ -xvf -
cd $YCSB/lib; curl -O --location https://jdbc.postgresql.org/download/postgresql-42.2.4.jar
```

## Test invalid dialects

## Test Default did not change existing behavior
```bash
cd $YCSB
# create table
java -cp lib/jdbc-binding-$YCSB_VER.jar:lib/postgresql-42.2.4.jar site.ycsb.db.JdbcDBCreateTable -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true" -p db.user=root -p db.passwd="" -n usertable 
# load initial data
bin/ycsb load jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p threadcount=3

```
## Test invalid dialect that will be using default
```bash
# workload A default
bin/ycsb run jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.dialect=xxxx -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1
```

### Test cockroach
```bash
# workload A default
bin/ycsb run jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1

# workload E default
bin/ycsb run jdbc -s -P workloads/workloade -p db.driver=org.postgresql.Driver -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1
```

## Test db.dialect=jdbc:cockroach

should expect to see the variations of the following in the stdout
```
CockroachDB: Using AOST
Using database dialect: jdbc:cockroach
CockroachDB: SELECT * FROM usertable AS OF SYSTEM TIME '-5s' WHERE YCSB_KEY = ?
```

```bash
# workload A with db.dialect=jdbc:cockroach which uses as of system time (AOST) '-5s'
bin/ycsb run jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.dialect=jdbc:cockroach -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1

CockroachDB: Using AOST
Using database dialect: jdbc:cockroach
CockroachDB: SELECT * FROM usertable AS OF SYSTEM TIME '-5s' WHERE YCSB_KEY = ?

# workload A with db.dialect=jdbc:cockroach:-1s'
bin/ycsb run jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.dialect="jdbc:cockroach:'-1s'" -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1

CockroachDB: Using AOST
Using database dialect: jdbc:cockroach:'-1s'
CockroachDB: SELECT * FROM usertable AS OF SYSTEM TIME '-1s' WHERE YCSB_KEY = ?

# workload A with db.dialect=jdbc:cockroachexperimental_follower_read_timestamp()'
bin/ycsb run jdbc -s -P workloads/workloada -p db.driver=org.postgresql.Driver -p db.dialect="jdbc:cockroach:experimental_follower_read_timestamp()" -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1

Using shards: 1, batchSize:128, fetchSize: 10
CockroachDB: Using AOST
Using database dialect: jdbc:cockroach:experimental_follower_read_timestamp()
CockroachDB: SELECT * FROM usertable AS OF SYSTEM TIME experimental_follower_read_timestamp() WHERE YCSB_KEY = ?

# workload E with db.dialect=jdbc:cockroach which uses as of system time (AOST) '-5s'
bin/ycsb run jdbc -s -P workloads/workloade -p db.driver=org.postgresql.Driver -p db.dialect=jdbc:cockroach -p db.url="jdbc:postgresql://127.0.0.1:26257/defaultdb?autoReconnect=true&sslmode=disable&ssl=false&reWriteBatchedInserts=true&loadBalanceHosts=true" -p db.user=root -p db.passwd="" -p db.batchsize=128  -p jdbc.fetchsize=10 -p jdbc.autocommit=true -p jdbc.batchupdateapi=true -p db.batchsize=128 -p recordcount=1000000 -p requestdistribution=uniform -p operationcount=300000 -p threadcount=1

CockroachDB: Using AOST
Using database dialect: jdbc:cockroach
CockroachDB: SELECT * FROM usertable AS OF SYSTEM TIME '-5s' WHERE YCSB_KEY >= ? ORDER BY YCSB_KEY LIMIT ?

```