### PR TITLE
Vanilla Redis improvements

### DIFF
--- a/bin/run-redis.sh
+++ b/bin/run-redis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
+
+./bin/ycsb run redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunA.txt
+./bin/ycsb run redis -s -P workloads/workloadb -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunB.txt
+./bin/ycsb run redis -s -P workloads/workloadc -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunC.txt
+./bin/ycsb run redis -s -P workloads/workloadf -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunF.txt
+./bin/ycsb run redis -s -P workloads/workloadd -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunD.txt
+
+redis-cli flushall
+
+./bin/ycsb load redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
+./bin/ycsb run redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunE.txt

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -220,7 +220,7 @@ def get_classpath_from_maven(module):
         # the last module will be the datastore binding
         line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
         return line[0][len("classpath="):]
-    except subprocess.CalledProcessError, err:
+    except subprocess.CalledProcessError as err:
         error("Attempting to generate a classpath from Maven failed "
               "with return code '" + str(err.returncode) + "'. The output from "
               "Maven follows, try running "

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@ LICENSE file.
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <redis.version>2.9.0</redis.version>
+    <redis.version>3.5.1</redis.version>
     <riak.version>2.0.5</riak.version>
     <rocksdb.version>6.2.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>

--- a/redis/README.md
+++ b/redis/README.md
@@ -45,15 +45,14 @@ Set host, port, password, and cluster mode in the workload you plan to run.
 
 Or, you can set configs with the shell command, EG:
 
-    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" > outputLoad.txt
+    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
 
 ### 5. Load data and run tests
 
 Load the data:
+    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
 
-    ./bin/ycsb load redis -s -P workloads/workloada > outputLoad.txt
 
 Run the workload test:
-
-    ./bin/ycsb run redis -s -P workloads/workloada > outputRun.txt
+    ./bin/ycsb run redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRun.txt
 

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -34,6 +34,17 @@ LICENSE file.
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>${redis.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>


### PR DESCRIPTION
This PR improves the overall vanilla YCSB redis implementation on:

**writes**: 
 - pipelining the HMSET and ZADD 

**deletes**: 
 - pipelining the DEL and ZREM 

**reads**:
- using HGETALL using HGETALL when fields length is equal to the total amount of fields or fields equal to nil

**scan**:
- pipelining the second burst of requests after the first zrangebyscore

For a bit of context on how we're modeling the YCSB default workloads on Redis ( which we didn't changed in this PR see the following sections ). 
For a way of reproducing the improvements on the workloads see the latest section of this PR


----


**A bit of context on default workloads dataset representation**

-    All six workloads have a data set that is similar, composed for N distinct records. 

-    Each record is identified by a primary key, which is a string like “user234123”. 

-    Within each record, by default, we have 10 fields, named field0, field1, and so on. The values of each field are a random string of ASCII characters of length L. 

 -   By default, we construct 1,000-byte records by using F = 10 fields, each of L = 100 bytes. 

Specifically, within Redis, we model each record as a HASH, as showcased below.

```
127.0.0.1:6379> hgetall user3081588361181406186
 1) "field1"
 2) "69~?[w)+051z)\"6=4.9;&=+$5H50'$,H;! ($Is+U36_s\"Tu#[g:X\x7f&]38D3(/p\"\\c'?p*(65.`+K=0<>=5p1,l:J1+\">).</Z79"
 3) "field4"
 4) "0D)=Rg,=l2\"\" A}'A7+44<&<<=|;<r Yy>C1!Ey; ,?)f6&(4&z>362W{&U1:Wo/\"p=T%<4\":V14Vw%$\"1>0)I{?,`.@e3J1(Gi?"
 5) "field3"
 6) "4'8! ,<,p:;d2;d+Uu!^7 5d,1$ 6\"2Ay')*:Z{6H##T#5E-*X\x7f3>.&-*9\" .7:9^m43|'-j-_-,Ga ]w'*0$L#8Bm1E3(4*.2d/"
 7) "field7"
 8) "?M'1Bw+N/$C=&N)4%20=n&Q'0S+10,;X10Kc9Ea7\\e%,j/:(9_)9/t7Ui#28\"0b3$l']-54<!8t6\"04Fq?)\"?Uu7/*!,,!Ue04*%"
 9) "field8"
