### PR TITLE
Redis: Using JedisPool instead of Jedis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ LICENSE file.
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <redis.version>2.9.0</redis.version>
+    <redis.version>3.6.0</redis.version>
     <riak.version>2.0.5</riak.version>
     <rocksdb.version>6.2.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>


### PR DESCRIPTION
Hi, I am one of the [Jedis](https://github.com/redis/jedis) Reviewers. When I used YCSB to write large amounts of data (over 100 million) to Redis, I encountered a failure when the connection is abnormal (even if the insertionRetryLimit is configured). After reading the YCSB code, I found that YCSB uses `Jedis` instead of `JedisPool`. When Jedis encounters a connection timeout or disconnection, it cannot be restored. In order to run the `long-term stable` test, I introduced JedisPool. This PR mainly includes:

- Replace Jedis with JedisPool
- Exception is processed and `Status.ERROR` is returned
- Upgrade the Jedis version to 3.6.0 (the latest stable version)
