### PR TITLE
[rocksdb] fix redundant write of default CF name

### DIFF
--- a/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
+++ b/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
@@ -325,7 +325,10 @@ public class RocksDBClient extends DB {
   private void saveColumnFamilyNames() throws IOException {
     final Path file = rocksDbDir.resolve(COLUMN_FAMILY_NAMES_FILENAME);
     try(final PrintWriter writer = new PrintWriter(Files.newBufferedWriter(file, UTF_8))) {
-      writer.println(new String(RocksDB.DEFAULT_COLUMN_FAMILY, UTF_8));
+      final String defaultCfName = new String(RocksDB.DEFAULT_COLUMN_FAMILY, UTF_8);
+      if(!COLUMN_FAMILIES.containsKey(defaultCfName)) {
+        writer.println(defaultCfName);
+      }
       for(final String cfName : COLUMN_FAMILIES.keySet()) {
         writer.println(cfName);
       }


### PR DESCRIPTION
In the previous code, `default` will write twice to `CF_NAMES` after run the workload.

reproduce:

```sh
$ ./bin/ycsb load rocksdb -s -P workloads/workloada -p rocksdb.dir=/tmp/ycsb-rocksdb-data
...
$ cat /tmp/ycsb-rocksdb-data/CF_NAMES
default
usertable
$ ./bin/ycsb run rocksdb -s -P workloads/workloada -p rocksdb.dir=/tmp/ycsb-rocksdb-data
...
$ cat /tmp/ycsb-rocksdb-data/CF_NAMES
default
default
usertable
```

`default` should only write once, although it won't cause any error.