### PR TITLE
Added support for Elasticsearch 7.x

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -70,6 +70,8 @@ DATABASES = {
     "elasticsearch": "site.ycsb.db.ElasticsearchClient",
     "elasticsearch5": "site.ycsb.db.elasticsearch5.ElasticsearchClient",
     "elasticsearch5-rest": "site.ycsb.db.elasticsearch5.ElasticsearchRestClient",
+    "elasticsearch7": "site.ycsb.db.elasticsearch7.ElasticsearchClient",
+    "elasticsearch7-rest": "site.ycsb.db.elasticsearch7.ElasticsearchRestClient",
     "foundationdb" : "site.ycsb.db.foundationdb.FoundationDBClient",
     "geode"        : "site.ycsb.db.GeodeClient",
     "googlebigtable"  : "site.ycsb.db.GoogleBigtableClient",

--- a/elasticsearch7/README.md
+++ b/elasticsearch7/README.md
@@ -1,0 +1,118 @@
+<!--
+Copyright (c) 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Elasticsearch 7.x running locally. 
+
+### 1. Install and Start Elasticsearch
+
+[Download and install Elasticsearch][1]. When starting Elasticsearch, you should
+[configure][2] the cluster name to be `es.ycsb.cluster` (see below).
+
+#### 1.1 Testing with Docker
+
+Note: For the sake of the demo we're using elastic7.9 to avoid the `Elasticsearch built-in security features are not enabled` log lines.
+
+```bash
+docker run -p 9200:9200 -p 9300:9300 \
+       -e "discovery.type=single-node" \
+       docker.elastic.co/elasticsearch/elasticsearch:7.9.2
+```
+
+### 2. Set Up YCSB
+
+Clone the YCSB git repository and compile:
+
+    git clone git://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
+    mvn -pl site.ycsb:elasticsearch7-binding -am clean package
+
+### 3. Run YCSB
+    
+Now you are ready to run! First, load the data:
+
+    ./bin/ycsb load elasticsearch7-rest -s -P workloads/workloada
+
+You can easily confirm the index status via the REST API (adjust to your conn details):
+
+    $ curl http://localhost:9200/es.ycsb/_count?pretty
+    {
+      "count" : 1000,
+      "_shards" : {
+        "total" : 1,
+        "successful" : 1,
+        "skipped" : 0,
+        "failed" : 0
+      }
+    }
+
+Then, run the workload:
+
+    ./bin/ycsb run elasticsearch7-rest -s -P workloads/workloada
+
+
+The Elasticsearch 7 binding requires a standalone instance of Elasticsearch.
+You must specify a hosts list for the transport client to connect to via
+`-p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`:
+
+    ./bin/ycsb run elasticsearch7-rest -s -P workloads/workloada \
+    -p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`
+
+Note that `es.hosts.list` defaults to `localhost:9300`. For further
+configuration see below:
+
+### Defaults Configuration
+The default setting for the Elasticsearch node that is created is as follows:
+
+    es.setting.cluster.name=es.ycsb.cluster
+    es.index.key=es.ycsb
+    es.number_of_shards=1
+    es.number_of_replicas=0
+    es.new_index=false
+    es.queries.cache.enabled=true
+    es.refresh_interval=1s
+    es.hosts.list=localhost:9200
+    es.user=""
+    es.password=""
+    es.hosts.scheme="http"
+
+### Custom Configuration
+If you wish to customize the settings used to create the Elasticsearch node
+you can created a new property file that contains your desired Elasticsearch 
+node settings and pass it in via the parameter to 'bin/ycsb' script. Note that 
+the default properties will be kept if you don't explicitly overwrite them.
+
+Assuming that we have a properties file named "myproperties.data" that contains 
+custom Elasticsearch node configuration you can execute the following to
+pass it into the Elasticsearch client:
+
+    ./bin/ycsb run elasticsearch7 -P workloads/workloada -P myproperties.data -s
+
+If you wish to change the default index name you can set the following property:
+
+    es.index.key=my_index_key
+
+By default this will use localhost:9300 as a seed node to discover the cluster.
+You can also specify
+
+    es.hosts.list=(\w+:\d+)+
+
+(a comma-separated list of host/port pairs) to change this.
+
+[1]: https://www.elastic.co/guide/en/elasticsearch/reference/7.2/install-elasticsearch.html
+[2]: https://www.elastic.co/guide/en/elasticsearch/reference/7.2/setup.html

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2017 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+
+  <properties>
+    <!-- Skip tests by default. will be activated by jdk8 profile -->
+    <skipTests>true</skipTests>
+    <elasticsearch.groupid>org.elasticsearch.distribution.zip</elasticsearch.groupid>
+
+    <!-- For integration tests using ANT -->
+    <integ.http.port>9400</integ.http.port>
+    <integ.transport.port>9500</integ.transport.port>
+
+    <!-- If tests are skipped, skip ES spin up -->
+    <es.skip>${skipTests}</es.skip>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>integ-setup-dependencies</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${elasticsearch.groupid}</groupId>
+                  <artifactId>elasticsearch</artifactId>
+                  <version>${elasticsearch7-version}</version>
+                  <type>zip</type>
+                </artifactItem>
+              </artifactItems>
+              <useBaseVersion>true</useBaseVersion>
+              <outputDirectory>${project.build.directory}/integration-tests/binaries</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.carrotsearch.randomizedtesting</groupId>
+        <artifactId>junit4-maven-plugin</artifactId>
+        <version>2.3.3</version>
+
+        <configuration>
+          <assertions enableSystemAssertions="false">
+            <enable/>
+          </assertions>
+
+          <listeners>
+            <report-text />
+          </listeners>
+        </configuration>
+
+        <executions>
+          <execution>
+            <id>unit-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>junit4</goal>
+            </goals>
+            <inherited>true</inherited>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*Test.class</include>
+              </includes>
+              <excludes>
+                <exclude>**/*$*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-tests</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>junit4</goal>
+            </goals>
+            <inherited>true</inherited>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+              <excludes>
+                <exclude>**/*$*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <artifactId>elasticsearch7-binding</artifactId>
+  <name>Elasticsearch 7.x Binding</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <!-- jna is supported in ES and will be used when provided
+           otherwise a fallback is used -->
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>jna</artifactId>
+      <version>4.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>transport</artifactId>
+      <version>${elasticsearch7-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>${elasticsearch7-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>2.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <!-- Requires JDK8 to run, so none of our tests
+         will work unless we're using jdk8.
+      -->
+    <profile>
+      <id>jdk8-tests</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.alexcojocaru</groupId>
+            <artifactId>elasticsearch-maven-plugin</artifactId>
+            <version>5.9</version>
+            <configuration>
+              <version>${elasticsearch7-version}</version>
+              <clusterName>test</clusterName>
+              <httpPort>9200</httpPort>
+              <transportPort>9300</transportPort>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-elasticsearch</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>runforked</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-elasticsearch</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/Elasticsearch7.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/Elasticsearch7.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import java.util.Properties;
+
+final class Elasticsearch7 {
+
+  static final String KEY = "key";
+
+  private Elasticsearch7() {
+
+  }
+
+  static int parseIntegerProperty(final Properties properties, final String key, final int defaultValue) {
+    final String value = properties.getProperty(key);
+    return value == null ? defaultValue : Integer.parseInt(value);
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchClient.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchClient.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import site.ycsb.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static org.elasticsearch.common.settings.Settings.Builder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.KEY;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.parseIntegerProperty;
+
+/**
+ * Elasticsearch client for YCSB framework.
+ */
+public class ElasticsearchClient extends DB {
+
+  private static final String DEFAULT_CLUSTER_NAME = "es.ycsb.cluster";
+  private static final String DEFAULT_INDEX_KEY = "es.ycsb";
+  private static final String DEFAULT_REMOTE_HOST = "localhost:9300";
+  private static final int NUMBER_OF_SHARDS = 1;
+  private static final int NUMBER_OF_REPLICAS = 0;
+  private TransportClient client;
+  private String indexKey;
+  private volatile boolean isRefreshNeeded = false;
+
+  /**
+   * Initialize any state for this DB. Called once per DB instance; there is one
+   * DB instance per client thread.
+   */
+  @Override
+  public void init() throws DBException {
+    final Properties props = getProperties();
+
+    this.indexKey = props.getProperty("es.index.key", DEFAULT_INDEX_KEY);
+
+    final int numberOfShards = parseIntegerProperty(props, "es.number_of_shards", NUMBER_OF_SHARDS);
+    final int numberOfReplicas = parseIntegerProperty(props, "es.number_of_replicas", NUMBER_OF_REPLICAS);
+
+    final Boolean newIndex = Boolean.parseBoolean(props.getProperty("es.new_index", "false"));
+    final Builder settings = Settings.builder().put("cluster.name", DEFAULT_CLUSTER_NAME);
+
+    // if properties file contains elasticsearch user defined properties
+    // add it to the settings file (will overwrite the defaults).
+    for (final Entry<Object, Object> e : props.entrySet()) {
+      if (e.getKey() instanceof String) {
+        final String key = (String) e.getKey();
+        if (key.startsWith("es.setting.")) {
+          settings.put(key.substring("es.setting.".length()), (Boolean) e.getValue());
+        }
+      }
+    }
+
+    settings.put("client.transport.sniff", true)
+        .put("client.transport.ignore_cluster_name", false)
+        .put("client.transport.ping_timeout", "30s")
+        .put("client.transport.nodes_sampler_interval", "30s");
+    // Default it to localhost:9300
+    final String[] nodeList = props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST).split(",");
+    client = new PreBuiltTransportClient(settings.build());
+    for (String h : nodeList) {
+      String[] nodes = h.split(":");
+
+      final InetAddress address;
+      try {
+        address = InetAddress.getByName(nodes[0]);
+      } catch (UnknownHostException e) {
+        throw new IllegalArgumentException("unable to identity host [" + nodes[0] + "]", e);
+      }
+      final int port;
+      try {
+        port = Integer.parseInt(nodes[1]);
+      } catch (final NumberFormatException e) {
+        throw new IllegalArgumentException("unable to parse port [" + nodes[1] + "]", e);
+      }
+      client.addTransportAddress(new InetSocketTransportAddress(address, port));
+    }
+
+    final boolean exists =
+        client.admin().indices()
+            .exists(Requests.indicesExistsRequest(indexKey)).actionGet()
+            .isExists();
+    if (exists && newIndex) {
+      client.admin().indices().prepareDelete(indexKey).get();
+    }
+    if (!exists || newIndex) {
+      client.admin().indices().create(
+          new CreateIndexRequest(indexKey)
+              .settings(
+                  Settings.builder()
+                      .put("index.number_of_shards", numberOfShards)
+                      .put("index.number_of_replicas", numberOfReplicas)
+              )).actionGet();
+    }
+    client.admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet();
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+  }
+
+  @Override
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
+    try (XContentBuilder doc = jsonBuilder()) {
+
+      doc.startObject();
+      for (final Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        doc.field(entry.getKey(), entry.getValue());
+      }
+      doc.field(KEY, key);
+      doc.endObject();
+
+      final IndexResponse indexResponse = client.prepareIndex(indexKey, table).setSource(doc).get();
+      if (indexResponse.isCreated()) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(final String table, final String key) {
+    try {
+      final SearchResponse searchResponse = search(table, key);
+      if (searchResponse.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final String id = searchResponse.getHits().getAt(0).getId();
+
+      final DeleteResponse deleteResponse = client.prepareDelete(indexKey, table, id).get();
+      if (!deleteResponse.isFound()) {
+        return Status.NOT_FOUND;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status read(
+      final String table,
+      final String key,
+      final Set<String> fields,
+      final Map<String, ByteIterator> result) {
+    try {
+      final SearchResponse searchResponse = search(table, key);
+      if (searchResponse.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final SearchHit hit = searchResponse.getHits().getAt(0);
+      if (fields != null) {
+        for (final String field : fields) {
+          result.put(field, new StringByteIterator((String) hit.getSource().get(field)));
+        }
+      } else {
+        for (final Map.Entry<String, Object> e : hit.getSource().entrySet()) {
+          if (KEY.equals(e.getKey())) {
+            continue;
+          }
+          result.put(e.getKey(), new StringByteIterator((String) e.getValue()));
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final SearchResponse response = search(table, key);
+      if (response.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final SearchHit hit = response.getHits().getAt(0);
+      for (final Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        hit.getSource().put(entry.getKey(), entry.getValue());
+      }
+
+      final IndexResponse indexResponse =
+          client.prepareIndex(indexKey, table, hit.getId()).setSource(hit.getSource()).get();
+
+      if (!indexResponse.isCreated()) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status scan(
+      final String table,
+      final String startkey,
+      final int recordcount,
+      final Set<String> fields,
+      final Vector<HashMap<String, ByteIterator>> result) {
+    try {
+      refreshIfNeeded();
+      final RangeQueryBuilder query = new RangeQueryBuilder(KEY).gte(startkey);
+      final SearchResponse response = client.prepareSearch(indexKey).setQuery(query).setSize(recordcount).get();
+
+      for (final SearchHit hit : response.getHits()) {
+        final HashMap<String, ByteIterator> entry;
+        if (fields != null) {
+          entry = new HashMap<>(fields.size());
+          for (final String field : fields) {
+            entry.put(field, new StringByteIterator((String) hit.getSource().get(field)));
+          }
+        } else {
+          entry = new HashMap<>(hit.getSource().size());
+          for (final Map.Entry<String, Object> field : hit.getSource().entrySet()) {
+            if (KEY.equals(field.getKey())) {
+              continue;
+            }
+            entry.put(field.getKey(), new StringByteIterator((String) field.getValue()));
+          }
+        }
+        result.add(entry);
+      }
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private void refreshIfNeeded() {
+    if (isRefreshNeeded) {
+      final boolean refresh;
+      synchronized (this) {
+        if (isRefreshNeeded) {
+          refresh = true;
+          isRefreshNeeded = false;
+        } else {
+          refresh = false;
+        }
+      }
+      if (refresh) {
+        client.admin().indices().refresh(new RefreshRequest()).actionGet();
+      }
+    }
+  }
+
+  private SearchResponse search(final String table, final String key) {
+    refreshIfNeeded();
+    return client.prepareSearch(indexKey).setTypes(table).setQuery(new TermQueryBuilder(KEY, key)).get();
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchRestClient.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchRestClient.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.nio.entity.NStringEntity;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import site.ycsb.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.KEY;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.parseIntegerProperty;
+
+/**
+ * Elasticsearch REST client for YCSB framework.
+ */
+public class ElasticsearchRestClient extends DB {
+
+  private static final String DEFAULT_INDEX_KEY = "es.ycsb";
+  private static final String DEFAULT_REMOTE_HOST = "localhost:9200";
+  private static final String DEFAULT_HOST_SCHEMA = "http";
+  private static final String CRED_USER_PROPERTY = "es.user";
+  private static final String DEFAULT_CRED_USER = "";
+  private static final String CRED_PASS_PROPERTY = "es.password";
+  private static final String DEFAULT_CRED_PASS = "";
+  private static final String DEFAULT_REFRESH_INTERVAL = "1s";
+  private static final int NUMBER_OF_SHARDS = 1;
+  private static final int NUMBER_OF_REPLICAS = 0;
+  private static final boolean INDEX_QUERY_CACHE_ENABLED_DEFAULT = true;
+  private static final String INDEX_QUERY_CACHE_ENABLED_PROPERTY = "es.queries.cache.enabled";
+  private static final String CONTENT_TYPE_APPLICATION_JSON = ContentType.APPLICATION_JSON.toString();
+  private RestClient restClient;
+  private String indexKey;
+  private volatile boolean isRefreshNeeded = false;
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint) throws DBException {
+    final Map<String, String> params = emptyMap();
+    return performRequest(restClient, method, endpoint, params);
+  }
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint,
+      final Map<String, String> params) throws DBException {
+    return performRequest(restClient, method, endpoint, params, null, null);
+  }
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint,
+      final Map<String, String> params,
+      final HttpEntity entity, NStringEntity contentTypeEntity) throws DBException {
+    try {
+      Request request = new Request(method,
+          endpoint);
+      request.addParameters(params);
+      if (entity != null) {
+        request.setEntity(entity);
+      }
+      return restClient.performRequest(request);
+    } catch (final IOException e) {
+      e.printStackTrace();
+      throw new DBException(e);
+    }
+  }
+
+  /**
+   * Initialize any state for this DB. Called once per DB instance; there is one
+   * DB instance per client thread.
+   */
+  @Override
+  public void init() throws DBException {
+    final Properties props = getProperties();
+
+    this.indexKey = props.getProperty("es.index.key", DEFAULT_INDEX_KEY);
+    final String indexRefreshInterval = props.getProperty("es.refresh_interval", DEFAULT_REFRESH_INTERVAL);
+
+    final int numberOfShards = parseIntegerProperty(props, "es.number_of_shards", NUMBER_OF_SHARDS);
+    final int numberOfReplicas = parseIntegerProperty(props, "es.number_of_replicas", NUMBER_OF_REPLICAS);
+    final boolean queryCacheEnabled = Boolean.parseBoolean(props.getProperty(INDEX_QUERY_CACHE_ENABLED_PROPERTY,
+        String.valueOf(INDEX_QUERY_CACHE_ENABLED_DEFAULT)));
+
+    final Boolean newIndex = Boolean.parseBoolean(props.getProperty("es.new_index", "false"));
+
+    final String[] nodeList = props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST).split(",");
+    final String hostSchema = props.getProperty("es.hosts.scheme", DEFAULT_HOST_SCHEMA);
+    final String user = props.getProperty(CRED_USER_PROPERTY, DEFAULT_CRED_USER);
+    final String pass = props.getProperty(CRED_PASS_PROPERTY, DEFAULT_CRED_PASS);
+    final CredentialsProvider credentialsProvider =
+        new BasicCredentialsProvider();
+    if (user != DEFAULT_CRED_USER && pass != DEFAULT_CRED_PASS) {
+      credentialsProvider.setCredentials(AuthScope.ANY,
+          new UsernamePasswordCredentials(user, pass));
+    }
+
+
+    final List<HttpHost> esHttpHosts = new ArrayList<>(nodeList.length);
+    for (String h : nodeList) {
+      String[] nodes = h.split(":");
+      HttpHost httpHost = new HttpHost(nodes[0], Integer.valueOf(nodes[1]), hostSchema);
+      esHttpHosts.add(httpHost);
+    }
+
+    RestClientBuilder restClientBuilder = RestClient.builder(esHttpHosts.toArray(new HttpHost[esHttpHosts.size()]));
+    // Based uppon https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_basic_authentication.html
+    if (user != DEFAULT_CRED_USER && pass != DEFAULT_CRED_PASS) {
+      restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
+          .setDefaultCredentialsProvider(credentialsProvider));
+    }
+    restClient = restClientBuilder.build();
+
+    final Response existsResponse = performRequest(restClient,
+        "HEAD", "/" + indexKey);
+    final boolean exists = existsResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
+
+    if (exists && newIndex) {
+      final Response deleteResponse = performRequest(restClient, "DELETE", "/" + indexKey);
+      final int statusCode = deleteResponse.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        throw new DBException("delete [" + indexKey + "] failed with status [" + statusCode + "]");
+      }
+    }
+
+    if (!exists || newIndex) {
+      try (XContentBuilder builder = jsonBuilder()) {
+        builder.startObject();
+        // {
+        builder.startObject("settings");
+        //   {
+        builder.field("index.number_of_shards", numberOfShards);
+        builder.field("index.number_of_replicas", numberOfReplicas);
+        // Check the following link to decide on which refresh interval to use during the benchmark
+        // https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html
+        builder.field("index.refresh_interval", indexRefreshInterval);
+        builder.field("index.queries.cache.enabled", queryCacheEnabled);
+        //   }
+        builder.endObject();
+        // }
+        builder.endObject();
+        final Map<String, String> params = emptyMap();
+        final StringEntity entity = new StringEntity(builder.string());
+        entity.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+        final Response createResponse = performRequest(restClient, "PUT", "/" + indexKey,
+            params, entity, null);
+        final int statusCode = createResponse.getStatusLine().getStatusCode();
+        if (statusCode != HttpStatus.SC_OK) {
+          throw new DBException("create [" + indexKey + "] failed with status [" + statusCode + "]");
+        }
+      } catch (final IOException e) {
+        throw new DBException(e);
+      }
+    }
+
+    final Map<String, String> params = Collections.singletonMap("wait_for_status", "green");
+    final Response healthResponse = performRequest(restClient, "GET", "/_cluster/health/" + indexKey,
+        params, null, null);
+    final int healthStatusCode = healthResponse.getStatusLine().getStatusCode();
+    if (healthStatusCode != HttpStatus.SC_OK) {
+      throw new DBException("cluster health [" + indexKey + "] failed with status [" + healthStatusCode + "]");
+    }
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+    if (restClient != null) {
+      try {
+        restClient.close();
+        restClient = null;
+      } catch (final IOException e) {
+        throw new DBException(e);
+      }
+    }
+  }
+
+  @Override
+  public Status insert(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final Map<String, String> data = StringByteIterator.getStringMap(values);
+      data.put(KEY, key);
+      NStringEntity payload = new NStringEntity(new ObjectMapper().writeValueAsString(data));
+      payload.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+      // Reason why we use auto-generated ids and not the specific key id
+      // https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html
+      // When indexing a document that has an explicit id, Elasticsearch needs to check whether a document with the
+      // same id already exists within the same shard, which is a costly operation and gets even more costly as
+      // the index grows. By using auto-generated ids, Elasticsearch can skip this check, which makes indexing faster.
+      final Response response = performRequest(restClient, "POST",
+          "/" + indexKey + "/_doc",
+          Collections.emptyMap(),
+          payload,
+          null
+      );
+
+      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(final String table, final String key) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == HttpStatus.SC_NOT_FOUND) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      String hitIdStr = (String) hit.get("_id");
+      final Response deleteResponse = performRequest(restClient, "DELETE",
+          "/" + indexKey + "/" + hitIdStr);
+      if (deleteResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status read(
+      final String table,
+      final String key,
+      final Set<String> fields,
+      final Map<String, ByteIterator> result) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == 404) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      if (fields != null) {
+        for (final String field : fields) {
+          result.put(field, new StringByteIterator((String) source.get(field)));
+        }
+      } else {
+        for (final Map.Entry<String, Object> e : source.entrySet()) {
+          if (KEY.equals(e.getKey())) {
+            continue;
+          }
+          result.put(e.getKey(), new StringByteIterator((String) e.getValue()));
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private int getTotalHits(Map<String, Object> hits) {
+    @SuppressWarnings("unchecked") final Map<String, Object> hitsTotal = (Map<String, Object>) hits.get("total");
+    final int total = (int) hitsTotal.get("value");
+    return total;
+  }
+
+  @Override
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == 404) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      for (final Map.Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        source.put(entry.getKey(), entry.getValue());
+      }
+      final Map<String, String> params = emptyMap();
+      NStringEntity payload = new NStringEntity(new ObjectMapper().writeValueAsString(source));
+      payload.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+      final Response response = performRequest(restClient, "PUT",
+          "/" + indexKey + "/_doc/" + hit.get("_id"),
+          params,
+          payload, null
+      );
+      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status scan(
+      final String table,
+      final String startkey,
+      final int recordcount,
+      final Set<String> fields,
+      final Vector<HashMap<String, ByteIterator>> result) {
+    try {
+      final Response response;
+      try (XContentBuilder builder = jsonBuilder()) {
+        builder.startObject();
+        builder.startObject("query");
+        builder.startObject("range");
+        builder.startObject(KEY);
+        builder.field("gte", startkey);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.field("size", recordcount);
+        builder.endObject();
+        response = search(table, builder);
+        processSearchReply(fields, result, response);
+      }
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private void processSearchReply(Set<String> fields, Vector<HashMap<String, ByteIterator>> result, Response response)
+      throws IOException {
+    @SuppressWarnings("unchecked") final Map<String, Object> map = map(response);
+    @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+    @SuppressWarnings("unchecked") final List<Map<String, Object>> list =
+        (List<Map<String, Object>>) hits.get("hits");
+
+    for (final Map<String, Object> hit : list) {
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      final HashMap<String, ByteIterator> entry;
+      if (fields != null) {
+        entry = new HashMap<>(fields.size());
+        for (final String field : fields) {
+          entry.put(field, new StringByteIterator((String) source.get(field)));
+        }
+      } else {
+        entry = new HashMap<>(hit.size());
+        for (final Map.Entry<String, Object> field : source.entrySet()) {
+          if (KEY.equals(field.getKey())) {
+            continue;
+          }
+          entry.put(field.getKey(), new StringByteIterator((String) field.getValue()));
+        }
+      }
+      result.add(entry);
+    }
+  }
+
+  private void refreshIfNeeded() throws IOException, DBException {
+    if (isRefreshNeeded) {
+      final boolean refresh;
+      synchronized (this) {
+        if (isRefreshNeeded) {
+          refresh = true;
+          isRefreshNeeded = false;
+        } else {
+          refresh = false;
+        }
+      }
+      if (refresh) {
+        performRequest(restClient, "POST", "/" + indexKey + "/_refresh");
+      }
+    }
+  }
+
+  private Response search(final String table, final String key) throws IOException, DBException {
+    try (XContentBuilder builder = jsonBuilder()) {
+      builder.startObject();
+      builder.startObject("query");
+      builder.startObject("term");
+      builder.field(KEY, key);
+      builder.endObject();
+      builder.endObject();
+      builder.endObject();
+      return search(table, builder);
+    }
+  }
+
+  private Response search(final String table, final XContentBuilder builder) throws IOException, DBException {
+    refreshIfNeeded();
+    final Map<String, String> params = emptyMap();
+    final StringEntity entity = new StringEntity(builder.string());
+    entity.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+    return performRequest(restClient, "GET", "/" + indexKey + "/_search",
+        params, entity, null);
+  }
+
+  private Map<String, Object> map(final Response response) throws IOException {
+    try (InputStream is = response.getEntity().getContent()) {
+      final ObjectMapper mapper = new ObjectMapper();
+      @SuppressWarnings("unchecked") final Map<String, Object> map = mapper.readValue(is, Map.class);
+      return map;
+    }
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/package-info.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017 YCSB Contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for
+ * <a href="https://www.elastic.co/products/elasticsearch">Elasticsearch</a>.
+ */
+package site.ycsb.db.elasticsearch7;
+

--- a/elasticsearch7/src/main/resources/log4j2.properties
+++ b/elasticsearch7/src/main/resources/log4j2.properties
@@ -1,0 +1,22 @@
+# Copyright (c) 2017 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+appender.console.type=Console
+appender.console.name=console
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.targetStr=SYSTEM_ERR
+rootLogger.level=info
+rootLogger.appenderRef.console.ref=console

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@ LICENSE file.
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
+    <elasticsearch7-version>7.12.0</elasticsearch7-version>
     <foundationdb.version>5.2.5</foundationdb.version>
     <geode.version>1.2.0</geode.version>
     <googlebigtable.version>1.4.0</googlebigtable.version>
@@ -172,6 +173,7 @@ LICENSE file.
     <module>dynamodb</module>
     <module>elasticsearch</module>
     <module>elasticsearch5</module>
+    <module>elasticsearch7</module>
     <module>foundationdb</module>
     <module>geode</module>
     <module>googlebigtable</module>


### PR DESCRIPTION
This PR adds support for Elasticsearch 7.x, and further fixes #1573 and #1574. 
Furthermore it enables specifying if the query cache should be enabled for testing via `es.queries.cache.enabled` ( default=true ) and the index refresh interval via `es.refresh_interval` ( default=1s ).

The bellow steps easily explain how to test it: 

#### 1.1 Testing with Docker

Note: For the sake of the demo we're using elastic7.9 to avoid the `Elasticsearch built-in security features are not enabled` log lines.

```bash
docker run -p 9200:9200 -p 9300:9300 \
       -e "discovery.type=single-node" \
       docker.elastic.co/elasticsearch/elasticsearch:7.9.2
```

### 2. Set Up YCSB

Clone the YCSB git repository and compile:

    git clone git://github.com/brianfrankcooper/YCSB.git
    cd YCSB
    mvn -pl site.ycsb:elasticsearch7-binding -am clean package

### 3. Run YCSB

Now you are ready to run! First, load the data:

    ./bin/ycsb load elasticsearch7-rest -s -P workloads/workloada

You can easily confirm the index status via the REST API (adjust to your conn details):

    $ curl http://localhost:9200/es.ycsb/_count?pretty
    {
      "count" : 1000,
      "_shards" : {
        "total" : 1,
        "successful" : 1,
        "skipped" : 0,
        "failed" : 0
      }
    }

Then, run the workload:

    ./bin/ycsb run elasticsearch7-rest -s -P workloads/workloada


The Elasticsearch 7 binding requires a standalone instance of Elasticsearch.
You must specify a hosts list for the transport client to connect to via
`-p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`:

    ./bin/ycsb run elasticsearch7-rest -s -P workloads/workloada \
    -p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`

Note that `es.hosts.list` defaults to `localhost:9300`. For further
configuration see below:

### Defaults Configuration
The default setting for the Elasticsearch node that is created is as follows:

    es.setting.cluster.name=es.ycsb.cluster
    es.index.key=es.ycsb
    es.number_of_shards=1
    es.number_of_replicas=0
    es.new_index=false
    es.queries.cache.enabled=true
    es.refresh_interval=1s
    es.hosts.list=localhost:9200
    es.user=""
    es.password=""
    es.hosts.scheme="http"