### PR TITLE
Add transaction workload

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -75,3 +75,4 @@ solr7:site.ycsb.db.solr7.SolrClient
 tarantool:site.ycsb.db.TarantoolClient
 tablestore:site.ycsb.db.tablestore.TableStoreClient
 voltdb:site.ycsb.db.voltdb.VoltClient4
+transactionrest:site.ycsb.transactionwebservice.transactionrest.TransactionRestClient

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -102,7 +102,8 @@ DATABASES = {
     "solr6"        : "site.ycsb.db.solr6.SolrClient",
     "solr7"        : "site.ycsb.db.solr7.SolrClient",
     "tarantool"    : "site.ycsb.db.TarantoolClient",
-    "tablestore"   : "site.ycsb.db.tablestore.TableStoreClient"
+    "tablestore"   : "site.ycsb.db.tablestore.TableStoreClient",
+    "transactionrest": "site.ycsb.transactionwebservice.transactionrest.TransactionRestClient"
 }
 
 OPTIONS = {

--- a/core/src/main/java/site/ycsb/DB.java
+++ b/core/src/main/java/site/ycsb/DB.java
@@ -132,4 +132,18 @@ public abstract class DB {
    * @return The result of the operation.
    */
   public abstract Status delete(String table, String key);
+
+  // Newly introduced:
+  public Status insert(String table, String key, Map<String, ByteIterator> values, int balance) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  public Status transfer(
+      String table, String outgoingKey, String incomingKey, int amount) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  public Status deleteAndTransfer(String table, String key, String incomingKey) {
+    return Status.NOT_IMPLEMENTED;
+  }
 }

--- a/core/src/main/java/site/ycsb/DBWrapper.java
+++ b/core/src/main/java/site/ycsb/DBWrapper.java
@@ -48,6 +48,8 @@ public class DBWrapper extends DB {
   private final String scopeStringRead;
   private final String scopeStringScan;
   private final String scopeStringUpdate;
+  private final String scopeStringTransfer;
+  private final String scopeStringDeleteAndTransfer;
 
   public DBWrapper(final DB db, final Tracer tracer) {
     this.db = db;
@@ -61,6 +63,8 @@ public class DBWrapper extends DB {
     scopeStringRead = simple + "#read";
     scopeStringScan = simple + "#scan";
     scopeStringUpdate = simple + "#update";
+    scopeStringTransfer = simple + "#transfer";
+    scopeStringDeleteAndTransfer = simple + "#deleteandtransfer";
   }
 
   /**
@@ -241,6 +245,45 @@ public class DBWrapper extends DB {
       long en = System.nanoTime();
       measure("DELETE", res, ist, st, en);
       measurements.reportStatus("DELETE", res);
+      return res;
+    }
+  }
+
+  @Override
+  public Status insert(String table, String key, Map<String, ByteIterator> values, int balance) {
+    try (final TraceScope span = tracer.newScope(scopeStringInsert)) {
+      long ist = measurements.getIntendedtartTimeNs();
+      long st = System.nanoTime();
+      Status res = db.insert(table, key, values, balance);
+      long en = System.nanoTime();
+      measure("INSERT", res, ist, st, en);
+      measurements.reportStatus("INSERT", res);
+      return res;
+    }
+  }
+
+  @Override
+  public Status transfer(String table, String outgoingKey, String incomingKey, int amount) {
+    try (final TraceScope span = tracer.newScope(scopeStringTransfer)) {
+      long ist = measurements.getIntendedtartTimeNs();
+      long st = System.nanoTime();
+      Status res = db.transfer(table, outgoingKey, incomingKey, amount);
+      long en = System.nanoTime();
+      measure("TRANSFER", res, ist, st, en);
+      measurements.reportStatus("TRANSFER", res);
+      return res;
+    }
+  }
+
+  @Override
+  public Status deleteAndTransfer(String table, String key, String incomingKey) {
+    try (final TraceScope span = tracer.newScope(scopeStringDeleteAndTransfer)) {
+      long ist = measurements.getIntendedtartTimeNs();
+      long st = System.nanoTime();
+      Status res = db.deleteAndTransfer(table, key, incomingKey);
+      long en = System.nanoTime();
+      measure("DELETEANDTRANSFER", res, ist, st, en);
+      measurements.reportStatus("DELETEANDTRANSFER", res);
       return res;
     }
   }

--- a/core/src/main/java/site/ycsb/Status.java
+++ b/core/src/main/java/site/ycsb/Status.java
@@ -106,5 +106,7 @@ public class Status {
       "service for the current binding is not available.");
   public static final Status BATCHED_OK = new Status("BATCHED_OK", "The operation has been batched by " +
       "the binding to be executed later.");
+  public static final Status TRANSACTION_FAILED = new Status("TRANSACTION_FAILED", "The transaction " +
+      "was not successful due to integrity constraints, no error occured.");
 }
 

--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -88,7 +88,7 @@ public class CoreWorkload extends Workload {
    */
   public static final String FIELD_COUNT_PROPERTY_DEFAULT = "10";
   
-  private List<String> fieldnames;
+  protected List<String> fieldnames;
 
   /**
    * The name of the property for the field length distribution. Options are "uniform", "zipfian"
@@ -183,7 +183,7 @@ public class CoreWorkload extends Workload {
    * Set to true if want to check correctness of reads. Must also
    * be set to true during loading phase to function.
    */
-  private boolean dataintegrity;
+  protected boolean dataintegrity;
 
   /**
    * The name of the property for the proportion of transactions that are reads.
@@ -530,7 +530,7 @@ public class CoreWorkload extends Workload {
   /**
    * Builds a value for a randomly chosen field.
    */
-  private HashMap<String, ByteIterator> buildSingleValue(String key) {
+  protected HashMap<String, ByteIterator> buildSingleValue(String key) {
     HashMap<String, ByteIterator> value = new HashMap<>();
 
     String fieldkey = fieldnames.get(fieldchooser.nextValue().intValue());
@@ -549,7 +549,7 @@ public class CoreWorkload extends Workload {
   /**
    * Builds values for all fields.
    */
-  private HashMap<String, ByteIterator> buildValues(String key) {
+  protected HashMap<String, ByteIterator> buildValues(String key) {
     HashMap<String, ByteIterator> values = new HashMap<>();
 
     for (String fieldkey : fieldnames) {
@@ -568,7 +568,7 @@ public class CoreWorkload extends Workload {
   /**
    * Build a deterministic value given the key information.
    */
-  private String buildDeterministicValue(String key, String fieldkey) {
+  protected String buildDeterministicValue(String key, String fieldkey) {
     int size = fieldlengthgenerator.nextValue().intValue();
     StringBuilder sb = new StringBuilder(size);
     sb.append(key);

--- a/core/src/main/java/site/ycsb/workloads/TransactionWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/TransactionWorkload.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (c) 2010 Yahoo! Inc., Copyright (c) 2016-2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.workloads;
+
+import site.ycsb.*;
+import site.ycsb.generator.*;
+
+import java.util.*;
+
+import static site.ycsb.workloads.RestWorkload.DELETE_PROPORTION_PROPERTY;
+
+/**
+ * Extension of properties.
+ * Properties added for this benchmark:
+ * <UL>
+ * <LI><b>startbalance</b>: the balance new insertions have (default: 1000)
+ * <LI><b>transferproportion</b>: what proportion of operations should be transfers (default: 0)
+ * <LI><b>mintransferamount</b>: what the minimal amount of transfer is (default: 1)
+ * <LI><b>maxtransferamount</b>: what the max amount of transfer is (default: 1000)
+ * <LI><b>deleteproportion</b>: what proportion of operations should be deletes (default: 0)
+ * </UL>
+ */
+public class TransactionWorkload extends CoreWorkload {
+  public static final String STARTBALANCE_PROPERTY = "startbalance";
+  public static final String STARTBALANCE_PROPERTY_DEFAULT = "1000";
+  public static final String MINTRANSFERAMOUNT_PROPERTY = "mintransferamount";
+  public static final String MINTRANSFERAMOUNT_PROPERTY_DEFAULT = "1";
+  public static final String MAXTRANSFERAMOUNT_PROPERTY = "maxtransferamount";
+  public static final String MAXTRANSFERAMOUNT_PROPERTY_DEFAULT = "1000";
+  public static final String TRANSFERAMOUNT_DISTRIBUTION_PROPERTY = "transferamountdistribution";
+  /**
+   * Uniform or Zipfian distributions.
+   */
+  public static final String TRANSFERAMOUNT_DISTRIBUTION_PROPERTY_DEFAULT = "uniform";
+  public static final String TRANSFER_PROPORTION_PROPERTY = "transferproportion";
+  public static final String TRANSFER_PROPORTION_PROPERTY_DEFAULT = "0.05";
+  public static final String READ_PROPORTION_PROPERTY_DEFAULT = "0.90";
+  public static final String DELETE_PROPORTION_PROPERTY = "deleteproportion";
+  public static final String DELETE_PROPORTION_PROPERTY_DEFAULT = "0";
+
+  protected NumberGenerator transferamount;
+  protected int startbalance;
+
+  /**
+   * Initialize the scenario.
+   * Called once, in the main client thread, before any operations are started.
+   */
+  @Override
+  public void init(Properties p) throws WorkloadException {
+    super.init(p);
+    int mintransferamount =
+        Integer.parseInt(p.getProperty(MINTRANSFERAMOUNT_PROPERTY, MINTRANSFERAMOUNT_PROPERTY_DEFAULT));
+    int maxtransferamount =
+        Integer.parseInt(p.getProperty(MAXTRANSFERAMOUNT_PROPERTY, MAXTRANSFERAMOUNT_PROPERTY_DEFAULT));
+
+    String transferAmountDistribution = p.getProperty(TRANSFERAMOUNT_DISTRIBUTION_PROPERTY,
+        TRANSFERAMOUNT_DISTRIBUTION_PROPERTY_DEFAULT);
+    if (transferAmountDistribution.compareTo("uniform") == 0) {
+      transferamount = new UniformLongGenerator(mintransferamount, maxtransferamount);
+    } else if (transferAmountDistribution.compareTo("zipfian") == 0) {
+      transferamount = new ZipfianGenerator(mintransferamount, maxtransferamount);
+    } else {
+      throw new WorkloadException("Unknown request distribution \"" + transferAmountDistribution + "\"");
+    }
+    startbalance = Integer.parseInt(p.getProperty(STARTBALANCE_PROPERTY, STARTBALANCE_PROPERTY_DEFAULT));
+  }
+
+  /**
+   * Do one insert operation. Because it will be called concurrently from multiple client threads,
+   * this function must be thread safe. However, avoid synchronized, or the threads will block waiting
+   * for each other, and it will be difficult to reach the target throughput. Ideally, this function would
+   * have no side effects other than DB operations.
+   */
+  @Override
+  public boolean doInsert(DB db, Object threadstate) {
+    int keynum = keysequence.nextValue().intValue();
+    String dbkey = buildKeyName(keynum);
+    HashMap<String, ByteIterator> values = super.buildValues(dbkey);
+
+    Status status;
+    int numOfRetries = 0;
+    do {
+      status = db.insert(table, dbkey, values, startbalance);
+      if (null != status && status.isOk()) {
+        break;
+      }
+      // Retry if configured. Without retrying, the load process will fail
+      // even if one single insertion fails. User can optionally configure
+      // an insertion retry limit (default is 0) to enable retry.
+      if (++numOfRetries <= insertionRetryLimit) {
+        System.err.println("Retrying insertion, retry count: " + numOfRetries);
+        try {
+          // Sleep for a random number between [0.8, 1.2)*insertionRetryInterval.
+          int sleepTime = (int) (1000 * insertionRetryInterval * (0.8 + 0.4 * Math.random()));
+          Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+          break;
+        }
+
+      } else {
+        System.err.println("Error inserting, not retrying any more. number of attempts: " + numOfRetries +
+            "Insertion Retry Limit: " + insertionRetryLimit);
+        break;
+
+      }
+    } while (true);
+
+    return null != status && status.isOk();
+  }
+
+  /**
+   * Do one transaction operation. Because it will be called concurrently from multiple client
+   * threads, this function must be thread safe. However, avoid synchronized, or the threads will block waiting
+   * for each other, and it will be difficult to reach the target throughput. Ideally, this function would
+   * have no side effects other than Transaction operations.
+   */
+  @Override
+  public boolean doTransaction(DB db, Object threadstate) {
+    String operation = operationchooser.nextString();
+    if(operation == null) {
+      return false;
+    }
+
+    switch (operation) {
+    case "READ":
+      doTransactionRead(db);
+      break;
+    case "UPDATE":
+      doTransactionUpdate(db);
+      break;
+    case "TRANSFER":
+      doTransactionTransfer(db);
+      break;
+    case "INSERT":
+      doTransactionInsert(db);
+      break;
+    case "DELETE":
+      doTransactionDeleteAndTransfer(db);
+      break;
+    case "SCAN":
+      doTransactionScan(db);
+      break;
+    default:
+      doTransactionReadModifyWrite(db);
+    }
+
+    return true;
+  }
+
+  private void doTransactionTransfer(DB db) {
+    long keynum = nextKeynum();
+    long keynumTwo = keynum;
+    while (keynum == keynumTwo) {
+      keynumTwo = nextKeynum();
+    }
+    db.transfer(table, buildKeyName(keynum),
+        buildKeyName(keynumTwo), transferamount.nextValue().intValue());
+  };
+
+  public void doTransactionRead(DB db) {
+    // choose a random key
+    long keynum = nextKeynum();
+
+    String keyname = buildKeyName(keynum);
+
+    HashSet<String> fields = null;
+
+    if (!readallfields) {
+      // read a random field
+      String fieldname = fieldnames.get(fieldchooser.nextValue().intValue());
+
+      fields = new HashSet<String>();
+      fields.add(fieldname);
+    } else if (dataintegrity) {
+      // pass the full field list if dataintegrity is on for verification
+      fields = new HashSet<String>(fieldnames);
+    }
+
+    HashMap<String, ByteIterator> cells = new HashMap<String, ByteIterator>();
+    db.read(table, keyname, fields, cells);
+
+    if (dataintegrity) {
+      verifyRow(keyname, cells);
+    }
+  }
+
+  public void doTransactionDeleteAndTransfer(DB db) {
+    long keynum = nextKeynum();
+    long keynumTwo = keynum;
+    while (keynum == keynumTwo) {
+      keynumTwo = nextKeynum();
+    }
+    db.deleteAndTransfer(table, buildKeyName(keynum), buildKeyName(keynumTwo));
+  }
+
+  public void doTransactionInsert(DB db) {
+    // choose the next key
+    long keynum = transactioninsertkeysequence.nextValue();
+
+    try {
+      String dbkey = buildKeyName(keynum);
+
+      HashMap<String, ByteIterator> values = buildValues(dbkey);
+      db.insert(table, dbkey, values, startbalance);
+    } finally {
+      transactioninsertkeysequence.acknowledge(keynum);
+    }
+  }
+
+  /**
+   * Creates a weighted discrete values with database operations for a workload to perform.
+   * Weights/proportions are read from the properties list and defaults are used
+   * when values are not configured.
+   * Current operations are "READ", "UPDATE", "INSERT", "SCAN" and "READMODIFYWRITE".
+   *
+   * @param p The properties list to pull weights from.
+   * @return A generator that can be used to determine the next operation to perform.
+   * @throws IllegalArgumentException if the properties object was null.
+   */
+  protected static DiscreteGenerator createOperationGenerator(final Properties p) {
+    if (p == null) {
+      throw new IllegalArgumentException("Properties object cannot be null");
+    }
+    final double readproportion = Double.parseDouble(
+        p.getProperty(READ_PROPORTION_PROPERTY, READ_PROPORTION_PROPERTY_DEFAULT));
+    final double updateproportion = Double.parseDouble(
+        p.getProperty(UPDATE_PROPORTION_PROPERTY, UPDATE_PROPORTION_PROPERTY_DEFAULT));
+    final double insertproportion = Double.parseDouble(
+        p.getProperty(INSERT_PROPORTION_PROPERTY, INSERT_PROPORTION_PROPERTY_DEFAULT));
+    final double transferproportion = Double.parseDouble(
+        p.getProperty(TRANSFER_PROPORTION_PROPERTY, TRANSFER_PROPORTION_PROPERTY_DEFAULT));
+    final double deleteproportion = Double.parseDouble(
+        p.getProperty(DELETE_PROPORTION_PROPERTY, DELETE_PROPORTION_PROPERTY_DEFAULT));
+    final double scanproportion = Double.parseDouble(
+        p.getProperty(SCAN_PROPORTION_PROPERTY, SCAN_PROPORTION_PROPERTY_DEFAULT));
+    final double readmodifywriteproportion = Double.parseDouble(p.getProperty(
+        READMODIFYWRITE_PROPORTION_PROPERTY, READMODIFYWRITE_PROPORTION_PROPERTY_DEFAULT));
+
+    final DiscreteGenerator operationchooser = new DiscreteGenerator();
+    if (readproportion > 0) {
+      operationchooser.addValue(readproportion, "READ");
+    }
+
+    if (updateproportion > 0) {
+      operationchooser.addValue(updateproportion, "UPDATE");
+    }
+
+    if (transferproportion > 0) {
+      operationchooser.addValue(transferproportion, "TRANSFER");
+    }
+
+    if (deleteproportion > 0) {
+      operationchooser.addValue(deleteproportion, "DELETE");
+    }
+
+    if (insertproportion > 0) {
+      operationchooser.addValue(insertproportion, "INSERT");
+    }
+
+    if (scanproportion > 0) {
+      operationchooser.addValue(scanproportion, "SCAN");
+    }
+
+    if (readmodifywriteproportion > 0) {
+      operationchooser.addValue(readmodifywriteproportion, "READMODIFYWRITE");
+    }
+    return operationchooser;
+  }
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -259,6 +259,11 @@ LICENSE file.
         <artifactId>tablestore-binding</artifactId>
         <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>transactionrest-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 <!--
     <dependency>
       <groupId>site.ycsb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@ LICENSE file.
     <module>solr7</module>
     <module>tarantool</module>
     <module>tablestore</module>
+    <module>transactionrest</module>
     <!--<module>voldemort</module>-->
     <module>voltdb</module>
   </modules>

--- a/transactionrest/pom.xml
+++ b/transactionrest/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2011 YCSB project, 2016 YCSB contributors. All 
+	rights reserved. Licensed under the Apache License, Version 2.0 (the "License"); 
+	you may not use this file except in compliance with the License. You may 
+	obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 
+	Unless required by applicable law or agreed to in writing, software distributed 
+	under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES 
+	OR CONDITIONS OF ANY KIND, either express or implied. See the License for 
+	the specific language governing permissions and limitations under the License. 
+	See accompanying LICENSE file. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+
+  <artifactId>transactionrest-binding</artifactId>
+  <name>Transaction Rest Client Binding</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <skipJDK9Tests>true</skipJDK9Tests>
+    <skipJDK10Tests>true</skipJDK10Tests>
+    <skipJDK11Tests>true</skipJDK11Tests>
+
+    <httpclient.version>4.5.1</httpclient.version>
+    <httpcore.version>4.4.4</httpcore.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20200518</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/transactionrest/src/main/java/site/ycsb/transactionwebservice/transactionrest/TransactionRestClient.java
+++ b/transactionrest/src/main/java/site/ycsb/transactionwebservice/transactionrest/TransactionRestClient.java
@@ -1,0 +1,421 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+//java site.ycsb.CommandLine -db site.ycsb.webservice.transactionrest.TransactionRestClient
+package site.ycsb.transactionwebservice.transactionrest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Vector;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+
+import org.json.JSONObject;
+import site.ycsb.*;
+
+/**
+ * Class responsible for making web service requests for benchmarking purpose.
+ * Using Apache HttpClient over standard Java HTTP API as this is more flexible
+ * and provides better functionality. For example HttpClient can automatically
+ * handle redirects and proxy authentication which the standard Java API can't.
+ */
+public class TransactionRestClient extends DB {
+
+  private static final String URL_PREFIX = "url.prefix";
+  private static final String CON_TIMEOUT = "timeout.con";
+  private static final String READ_TIMEOUT = "timeout.read";
+  private static final String EXEC_TIMEOUT = "timeout.exec";
+  private static final String LOG_ENABLED = "log.enable";
+  private boolean logEnabled;
+  private String urlPrefix;
+  private Properties props;
+  private CloseableHttpClient client;
+  private int conTimeout = 10000;
+  private int readTimeout = 10000;
+  private int execTimeout = 10000;
+  private volatile Criteria requestTimedout = new Criteria(false);
+
+  @Override
+  public void init() throws DBException {
+    props = getProperties();
+    urlPrefix = props.getProperty(URL_PREFIX, "http://127.0.0.1:80");
+    conTimeout = Integer.valueOf(props.getProperty(CON_TIMEOUT, "10")) * 1000;
+    readTimeout = Integer.valueOf(props.getProperty(READ_TIMEOUT, "10")) * 1000;
+    execTimeout = Integer.valueOf(props.getProperty(EXEC_TIMEOUT, "10")) * 1000;
+    logEnabled = Boolean.valueOf(props.getProperty(LOG_ENABLED, "false").trim());
+    setupClient();
+  }
+
+  private void setupClient() {
+    RequestConfig.Builder requestBuilder = RequestConfig.custom();
+    requestBuilder = requestBuilder.setConnectTimeout(conTimeout);
+    requestBuilder = requestBuilder.setConnectionRequestTimeout(readTimeout);
+    requestBuilder = requestBuilder.setSocketTimeout(readTimeout);
+    HttpClientBuilder clientBuilder = HttpClientBuilder.create().setDefaultRequestConfig(requestBuilder.build());
+    this.client = clientBuilder.setConnectionManagerShared(true).build();
+  }
+
+  @Override
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  public Status read(String table, String key, Set<String> fields, Map<String, ByteIterator> result) {
+    int responseCode;
+    String url = urlPrefix + "/" + table + "/read/" + key;
+    try {
+      responseCode = httpGet(url, result);
+    } catch (Exception e) {
+      responseCode = handleExceptions(e, url, "GET");
+    }
+    if (logEnabled) {
+      System.err.println(new StringBuilder("GET Request: ").append(url)
+          .append(" | Response Code: ").append(responseCode).toString());
+    }
+    return getStatus(responseCode);
+  }
+
+  @Override
+  public Status insert(String table, String key, Map<String, ByteIterator> values, int balance) {
+    int responseCode;
+    String url = urlPrefix + "/" + table + "/insert";
+    try {
+      responseCode = httpInsert(new HttpPost(url), key, values, balance);
+    } catch (Exception e) {
+      responseCode = handleExceptions(e, url, "POST");
+    }
+    if (logEnabled) {
+      System.err.println(new StringBuilder("POST Request: ").append(url)
+          .append(" | Response Code: ").append(responseCode).toString());
+    }
+    return getStatus(responseCode);
+  }
+
+  @Override
+  public Status transfer(String table, String outgoingKey, String incomingKey, int amount) {
+    int responseCode;
+    String url = urlPrefix + "/" + table + "/transfer";
+    try {
+      responseCode = httpTransfer(new HttpPost(url), outgoingKey, incomingKey, amount);
+    } catch (Exception e) {
+      responseCode = handleExceptions(e, url, "POST");
+    }
+    if (logEnabled) {
+      System.err.println(new StringBuilder("POST Request: ").append(url)
+          .append(" | Response Code: ").append(responseCode).toString());
+    }
+    return getStatus(responseCode);
+  }
+
+  @Override
+  public Status delete(String table, String endpoint) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  public Status deleteAndTransfer(String table, String key, String incomingKey) {
+    int responseCode;
+    String url = urlPrefix + "/" + table + "/delete";
+    try {
+      responseCode = httpDelete(new HttpPost(url), key, incomingKey);
+    } catch (Exception e) {
+      responseCode = handleExceptions(e, url, "POST");
+    }
+    if (logEnabled) {
+      System.err.println(new StringBuilder("POST Request: ").append(url)
+          .append(" | Response Code: ").append(responseCode).toString());
+    }
+    return getStatus(responseCode);
+  }
+
+  @Override
+  public Status update(String table, String key, Map<String, ByteIterator> values) {
+    int responseCode;
+    String url = urlPrefix + "/" + table + "/update";
+    try {
+      responseCode = httpUpdate(new HttpPost(url), key, values);
+    } catch (Exception e) {
+      responseCode = handleExceptions(e, url, "POST");
+    }
+    if (logEnabled) {
+      System.err.println(new StringBuilder("POST Request: ").append(url)
+          .append(" | Response Code: ").append(responseCode).toString());
+    }
+    return getStatus(responseCode);
+  }
+
+  @Override
+  public Status scan(String table, String startkey, int recordcount, Set<String> fields,
+                     Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  // Maps HTTP status codes to YCSB status codes.
+  private Status getStatus(int responseCode) {
+    int rc = responseCode / 100;
+    if (responseCode == 422) {
+      return Status.TRANSACTION_FAILED;
+    } else if (responseCode == 404) {
+      return Status.NOT_FOUND;
+    } else if (rc == 5 | rc == 4) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+
+  private int handleExceptions(Exception e, String url, String method) {
+    if (logEnabled) {
+      System.err.println(new StringBuilder(method).append(" Request: ").append(url).append(" | ")
+          .append(e.getClass().getName()).append(" occured | Error message: ")
+          .append(e.getMessage()).toString());
+    }
+
+    if (e instanceof ClientProtocolException) {
+      return 400;
+    }
+    return 500;
+  }
+
+  // Connection is automatically released back in case of an exception.
+  private int httpGet(String endpoint, Map<String, ByteIterator> result) throws IOException {
+    requestTimedout.setIsSatisfied(false);
+    Thread timer = new Thread(new Timer(execTimeout, requestTimedout));
+    timer.start();
+    int responseCode = 200;
+    HttpGet request = new HttpGet(endpoint);
+    CloseableHttpResponse response = client.execute(request);
+    responseCode = response.getStatusLine().getStatusCode();
+    HttpEntity responseEntity = response.getEntity();
+    // If null entity don't bother about connection release.
+    if (responseEntity != null) {
+      InputStream stream = responseEntity.getContent();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+      StringBuffer responseContent = new StringBuffer();
+      String line = "";
+      while ((line = reader.readLine()) != null) {
+        if (requestTimedout.isSatisfied()) {
+          // Must avoid memory leak.
+          reader.close();
+          stream.close();
+          EntityUtils.consumeQuietly(responseEntity);
+          response.close();
+          client.close();
+          throw new TimeoutException();
+        }
+        responseContent.append(line);
+      }
+      timer.interrupt();
+      result.put("response", new StringByteIterator(responseContent.toString()));
+      // Closing the input stream will trigger connection release.
+      stream.close();
+    }
+    EntityUtils.consumeQuietly(responseEntity);
+    response.close();
+    client.close();
+    return responseCode;
+  }
+
+  private int httpInsert(
+      HttpPost request, String key, Map<String, ByteIterator> values, int balance) throws IOException {
+    requestTimedout.setIsSatisfied(false);
+    Thread timer = new Thread(new Timer(execTimeout, requestTimedout));
+    timer.start();
+
+    JSONObject result = new JSONObject();
+    result.put("id", key);
+    result.put("balance", balance);
+    JSONObject fields = new JSONObject();
+    for (Map.Entry<String, ByteIterator> entry: values.entrySet()) {
+      fields.put(entry.getKey(), entry.getValue().toString());
+    }
+    result.put("fields", fields);
+
+    StringEntity entity = new StringEntity(result.toString());
+    request.setEntity(entity);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-type", "application/json");
+
+    return httpExecute(request, timer);
+  }
+
+  private int httpTransfer(HttpPost request, String outgoingKey, String incomingKey, int amount) throws IOException {
+    requestTimedout.setIsSatisfied(false);
+    Thread timer = new Thread(new Timer(execTimeout, requestTimedout));
+    timer.start();
+
+    JSONObject result = new JSONObject();
+    result.put("outgoing_id", outgoingKey);
+    result.put("incoming_id", incomingKey);
+    result.put("amount", amount);
+
+    StringEntity entity = new StringEntity(result.toString());
+    request.setEntity(entity);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-type", "application/json");
+
+    return httpExecute(request, timer);
+  }
+
+  private int httpDelete(HttpPost request, String key, String incomingKey) throws IOException {
+    requestTimedout.setIsSatisfied(false);
+    Thread timer = new Thread(new Timer(execTimeout, requestTimedout));
+    timer.start();
+
+    JSONObject result = new JSONObject();
+    result.put("id", key);
+    result.put("incoming_id", incomingKey);
+
+    StringEntity entity = new StringEntity(result.toString());
+    request.setEntity(entity);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-type", "application/json");
+
+    return httpExecute(request, timer);
+  }
+
+  private int httpUpdate(HttpPost request, String key, Map<String, ByteIterator> values) throws IOException {
+    requestTimedout.setIsSatisfied(false);
+    Thread timer = new Thread(new Timer(execTimeout, requestTimedout));
+    timer.start();
+
+    JSONObject result = new JSONObject();
+    result.put("id", key);
+    JSONObject fields = new JSONObject();
+    for (Map.Entry<String, ByteIterator> entry: values.entrySet()) {
+      fields.put(entry.getKey(), entry.getValue().toString());
+    }
+    result.put("fields", fields);
+
+    StringEntity entity = new StringEntity(result.toString());
+    request.setEntity(entity);
+    request.setHeader("Accept", "application/json");
+    request.setHeader("Content-type", "application/json");
+
+    return httpExecute(request, timer);
+
+  }
+
+  private int httpExecute(HttpEntityEnclosingRequestBase request, Thread timer) throws IOException {
+    int responseCode = 200;
+
+    CloseableHttpResponse response = client.execute(request);
+    responseCode = response.getStatusLine().getStatusCode();
+    HttpEntity responseEntity = response.getEntity();
+    // If null entity don't bother about connection release.
+    if (responseEntity != null) {
+      InputStream stream = responseEntity.getContent();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+      StringBuffer responseContent = new StringBuffer();
+      String line = "";
+      while ((line = reader.readLine()) != null) {
+        if (requestTimedout.isSatisfied()) {
+          // Must avoid memory leak.
+          reader.close();
+          stream.close();
+          EntityUtils.consumeQuietly(responseEntity);
+          response.close();
+          client.close();
+          throw new TimeoutException();
+        }
+        responseContent.append(line);
+      }
+      timer.interrupt();
+      // Closing the input stream will trigger connection release.
+      stream.close();
+    }
+    EntityUtils.consumeQuietly(responseEntity);
+    response.close();
+    client.close();
+    return responseCode;
+  }
+
+  /**
+   * Marks the input {@link Criteria} as satisfied when the input time has elapsed.
+   */
+  class Timer implements Runnable {
+
+    private long timeout;
+    private Criteria timedout;
+
+    public Timer(long timeout, Criteria timedout) {
+      this.timedout = timedout;
+      this.timeout = timeout;
+    }
+
+    @Override
+    public void run() {
+      try {
+        Thread.sleep(timeout);
+        this.timedout.setIsSatisfied(true);
+      } catch (InterruptedException e) {
+        // Do nothing.
+      }
+    }
+
+  }
+
+  /**
+   * Sets the flag when a criteria is fulfilled.
+   */
+  class Criteria {
+
+    private boolean isSatisfied;
+
+    public Criteria(boolean isSatisfied) {
+      this.isSatisfied = isSatisfied;
+    }
+
+    public boolean isSatisfied() {
+      return isSatisfied;
+    }
+
+    public void setIsSatisfied(boolean satisfied) {
+      this.isSatisfied = satisfied;
+    }
+
+  }
+
+  /**
+   * Private exception class for execution timeout.
+   */
+  class TimeoutException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TimeoutException() {
+      super("HTTP Request exceeded execution time limit.");
+    }
+
+  }
+
+}

--- a/transactionrest/src/main/java/site/ycsb/transactionwebservice/transactionrest/package-info.java
+++ b/transactionrest/src/main/java/site/ycsb/transactionwebservice/transactionrest/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2016 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * YCSB binding for a REST service implementing the TransactionWorkload.
+ */
+package site.ycsb.transactionwebservice.transactionrest;
+

--- a/workloads/workload_transaction_rest
+++ b/workloads/workload_transaction_rest
@@ -1,0 +1,42 @@
+# Copyright (c) 2016 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+#	Core Properties
+workload=site.ycsb.workloads.TransactionWorkload
+db=site.ycsb.webservice.transactionrest.TransactionRestClient
+exporter=site.ycsb.measurements.exporter.TextMeasurementsExporter
+threadcount=10
+fieldlengthdistribution=uniform
+
+#	Workload Properties
+fieldcount=3
+fieldlength=200
+maxtransferamount=1
+readproportion=0.7
+updateproportion=0.1
+deleteproportion=0.1
+transactionproportion=0.1
+insertproportion=0
+requestdistribution=zipfian
+recordcount=100
+operationcount=100
+maxexecutiontime=720
+
+#	Custom Properties
+url.prefix=http://127.0.0.1:80
+timeout.con=60
+timeout.read=60
+timeout.exec=60
+log.enable=true


### PR DESCRIPTION
Hello! 

Thanks for the work you have done on this. 

I was looking for a benchmark to test a system which does have transaction features, but simpler than TPCC. I stumbled upon YCSB+T (#169). I wanted something like this, unfortunately this was never merged.

I implemented something similar myself. It is a very simple closed economy model. It adds an integer field to the documents (`balance`) and adds a `transfer` operation to the DB. This `transfer` operation represents a transaction where a certain amount of balance is subtracted from one document and added to another.

For this to work I also added an `insert` operation where the workload can set an initial balance for the documents. I also added a `deleteAndTransfer` operation. This deletes a document and transfers all of its balance to another document.

The implementation of these "transactional" operations (`transfer` and `deleteAndTransfer`) is left to the DB binding.

I created a workload which includes these new operations. 

I also added a REST client binding which implements the new operations.

I think I will add a validation step (as described in #169) as well. 

I am interested to hear what you think of this addition and whether you think it could be a good addition to YCSB.