### PR TITLE
[core] print data integrity status is enabled

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -475,6 +475,9 @@ public class CoreWorkload extends Workload {
       System.err.println("Must have constant field size to check data integrity.");
       System.exit(-1);
     }
+    if (dataintegrity) {
+      System.out.println("Data integrity is enabled.");
+    }
 
     if (p.getProperty(INSERT_ORDER_PROPERTY, INSERT_ORDER_PROPERTY_DEFAULT).compareTo("hashed") == 0) {
       orderedinserts = false;

--- a/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
@@ -634,6 +634,9 @@ public class TimeSeriesWorkload extends Workload {
     dataintegrity = Boolean.parseBoolean(
         p.getProperty(CoreWorkload.DATA_INTEGRITY_PROPERTY, 
             CoreWorkload.DATA_INTEGRITY_PROPERTY_DEFAULT));
+    if (dataintegrity) {
+      System.out.println("Data integrity is enabled.");
+    }
     
     queryTimeSpan = Integer.parseInt(p.getProperty(QUERY_TIMESPAN_PROPERTY, 
         QUERY_TIMESPAN_PROPERTY_DEFAULT));


### PR DESCRIPTION
Users would benefit if they would know exactly that their
flags take an effect.