### PR TITLE
[pmemkv] Add PmemKV client using pmemkv's Java API.

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012 - 2020 YCSB contributors. All rights reserved.
+# Copyright (c) 2012 - 2021 YCSB contributors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License. You
@@ -61,6 +61,7 @@ mongodb:site.ycsb.db.MongoDbClient
 mongodb-async:site.ycsb.db.AsyncMongoDbClient
 nosqldb:site.ycsb.db.NoSqlDbClient
 orientdb:site.ycsb.db.OrientDBClient
+pmemkv:site.ycsb.db.PmemKVClient
 postgrenosql:site.ycsb.postgrenosql.PostgreNoSQLDBClient
 rados:site.ycsb.db.RadosClient
 redis:site.ycsb.db.RedisClient

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2012 - 2020 YCSB contributors. All rights reserved.
+# Copyright (c) 2012 - 2021 YCSB contributors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you
 # may not use this file except in compliance with the License. You
@@ -90,6 +90,7 @@ DATABASES = {
     "mongodb-async": "site.ycsb.db.AsyncMongoDbClient",
     "nosqldb"      : "site.ycsb.db.NoSqlDbClient",
     "orientdb"     : "site.ycsb.db.OrientDBClient",
+    "pmemkv"       : "site.ycsb.db.PmemKVClient",
     "postgrenosql" : "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
     "rados"        : "site.ycsb.db.RadosClient",
     "redis"        : "site.ycsb.db.RedisClient",

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -1,5 +1,5 @@
 <!-- 
-Copyright (c) 2012 - 2020 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2021 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -192,6 +192,11 @@ LICENSE file.
     <dependency>
       <groupId>site.ycsb</groupId>
       <artifactId>orientdb-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>pmemkv-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pmemkv/README.md
+++ b/pmemkv/README.md
@@ -1,0 +1,70 @@
+<!--
+Copyright (c) 2015 - 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+# PmemKV Driver for YCSB
+This driver is a binding for the YCSB facilities to operate against a [PmemKV](https://github.com/pmem/pmemkv).
+It uses the PmemKV Java bindings.
+
+## Quick Start
+
+### 0. Install PmemKV Java Binding
+**Optionally** you can compile and install custom version of PmemKV Java binding.
+The min. supported version is `1.1.0`.
+
+>Note: If you want to use custom installation, you'll have to set additional
+>maven parameter for building/execution of **PmemKV module**: `-Dpmemkv.packageName=pmemkv`.
+
+Simple follow [PmemKV Java installation instruction](https://github.com/pmem/pmemkv-java#installation),
+including at least:
+
+    export JAVA_HOME=#PATH_TO_YOUR_JAVA_HOME
+    git clone https://github.com/pmem/pmemkv-java.git
+    cd pmemkv-java
+    mvn install
+
+### 1. Set Up YCSB
+You need to clone the repository and compile **PmemKV module**.
+
+    git clone git://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
+    mvn -pl site.ycsb:pmemkv-binding -am package
+
+Optionally, you can use specific pmemkv version, by adding extra maven parameter: `-Dpmemkv.packageVersion=X.Y.Z`
+
+### 2. Run the Workload
+Before you can actually run the workload, you need to "load" the data first.
+
+    bin/ycsb.sh load pmemkv -P workloads/workloada -p pmemkv.engine=cmap -p pmemkv.dbsize=DB_SIZE -p pmemkv.dbpath=/path/to/pmem/pool
+
+Then, you can run the workload:
+
+    bin/ycsb.sh run pmemkv -P workloads/workloada -p pmemkv.engine=cmap -p pmemkv.dbsize=DB_SIZE -p pmemkv.dbpath=/path/to/pmem/pool
+
+## Configuration Options
+Driver has a few configuration options to parametrize engine, path, and size using the following:
+
+| Parameter     | Meaning        | Obligatory |
+| :-----------: | -------------- | :--------: |
+| pmemkv.engine | Storage engine | N          |
+| pmemkv.dbpath | Pool file path | Y          |
+| pmemkv.dbsize | Pool file size | Y          |
+
+To check possible values for storage engine see
+[pmemkv's documentation](https://github.com/pmem/pmemkv#storage-engines).
+The default engine used in YCSB (if not defined otherwise) is cmap.
+Please take into consideration each engine may require different path and size
+setting - as described in the mentioned documentation.

--- a/pmemkv/pom.xml
+++ b/pmemkv/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2015-2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+
+  <artifactId>pmemkv-binding</artifactId>
+  <name>PmemKV Binding</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <!-- extra parameters to allow easier building with pmemkv from sources -->
+    <pmemkv.packageName>pmemkv-root</pmemkv.packageName>
+    <pmemkv.packageVersion>[1.1.0,)</pmemkv.packageVersion>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.pmem</groupId>
+      <artifactId>${pmemkv.packageName}</artifactId>
+      <version>${pmemkv.packageVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pmemkv/src/main/java/site/ycsb/db/pmemkv/PmemKVClient.java
+++ b/pmemkv/src/main/java/site/ycsb/db/pmemkv/PmemKVClient.java
@@ -1,0 +1,232 @@
+/**
+ * Copyright (c) 2013 - 2021 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+ /*
+ * PmemKV client binding for YCSB.
+ *
+ * https://github.com/pmem/pmemkv-java
+ */
+package site.ycsb.db;
+
+import io.pmem.pmemkv.*;
+import site.ycsb.ByteArrayByteIterator;
+import site.ycsb.ByteIterator;
+import site.ycsb.DB;
+import site.ycsb.DBException;
+import site.ycsb.Status;
+
+import java.nio.ByteBuffer;
+import java.io.*;
+import java.util.*;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+class ByteConverter implements Converter<byte[]> {
+  @Override
+  public ByteBuffer toByteBuffer(byte[] bytes) {
+    return ByteBuffer.wrap(bytes);
+  }
+
+  @Override
+  public byte[] fromByteBuffer(ByteBuffer byteBuffer) {
+    byte[] data = new byte[byteBuffer.remaining()];
+    byteBuffer.get(data);
+    return data;
+  }
+}
+
+class MapToByteBufferConverter implements Converter<Map<String, ByteIterator>> {
+
+  public MapToByteBufferConverter() {
+  }
+
+  @Override
+  public ByteBuffer toByteBuffer(Map<String, ByteIterator> entries) {
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      final ByteBuffer buf = ByteBuffer.allocate(4);
+
+      for (final Map.Entry<String, ByteIterator> entry : entries.entrySet()) {
+        final byte[] keyBytes = entry.getKey().getBytes(UTF_8);
+        final byte[] valueBytes = entry.getValue().toArray();
+        buf.putInt(keyBytes.length);
+        baos.write(buf.array());
+        baos.write(keyBytes);
+        buf.clear();
+
+        buf.putInt(valueBytes.length);
+        baos.write(buf.array());
+        baos.write(valueBytes);
+        buf.clear();
+      }
+      return ByteBuffer.wrap(baos.toByteArray());
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+  @Override
+  public Map<String, ByteIterator> fromByteBuffer(ByteBuffer input) {
+    Map<String, ByteIterator> result = new HashMap<>();
+
+    while (input.remaining() != 0) {
+      final int keyLen = input.getInt(); /* increments position by 4 */
+      byte[] values = new byte[keyLen];
+      input.get(values, 0, keyLen);
+      final String key = new String(values, 0, keyLen);
+      final int valueLen = input.getInt();
+      values = new byte[valueLen];
+      input.get(values, 0, valueLen);
+      result.put(key, new ByteArrayByteIterator(values, 0, valueLen));
+    }
+
+    return result;
+  }
+}
+
+/**
+ * A class that wraps the PmemKVClient to allow it to be interfaced with YCSB.
+ * This class extends {@link DB} and implements the database interface used by YCSB client.
+ */
+public class PmemKVClient extends DB {
+  public static final String ENGINE_PROPERTY = "pmemkv.engine";
+  public static final String SIZE_PROPERTY = "pmemkv.dbsize";
+  public static final String PATH_PROPERTY = "pmemkv.dbpath";
+
+  private static Database<byte[], Map<String, ByteIterator>> db = null;
+  private static int activeThreads = 0;
+
+  @Override
+  public void init() throws DBException {
+    synchronized(PmemKVClient.class) {
+      if (db == null) {
+        Properties props = getProperties();
+        /* use cmap as default engine */
+        String engineName = props.getProperty(ENGINE_PROPERTY, "cmap");
+
+        String path = props.getProperty(PATH_PROPERTY);
+        if (path == null) {
+          throw new DBException(PATH_PROPERTY + " is obligatory to run PmemKV client");
+        }
+        String size = props.getProperty(SIZE_PROPERTY);
+        if (size == null) {
+          throw new DBException(SIZE_PROPERTY + " is obligatory to run PmemKV client");
+        }
+        boolean startError = false;
+        try {
+          /* try to open db first */
+          db = new Database.Builder<byte[], Map<String, ByteIterator>>(engineName)
+              .setSize(Long.parseLong(size))
+              .setPath(path)
+              .setKeyConverter(new ByteConverter())
+              .setValueConverter(new MapToByteBufferConverter())
+              .build();
+        } catch (DatabaseException e) {
+          startError = true;
+        }
+        if (startError) {
+          try {
+            /* or create it, if it doesn't exist */
+            db = new Database.Builder<byte[], Map<String, ByteIterator>>(engineName)
+                .setSize(Long.parseLong(size))
+                .setPath(path)
+                .setKeyConverter(new ByteConverter())
+                .setValueConverter(new MapToByteBufferConverter())
+                .setForceCreate(true)
+                .build();
+          } catch (DatabaseException e) {
+            throw new DBException("Error while open with " + engineName +
+                                  ".\nFull error: " + e.getMessage());
+          }
+        }
+      }
+      activeThreads++;
+    }
+  }
+
+  /**
+   * Shutdown the client.
+   */
+  @Override
+  public void cleanup() {
+    synchronized(PmemKVClient.class) {
+      activeThreads--;
+      if (activeThreads == 0 && db != null) {
+        db.stop();
+        db = null;
+      }
+    }
+  }
+
+  @Override
+  public Status read(final String table, final String key, final Set<String> fields,
+                     final Map<String, ByteIterator> result) {
+    try {
+      db.get(key.getBytes(UTF_8), result::putAll);
+    } catch (NotFoundException e) {
+      return Status.NOT_FOUND;
+    }
+    return Status.OK;
+  }
+
+  @Override
+  public Status scan(final String table, final String startkey, final int recordcount, final Set<String> fields,
+                     final Vector<HashMap<String, ByteIterator>> result) {
+    /* TODO(kfilipek): Implement if possible/necessary */
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
+    final Map<String, ByteIterator> result = new HashMap<>();
+    Map<String, ByteIterator> currentValues = db.getCopy(key.getBytes(UTF_8));
+    if (currentValues == null) {
+      return Status.NOT_FOUND;
+    }
+
+    result.putAll(values);
+
+    try {
+      db.put(key.getBytes(UTF_8), result);
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+
+  @Override
+  public Status insert(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      db.put(key.getBytes(UTF_8), values);
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+
+  @Override
+  public Status delete(final String table, final String key) {
+    try {
+      if (!db.remove(key.getBytes(UTF_8))) {
+        return Status.NOT_FOUND;
+      }
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+}

--- a/pmemkv/src/main/java/site/ycsb/db/pmemkv/package-info.java
+++ b/pmemkv/src/main/java/site/ycsb/db/pmemkv/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 - 2021 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://github.com/pmem/pmemkv-java/">PmemKV</a>.
+ */
+package site.ycsb.db;

--- a/pmemkv/src/test/java/site/ycsb/db/pmemkv/PmemKVClientTest.java
+++ b/pmemkv/src/test/java/site/ycsb/db/pmemkv/PmemKVClientTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2018-2021 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db;
+
+import site.ycsb.ByteIterator;
+import site.ycsb.Status;
+import site.ycsb.StringByteIterator;
+import site.ycsb.workloads.CoreWorkload;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class PmemKVClientTest {
+
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private static final String MOCK_TABLE = "ycsb";
+  private static final String MOCK_KEY0 = "0";
+  private static final String MOCK_KEY1 = "1";
+  private static final String MOCK_KEY2 = "2";
+  private static final String MOCK_KEY3 = "3";
+  private static final int NUM_RECORDS = 10;
+  private static final String FIELD_PREFIX = CoreWorkload.FIELD_NAME_PREFIX_DEFAULT;
+
+  private static final Map<String, ByteIterator> MOCK_DATA;
+  static {
+    MOCK_DATA = new HashMap<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      MOCK_DATA.put(FIELD_PREFIX + i, new StringByteIterator("value" + i));
+    }
+  }
+
+  private PmemKVClient instance;
+
+  @Before
+  public void setup() throws Exception {
+    instance = new PmemKVClient();
+
+    final Properties properties = new Properties();
+    properties.setProperty(PmemKVClient.PATH_PROPERTY, tmpFolder.getRoot().getAbsolutePath() + "/pmemkv_db");
+    properties.setProperty(PmemKVClient.SIZE_PROPERTY, "60777216");
+    instance.setProperties(properties);
+
+    instance.init();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    instance.cleanup();
+  }
+
+  @Test
+  public void dummyTest() throws Exception {
+    assertEquals(Status.OK, Status.OK);
+  }
+
+  @Test
+  public void readFromEmptyDB() throws Exception {
+    final Set<String> fields = MOCK_DATA.keySet();
+    final Map<String, ByteIterator> resultParam = new HashMap<>(NUM_RECORDS);
+    final Status readResult = instance.read(MOCK_TABLE, MOCK_KEY0, fields, resultParam);
+    assertEquals(Status.NOT_FOUND, readResult);
+  }
+
+  @Test
+  public void deleteNonExistingKey() throws Exception {
+    final Status result = instance.delete(MOCK_TABLE, MOCK_KEY1+"_non_existent");
+    assertEquals(Status.NOT_FOUND, result);
+  }
+
+  @Test
+  public void insertAndRead() throws Exception {
+    final Status insertResult = instance.insert(MOCK_TABLE, MOCK_KEY0, MOCK_DATA);
+    assertEquals(Status.OK, insertResult);
+
+    final Set<String> fields = MOCK_DATA.keySet();
+    final Map<String, ByteIterator> resultParam = new HashMap<>(NUM_RECORDS);
+    final Status readResult = instance.read(MOCK_TABLE, MOCK_KEY0, fields, resultParam);
+    assertEquals(Status.OK, readResult);
+  }
+
+  @Test
+  public void insertAndDelete() throws Exception {
+    final Status insertResult = instance.insert(MOCK_TABLE, MOCK_KEY1, MOCK_DATA);
+    assertEquals(Status.OK, insertResult);
+
+    final Status result = instance.delete(MOCK_TABLE, MOCK_KEY1);
+    assertEquals(Status.OK, result);
+
+    final Set<String> fields = MOCK_DATA.keySet();
+    final Map<String, ByteIterator> resultParam = new HashMap<>(NUM_RECORDS);
+    final Status readResult = instance.read(MOCK_TABLE, MOCK_KEY1, fields, resultParam);
+    assertEquals(Status.NOT_FOUND, readResult);
+  }
+
+  @Test
+  public void insertUpdateAndRead() throws Exception {
+    final Map<String, ByteIterator> newValues = new HashMap<>(NUM_RECORDS);
+
+    final Status insertResult = instance.insert(MOCK_TABLE, MOCK_KEY2, MOCK_DATA);
+    assertEquals(Status.OK, insertResult);
+
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      newValues.put(FIELD_PREFIX + i, new StringByteIterator("newvalue" + i));
+    }
+
+    final Status result = instance.update(MOCK_TABLE, MOCK_KEY2, newValues);
+    assertEquals(Status.OK, result);
+
+    /* validate the values changed */
+    final Map<String, ByteIterator> resultParam = new HashMap<>(NUM_RECORDS);
+    instance.read(MOCK_TABLE, MOCK_KEY2, MOCK_DATA.keySet(), resultParam);
+
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      assertEquals("newvalue" + i, resultParam.get(FIELD_PREFIX + i).toString());
+    }
+  }
+
+  @Test
+  public void insertAndScan() throws Exception {
+    final Status insertResult = instance.insert(MOCK_TABLE, MOCK_KEY3, MOCK_DATA);
+    assertEquals(Status.OK, insertResult);
+
+    final Set<String> fields = MOCK_DATA.keySet();
+    final Vector<HashMap<String, ByteIterator>> resultParam = new Vector<>(NUM_RECORDS);
+    final Status result = instance.scan(MOCK_TABLE, MOCK_KEY3, NUM_RECORDS, fields, resultParam);
+    assertEquals(Status.NOT_IMPLEMENTED, result);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2012 - 2020 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2021 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -137,6 +137,7 @@ LICENSE file.
     <mongodb.async.version>2.0.1</mongodb.async.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
+    <pmemkv.version>1.0.0</pmemkv.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <redis.version>2.9.0</redis.version>
     <riak.version>2.0.5</riak.version>
@@ -189,6 +190,7 @@ LICENSE file.
     <module>mongodb</module>
     <module>nosqldb</module>
     <module>orientdb</module>
+    <module>pmemkv</module>
     <module>postgrenosql</module>
     <module>rados</module>
     <module>redis</module>


### PR DESCRIPTION
pmemkv is a local/embedded key-value datastore optimized
for persistent memory (https://github.com/pmem/pmemkv-java).


// Rationale:
We've prepared a new module for pmemkv(-java) datastore and we've successfully gathered some data using this module. We believe it may be useful for potential pmemkv users to test it on their own.

// Known caveats:
There's still a tiny issue, we couldn't overcome and we were hoping you can help us solve it.
Please see: https://github.com/pmem/YCSB/issues/3
Maybe we're missing something obvious.