10) "+E\x7f?3*3;($0j,.|\"*b<Pq+Zu58t*7.=4h7&z%Ky?640K'9V7,!,068:Fg:W\x7f70d&Yy>D;1(f$',1#v*:0)[w3:n3>4+Zi/)p63f&"
11) "field0"
12) "%,p70h> t7B54&d+-f-Fu3Y=%Tw7+|>50)#h?Vy6Qo:,.-]}7:n*B13]}*_c(=\"8@%?Ae*2*$'b+Ls97`/B}$#|.Tq#9:%+l1%.0"
13) "field2"
14) "=H-(9&)# -H\x7f5G!=]e.H+,P}%(|2)r<Yu\"Wg6#z*/4%Fe;(p6 z#:x1P3%T+\">h;%:\"Na.Og1^k:K!*!&9\" :Y?=Vi89t*&z.&v:"
15) "field6"
16) "-N)1Ni,$$=\"n,,~#0.#1x&%v=@385><\"t.;b9@+0!$+6l6G57D%)Xy?\"x.Va9S? Dg  h?/h=;0<Gy3&j'+.?+v/K3.=|+8~'Sm/"
17) "field9"
18) "$R}6P'!5v2R-*Am2\"*&@1$Ke:!4)6r%Tk/!(#1(1,.:De?.t*U/)@/;^3,[-)\",<N#?%,!&p*24-V%:=>$.\">U9$\\c5>$,8\"..h7"
19) "field5"
20) "+$\",(t(J\x7f6.|-Ey2I)?:,(#,2<6$Rq$^%4F\x7f74 !#x38~>#t3Ym;4\",Z1-9,/%\" 7f'X9=N+)*t#^e7#<  4&Y9(&:2_1=?21Y-<"
```

**Scanning based on sorted sets…**

As you will see below, there is the need to model a scan operation within different records, in which we scan records in order, starting at a randomly chosen record key. The number of records to scan is randomly chosen. To model this within Vanilla Redis, we use a sorted set named “_indices“ in which the element is the primary key, and the score of the element is given by computing a hash of the key name. 

Therefore, the cardinality of the “_indices“ sorted set is the same as the number of simulated records. When we want to simulate the scan operation for a given primary key, we calculate the keys we wish to scan by doing a ZRANGEBYSCORE starting at the given key score and setting as limit +Inf with a count equal to the scan size. We then retrieve each independent key like a normal read. 

--------------

**A bit of content on running the workloads**

All six workloads have a data set that is similar. Workloads D and E insert records during the test run. Thus, to keep the database size consistent, we recommend the following sequence:

 -  Load the database, using workload A’s parameter file (workloads/workloada) and the “-load” switch to the client.

 - Run workload A (using workloads/workloada and “-t”) for a variety of throughputs.

 - Run workload B (using workloads/workloadb and “-t”) for a variety of throughputs.

 - Run workload C (using workloads/workloadc and “-t”) for a variety of throughputs. 

-    Run workload F (using workloads/workloadf and “-t”) for a variety of throughputs.

 -   Run workload D (using workloads/workloadd and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.

-    Delete the data in the database.

  -  Reload the database, using workload E’s parameter file (workloads/workloade) and the "-load switch to the client.

   - Run workload E (using workloads/workloade and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.

----

**Running a local sequence without preloading the RDB:**

```
# build it

git clone http://github.com/RediSearch/YCSB.git
git checkout redis.update
cd YCSB
mvn -pl site.ycsb:redis-binding -am clean package

# load, run A, B, C, F, D, (flushdb), load, E
./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt

./bin/ycsb run redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunA.txt
./bin/ycsb run redis -s -P workloads/workloadb -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunB.txt
./bin/ycsb run redis -s -P workloads/workloadc -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunC.txt
./bin/ycsb run redis -s -P workloads/workloadf -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunF.txt
./bin/ycsb run redis -s -P workloads/workloadd -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunD.txt

redis-cli flushall

./bin/ycsb load redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
./bin/ycsb run redis -s -P workloads/workloade -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRunE.txt
```