### PR TITLE
[core] Update HDR Histogram to 2.1.12.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2021 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -57,7 +57,7 @@ LICENSE file.
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.12</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This causes it to emit HDR Histogram v2 files, which are incompatible with v1.  Tools in other languages (such as Go) only support v2, and cannot parse YCSB histogram files without this change.