### PR TITLE
update driver to support mongodb 4.4

### DIFF
--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -33,7 +33,7 @@ LICENSE file.
   <dependencies>
     <dependency>
       <groupId>org.mongodb</groupId>
-      <artifactId>mongo-java-driver</artifactId>
+      <artifactId>mongodb-driver-legacy</artifactId>
       <version>${mongodb.version}</version>
     </dependency>
     <dependency>

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -63,7 +63,7 @@ LICENSE file.
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.7.1</version>
+      <version>1.1.8.2</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/mongodb/src/main/java/site/ycsb/db/MongoDbClient.java
+++ b/mongodb/src/main/java/site/ycsb/db/MongoDbClient.java
@@ -265,7 +265,7 @@ public class MongoDbClient extends DB {
           // this is effectively an insert, but using an upsert instead due
           // to current inability of the framework to clean up after itself
           // between test runs.
-          collection.replaceOne(new Document("_id", toInsert.get("_id")),
+          collection.updateOne(new Document("_id", toInsert.get("_id")),
               toInsert, UPDATE_WITH_UPSERT);
         } else {
           collection.insertOne(toInsert);

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ LICENSE file.
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>1.11.1</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>
-    <mongodb.version>3.12.7</mongodb.version>
+    <mongodb.version>4.1.1</mongodb.version>
     <mongodb.async.version>2.0.1</mongodb.async.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@ LICENSE file.
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>1.11.1</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>
-    <mongodb.version>3.11.0</mongodb.version>
-    <mongodb.async.version>2.0.1</mongodb.async.version>
+    <mongodb.version>4.2.0</mongodb.version>
+    <mongodb.async.version>3.12.7</mongodb.async.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -133,8 +133,8 @@ LICENSE file.
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>1.11.1</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>
-    <mongodb.version>4.2.0</mongodb.version>
-    <mongodb.async.version>3.12.7</mongodb.async.version>
+    <mongodb.version>3.12.7</mongodb.version>
+    <mongodb.async.version>2.0.1</mongodb.async.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
1. update mongo-java-driver to mongodb-driver-legacy 4.1.1 to support MongoDB 4.4.
2. replaceOne was updated to updateOne, because replaceOne in this scenes removed in mongodb-driver-legacy 4.0 or upper.