### PR TITLE
Added capability of exporting per operation type full latency percentile output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # ignore compiled byte code
 target
 
+# percentile output format
+*.txt
+
 # ignore output files from testing
 output*
 


### PR DESCRIPTION
The following PR enables exporting the full percentile latencies of each operation type, in the HdrHistogram standard output format, via the added properties `hdrhistogram.percentiles.export` (true or false) and `hdrhistogram.percentiles.export.filepath` (default = "" which stores to current folder ).


Tools like https://hdrhistogram.github.io/HdrHistogram/plotFiles.html and https://github.com/BrunoBonacci/hdr-plot can be used to generate charts like the following one:

![image](https://user-images.githubusercontent.com/5832149/141475486-53625361-10d3-4a79-90d9-9a4e8383a6a3.png)



The bellow steps easily explain how to test it: 

### 1 Testing with Docker

```bash
docker run -p 6379:6379 \
       redis
```

### 2. Set Up YCSB

Clone the YCSB git repository and compile:

    git clone git://github.com/brianfrankcooper/YCSB.git
    cd YCSB
    mvn -pl site.ycsb:redis-binding -am clean package

### 3. Run YCSB

Now you are ready to run!:
```
./bin/ycsb load redis -s -P workloads/workloada \
        -p hdrhistogram.percentiles.export=true \
        -p recordcount=10000000 -p redis.host=localhost -p redis.port=6379 -p threadcount=8
```

You should then see a log of interest:
```
[INFO] Finished exporting the full latency spectrum in percentile output format for INSERT into file INSERT-percentiles.txt.
```

and an `INSERT-percentiles.txt` file that you can then use to produce the image as follow using ( hdr-plot ):
```
hdr-plot --colors red INSERT-percentiles.txt --max-percentile 0.9999 --latency-conversion-factor 0.001 --labels [INSERT] --title "Latency by percentile distribution for [INSERT] operation local standalone Redis"
```