### PR TITLE
Fix 1516: Move FoundationDB version forward

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ LICENSE file.
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
-    <foundationdb.version>5.2.5</foundationdb.version>
+    <foundationdb.version>6.2.10</foundationdb.version>
     <geode.version>1.2.0</geode.version>
     <googlebigtable.version>1.4.0</googlebigtable.version>
     <griddb.version>4.0.0</griddb.version>


### PR DESCRIPTION
Moving the version to a stable 6.2.10 release.  5.2.5 is quite old.