### PR TITLE
Introduce a new operation (search), and a new workload (ecommerce)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # ignore compiled byte code
 target
 
+# percentile output format
+*.txt
+
 # ignore output files from testing
 output*
 

--- a/accumulo1.9/pom.xml
+++ b/accumulo1.9/pom.xml
@@ -78,6 +78,11 @@ LICENSE file.
       <artifactId>slf4j-api</artifactId>
       <version>1.7.13</version>
     </dependency>
+      <dependency>
+          <groupId>org.javatuples</groupId>
+          <artifactId>javatuples</artifactId>
+          <version>1.2</version>
+      </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
+++ b/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
@@ -21,13 +21,8 @@ package site.ycsb.db.accumulo;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
@@ -58,6 +53,9 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
+import org.javatuples.Pair;
 
 /**
  * <a href="https://accumulo.apache.org/">Accumulo</a> binding for YCSB.
@@ -337,6 +335,23 @@ public class AccumuloClient extends DB {
     }
 
     return Status.OK;
+  }
+
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+      return Status.NOT_IMPLEMENTED;
   }
 
   // These functions are adapted from RowOperations.java:

--- a/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
+++ b/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
@@ -55,7 +55,6 @@ import site.ycsb.DBException;
 import site.ycsb.Status;
 import org.javatuples.Pair;
 
-import org.javatuples.Pair;
 
 /**
  * <a href="https://accumulo.apache.org/">Accumulo</a> binding for YCSB.

--- a/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
+++ b/accumulo1.9/src/main/java/site/ycsb/db/accumulo/AccumuloClient.java
@@ -349,8 +349,10 @@ public class AccumuloClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
-      return Status.NOT_IMPLEMENTED;
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   // These functions are adapted from RowOperations.java:

--- a/aerospike/src/main/java/site/ycsb/db/AerospikeClient.java
+++ b/aerospike/src/main/java/site/ycsb/db/AerospikeClient.java
@@ -29,12 +29,10 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+
+import java.util.*;
 
 /**
  * YCSB binding for <a href="http://www.aerospike.com/">Areospike</a>.
@@ -179,5 +177,21 @@ public class AerospikeClient extends site.ycsb.DB {
       System.err.println("Error while deleting key " + key + ": " + e);
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/aerospike/src/main/java/site/ycsb/db/AerospikeClient.java
+++ b/aerospike/src/main/java/site/ycsb/db/AerospikeClient.java
@@ -191,7 +191,9 @@ public class AerospikeClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/arangodb/src/main/java/site/ycsb/db/arangodb/ArangoDBClient.java
+++ b/arangodb/src/main/java/site/ycsb/db/arangodb/ArangoDBClient.java
@@ -17,12 +17,7 @@
 package site.ycsb.db.arangodb;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -44,6 +39,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 /**
@@ -338,6 +335,22 @@ public class ArangoDBClient extends DB {
       }
     }
     return Status.ERROR;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private String createDocumentHandle(String collection, String documentKey) throws ArangoDBException {

--- a/arangodb/src/main/java/site/ycsb/db/arangodb/ArangoDBClient.java
+++ b/arangodb/src/main/java/site/ycsb/db/arangodb/ArangoDBClient.java
@@ -349,7 +349,9 @@ public class ArangoDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/asynchbase/src/main/java/site/ycsb/db/AsyncHBaseClient.java
+++ b/asynchbase/src/main/java/site/ycsb/db/AsyncHBaseClient.java
@@ -394,7 +394,9 @@ public class AsyncHBaseClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/asynchbase/src/main/java/site/ycsb/db/AsyncHBaseClient.java
+++ b/asynchbase/src/main/java/site/ycsb/db/AsyncHBaseClient.java
@@ -18,13 +18,8 @@ package site.ycsb.db;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.Vector;
 
 import org.hbase.async.Bytes;
 import org.hbase.async.Config;
@@ -39,6 +34,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY_DEFAULT;
@@ -383,6 +380,22 @@ public class AsyncHBaseClient extends site.ycsb.DB {
       client.delete(delete);
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   /**

--- a/asynchbase/src/test/java/site/ycsb/db/AsyncHBaseTest.java
+++ b/asynchbase/src/test/java/site/ycsb/db/AsyncHBaseTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assume.assumeTrue;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
+++ b/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
@@ -507,7 +507,9 @@ public class AzureCosmosClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
+++ b/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
@@ -17,14 +17,8 @@
 package site.ycsb.db;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -56,6 +50,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 /**
@@ -497,6 +493,22 @@ public class AzureCosmosClient extends DB {
       LOGGER.error("Failed to delete key {} in collection {}", key, table, e);
     }
     return Status.ERROR;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private String createSelectTop(Set<String> fields, int top) {

--- a/azuretablestorage/src/main/java/site/ycsb/db/azuretablestorage/AzureClient.java
+++ b/azuretablestorage/src/main/java/site/ycsb/db/azuretablestorage/AzureClient.java
@@ -32,14 +32,11 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
 
 
 /**
@@ -258,6 +255,22 @@ public class AzureClient extends DB {
       }
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
   
   private Status insertOrUpdate(String key, Map<String, ByteIterator> values) {

--- a/azuretablestorage/src/main/java/site/ycsb/db/azuretablestorage/AzureClient.java
+++ b/azuretablestorage/src/main/java/site/ycsb/db/azuretablestorage/AzureClient.java
@@ -269,7 +269,9 @@ public class AzureClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
   

--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -44,6 +44,8 @@ dynamodb:site.ycsb.db.DynamoDBClient
 elasticsearch:site.ycsb.db.ElasticsearchClient
 elasticsearch5:site.ycsb.db.elasticsearch5.ElasticsearchClient
 elasticsearch5-rest:site.ycsb.db.elasticsearch5.ElasticsearchRestClient
+elasticsearch7:site.ycsb.db.elasticsearch7.ElasticsearchClient
+elasticsearch7-rest:site.ycsb.db.elasticsearch7.ElasticsearchRestClient
 foundationdb:site.ycsb.db.foundationdb.FoundationDBClient
 geode:site.ycsb.db.GeodeClient
 googlebigtable:site.ycsb.db.GoogleBigtableClient
@@ -64,6 +66,8 @@ orientdb:site.ycsb.db.OrientDBClient
 postgrenosql:site.ycsb.postgrenosql.PostgreNoSQLDBClient
 rados:site.ycsb.db.RadosClient
 redis:site.ycsb.db.RedisClient
+redisearch:site.ycsb.db.RediSearchClient
+redisjson2:site.ycsb.db.RedisJSONClient
 rest:site.ycsb.webservice.rest.RestClient
 riak:site.ycsb.db.riak.RiakKVClient
 rocksdb:site.ycsb.db.rocksdb.RocksDBClient

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -70,6 +70,8 @@ DATABASES = {
     "elasticsearch": "site.ycsb.db.ElasticsearchClient",
     "elasticsearch5": "site.ycsb.db.elasticsearch5.ElasticsearchClient",
     "elasticsearch5-rest": "site.ycsb.db.elasticsearch5.ElasticsearchRestClient",
+    "elasticsearch7": "site.ycsb.db.elasticsearch7.ElasticsearchClient",
+    "elasticsearch7-rest": "site.ycsb.db.elasticsearch7.ElasticsearchRestClient",
     "foundationdb" : "site.ycsb.db.foundationdb.FoundationDBClient",
     "geode"        : "site.ycsb.db.GeodeClient",
     "googlebigtable"  : "site.ycsb.db.GoogleBigtableClient",
@@ -93,6 +95,8 @@ DATABASES = {
     "postgrenosql" : "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
     "rados"        : "site.ycsb.db.RadosClient",
     "redis"        : "site.ycsb.db.RedisClient",
+    "redisearch"   : "site.ycsb.db.RediSearchClient",
+    "redisjson2"   : "site.ycsb.db.RedisJSONClient",
     "rest"         : "site.ycsb.webservice.rest.RestClient",
     "riak"         : "site.ycsb.db.riak.RiakKVClient",
     "rocksdb"      : "site.ycsb.db.rocksdb.RocksDBClient",
@@ -196,6 +200,7 @@ def get_ycsb_home():
     dir = os.path.abspath(os.path.dirname(sys.argv[0]))
     while "LICENSE.txt" not in os.listdir(dir):
         dir = os.path.join(dir, os.path.pardir)
+    debug("YCSB home: " + os.path.abspath(dir))
     return os.path.abspath(dir)
 
 def is_distribution():
@@ -220,7 +225,7 @@ def get_classpath_from_maven(module):
         # the last module will be the datastore binding
         line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
         return line[0][len("classpath="):]
-    except subprocess.CalledProcessError, err:
+    except subprocess.CalledProcessError as err:
         error("Attempting to generate a classpath from Maven failed "
               "with return code '" + str(err.returncode) + "'. The output from "
               "Maven follows, try running "

--- a/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
+++ b/binding-parent/datastore-specific-descriptor/src/main/resources/assemblies/datastore-specific-assembly.xml
@@ -50,6 +50,7 @@ LICENSE file.
       <fileMode>0644</fileMode>
       <includes>
         <include>bindings.properties</include>
+        <include>uci_online_retail.csv</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
@@ -37,6 +37,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -634,6 +636,22 @@ public class CassandraCQLClient extends DB {
     }
 
     return Status.ERROR;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
@@ -650,7 +650,9 @@ public class CassandraCQLClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/cassandra/src/test/java/site/ycsb/db/CassandraCQLClientTest.java
+++ b/cassandra/src/test/java/site/ycsb/db/CassandraCQLClientTest.java
@@ -35,6 +35,8 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -37,16 +37,12 @@ import site.ycsb.Client;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.concurrent.TimeUnit;
@@ -388,6 +384,22 @@ public class CloudSpannerClient extends DB {
       return Status.ERROR;
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private static void decodeStruct(

--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -398,7 +398,9 @@ public class CloudSpannerClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,16 @@ LICENSE file.
       <artifactId>HdrHistogram</artifactId>
       <version>2.1.4</version>
     </dependency>
+    <dependency>
+        <groupId>com.github.javafaker</groupId>
+        <artifactId>javafaker</artifactId>
+        <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.javatuples</groupId>
+      <artifactId>javatuples</artifactId>
+      <version>1.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/site/ycsb/BasicDB.java
+++ b/core/src/main/java/site/ycsb/BasicDB.java
@@ -17,6 +17,8 @@
 
 package site.ycsb;
 
+import org.javatuples.Pair;
+
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.Map;
@@ -297,6 +299,16 @@ public class BasicDB extends DB {
       }
     }
   }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.OK;
+  }
+
   
   /**
    * Increments the count on the hash in the map.

--- a/core/src/main/java/site/ycsb/BasicTSDB.java
+++ b/core/src/main/java/site/ycsb/BasicTSDB.java
@@ -16,13 +16,10 @@
  */
 package site.ycsb;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
 
+import org.javatuples.Pair;
 import site.ycsb.workloads.TimeSeriesWorkload;
 
 /**
@@ -220,6 +217,15 @@ public class BasicTSDB extends BasicDB {
       }
     }
 
+    return Status.OK;
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.OK;
   }
 

--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -311,19 +311,6 @@ public final class Client {
     final List<ClientThread> clients = initDb(dbname, props, threadcount, targetperthreadperms,
         workload, tracer, completeLatch);
 
-    if (status) {
-      boolean standardstatus = false;
-      if (props.getProperty(Measurements.MEASUREMENT_TYPE_PROPERTY, "").compareTo("timeseries") == 0) {
-        standardstatus = true;
-      }
-      int statusIntervalSeconds = Integer.parseInt(props.getProperty("status.interval", "10"));
-      boolean trackJVMStats = props.getProperty(Measurements.MEASUREMENT_TRACK_JVM_PROPERTY,
-          Measurements.MEASUREMENT_TRACK_JVM_PROPERTY_DEFAULT).equals("true");
-      statusthread = new StatusThread(completeLatch, clients, label, standardstatus, statusIntervalSeconds,
-          trackJVMStats);
-      statusthread.start();
-    }
-
     Thread terminator = null;
     long st;
     long en;
@@ -336,8 +323,6 @@ public final class Client {
         threads.put(new Thread(tracer.wrap(client, "ClientThread")), client);
       }
 
-      st = System.currentTimeMillis();
-
       for (Thread t : threads.keySet()) {
         t.start();
       }
@@ -347,7 +332,22 @@ public final class Client {
         terminator.start();
       }
 
+
+      if (status) {
+        boolean standardstatus = false;
+        if (props.getProperty(Measurements.MEASUREMENT_TYPE_PROPERTY, "").compareTo("timeseries") == 0) {
+          standardstatus = true;
+        }
+        int statusIntervalSeconds = Integer.parseInt(props.getProperty("status.interval", "10"));
+        boolean trackJVMStats = props.getProperty(Measurements.MEASUREMENT_TRACK_JVM_PROPERTY,
+            Measurements.MEASUREMENT_TRACK_JVM_PROPERTY_DEFAULT).equals("true");
+        statusthread = new StatusThread(completeLatch, clients, label, standardstatus, statusIntervalSeconds,
+            trackJVMStats);
+        statusthread.start();
+      }
+
       opsDone = 0;
+      st = System.currentTimeMillis();
 
       for (Map.Entry<Thread, ClientThread> entry : threads.entrySet()) {
         try {

--- a/core/src/main/java/site/ycsb/DB.java
+++ b/core/src/main/java/site/ycsb/DB.java
@@ -17,11 +17,9 @@
 
 package site.ycsb;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import org.javatuples.Pair;
+
+import java.util.*;
 
 /**
  * A layer for accessing a database to be benchmarked. Each thread in the client
@@ -29,17 +27,17 @@ import java.util.Vector;
  * This class should be constructed using a no-argument constructor, so we can
  * load it dynamically. Any argument-based initialization should be
  * done by init().
- *
+ * <p>
  * Note that YCSB does not make any use of the return codes returned by this class.
  * Instead, it keeps a count of the return values and presents them to the user.
- *
+ * <p>
  * The semantics of methods such as insert, update and delete vary from database
  * to database.  In particular, operations may or may not be durable once these
  * methods commit, and some systems may return 'success' regardless of whether
  * or not a tuple with a matching key existed before the call.  Rather than dictate
  * the exact semantics of these methods, we recommend you either implement them
- * to match the database's default semantics, or the semantics of your 
- * target application.  For the sake of comparison between experiments we also 
+ * to match the database's default semantics, or the semantics of your
+ * target application.  For the sake of comparison between experiments we also
  * recommend you explain the semantics you chose when presenting performance results.
  */
 public abstract class DB {
@@ -49,18 +47,18 @@ public abstract class DB {
   private Properties properties = new Properties();
 
   /**
+   * Get the set of properties for this DB.
+   */
+  public Properties getProperties() {
+    return properties;
+  }
+
+  /**
    * Set the properties for this DB.
    */
   public void setProperties(Properties p) {
     properties = p;
 
-  }
-
-  /**
-   * Get the set of properties for this DB.
-   */
-  public Properties getProperties() {
-    return properties;
   }
 
   /**
@@ -80,8 +78,8 @@ public abstract class DB {
   /**
    * Read a record from the database. Each field/value pair from the result will be stored in a HashMap.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to read.
+   * @param table  The name of the table
+   * @param key    The record key of the record to read.
    * @param fields The list of fields to read, or null for all of them
    * @param result A HashMap of field/value pairs for the result
    * @return The result of the operation.
@@ -92,11 +90,11 @@ public abstract class DB {
    * Perform a range scan for a set of records in the database. Each field/value pair from the result will be stored
    * in a HashMap.
    *
-   * @param table The name of the table
-   * @param startkey The record key of the first record to read.
+   * @param table       The name of the table
+   * @param startkey    The record key of the first record to read.
    * @param recordcount The number of records to read
-   * @param fields The list of fields to read, or null for all of them
-   * @param result A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
+   * @param fields      The list of fields to read, or null for all of them
+   * @param result      A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
    * @return The result of the operation.
    */
   public abstract Status scan(String table, String startkey, int recordcount, Set<String> fields,
@@ -106,8 +104,8 @@ public abstract class DB {
    * Update a record in the database. Any field/value pairs in the specified values HashMap will be written into the
    * record with the specified record key, overwriting any existing values with the same field name.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to write.
+   * @param table  The name of the table
+   * @param key    The record key of the record to write.
    * @param values A HashMap of field/value pairs to update in the record
    * @return The result of the operation.
    */
@@ -117,8 +115,8 @@ public abstract class DB {
    * Insert a record in the database. Any field/value pairs in the specified values HashMap will be written into the
    * record with the specified record key.
    *
-   * @param table The name of the table
-   * @param key The record key of the record to insert.
+   * @param table  The name of the table
+   * @param key    The record key of the record to insert.
    * @param values A HashMap of field/value pairs to insert in the record
    * @return The result of the operation.
    */
@@ -128,8 +126,15 @@ public abstract class DB {
    * Delete a record from the database.
    *
    * @param table The name of the table
-   * @param key The record key of the record to delete.
+   * @param key   The record key of the record to delete.
    * @return The result of the operation.
    */
   public abstract Status delete(String table, String key);
+
+  public abstract Status search(String table,
+                                Pair<String, String> queryPair, boolean onlyinsale,
+                                Pair<Integer, Integer> pagePair,
+                                HashSet<String> fields,
+                                Vector<HashMap<String, ByteIterator>> hashMaps);
+
 }

--- a/core/src/main/java/site/ycsb/DB.java
+++ b/core/src/main/java/site/ycsb/DB.java
@@ -131,6 +131,17 @@ public abstract class DB {
    */
   public abstract Status delete(String table, String key);
 
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
   public abstract Status search(String table,
                                 Pair<String, String> queryPair, boolean onlyinsale,
                                 Pair<Integer, Integer> pagePair,

--- a/core/src/main/java/site/ycsb/GoodBadUglyDB.java
+++ b/core/src/main/java/site/ycsb/GoodBadUglyDB.java
@@ -17,11 +17,9 @@
 
 package site.ycsb;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
-import java.util.Vector;
+import org.javatuples.Pair;
+
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
@@ -84,6 +82,14 @@ public class GoodBadUglyDB extends DB {
     for (String delay : getProperties().getProperty(SIMULATE_DELAY, SIMULATE_DELAY_DEFAULT).split(",")) {
       delays[i++] = Long.parseLong(delay);
     }
+  }
+
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.OK;
   }
 
   /**

--- a/core/src/main/java/site/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/site/ycsb/measurements/Measurements.java
@@ -18,6 +18,8 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 
 import java.io.IOException;

--- a/core/src/main/java/site/ycsb/measurements/Measurements.java
+++ b/core/src/main/java/site/ycsb/measurements/Measurements.java
@@ -18,7 +18,6 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 

--- a/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
@@ -18,6 +18,8 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 
 import java.io.IOException;

--- a/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
+++ b/core/src/main/java/site/ycsb/measurements/OneMeasurement.java
@@ -18,7 +18,6 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 

--- a/core/src/main/java/site/ycsb/measurements/TwoInOneMeasurement.java
+++ b/core/src/main/java/site/ycsb/measurements/TwoInOneMeasurement.java
@@ -18,6 +18,8 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 
 import java.io.IOException;

--- a/core/src/main/java/site/ycsb/measurements/TwoInOneMeasurement.java
+++ b/core/src/main/java/site/ycsb/measurements/TwoInOneMeasurement.java
@@ -18,7 +18,6 @@
 package site.ycsb.measurements;
 
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 import site.ycsb.measurements.exporter.MeasurementsExporter;
 

--- a/core/src/main/java/site/ycsb/workloads/CommerceWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CommerceWorkload.java
@@ -1,0 +1,521 @@
+package site.ycsb.workloads;
+
+import com.github.javafaker.Faker;
+import org.javatuples.Pair;
+import site.ycsb.*;
+import site.ycsb.generator.*;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ *
+ */
+public class CommerceWorkload extends CoreWorkload {
+  /**
+   * The name of the database table to run queries against.
+   */
+  public static final String TABLENAME_PROPERTY = "table";
+
+  /**
+   * The default name of the database table to run queries against.
+   */
+  public static final String TABLENAME_PROPERTY_DEFAULT = "products";
+
+  /**
+   * The name of the property for the min search length (number of records).
+   */
+  public static final String MIN_SEARCH_LENGTH_PROPERTY = "minsearchlength";
+
+  public static final String INDEXED_FIELDS_SEARCH_PROPERTY = "indexedfields";
+  public static final String INDEXED_FIELDS_SEARCH_PROPERTY_DEFAULT =
+      "productName";
+
+  public static final String SEARCH_WORDS_DICT_PROPERTY = "dictfile";
+  public static final String SEARCH_WORDS_DICT_DEFAULT =
+      "uci_online_retail.txt";
+
+  public static final String NON_INDEXED_FIELDS_SEARCH_PROPERTY = "nonindexedfields";
+  public static final String NON_INDEXED_FIELDS_SEARCH_PROPERTY_DEFAULT =
+      "nonindexedfields=productScore,code,image,price,currencyCode,stockCount,creator,shipsFrom";
+
+
+  public static final String SEARCH_FIELDS_PROPORTION_PROPERTY = "searchfieldsproportion";
+  public static final String SEARCH_FIELDS_PROPORTION_PROPERTY_DEFAULT = "0.70,0.10,0.05,0.05,0.05,0.05";
+
+  public static final String SEARCH_FIELDS_PROPERTY = "searchfields";
+  public static final String SEARCH_FIELDS_PROPERTY_DEFAULT = "department,brand,productName,color,inStock";
+
+
+  /**
+   * The default min search length.
+   */
+  public static final String MIN_SEARCH_LENGTH_PROPERTY_DEFAULT = "5";
+  /**
+   * The name of the property for the max search length (number of records).
+   */
+  public static final String MAX_SEARCH_LENGTH_PROPERTY = "maxsearchlength";
+  /**
+   * The default max search length.
+   */
+  public static final String MAX_SEARCH_LENGTH_PROPERTY_DEFAULT = "50";
+  /**
+   * The name of the property for the search length distribution. Options are "uniform" and "zipfian"
+   * (favoring short pages)
+   */
+  public static final String SEARCH_LENGTH_DISTRIBUTION_PROPERTY = "searchlengthdistribution";
+
+  public static final String SEARCH_LENGTH_DISTRIBUTION_PROPERTY_DEFAULT = "zipfian";
+  private static final String SEARCH_PROPORTION_PROPERTY = "searchproportion";
+  private static final String SEARCH_PROPORTION_PROPERTY_DEFAULT = "0.6";
+  protected NumberGenerator searchlength;
+  private String[] indexedFields;
+  private ArrayList<Double> indexedFieldsProportionPDF;
+  private ArrayList<String> searchDict;
+  private int ingestDictPos;
+  private Faker faker;
+  private Random rand;
+
+  public static String buildKeyName(long keynum, int zeropadding, boolean orderedinserts) {
+//    if (!orderedinserts) {
+//      keynum = Utils.hash(keynum);
+//    }
+    String value = Long.toString(keynum);
+    int fill = zeropadding - value.length();
+    String prekey = "product";
+    for (int i = 0; i < fill; i++) {
+      prekey += '0';
+    }
+    return prekey + value;
+  }
+
+
+  /**
+   * Creates a weighted discrete values with database operations for a workload to perform.
+   * Weights/proportions are read from the properties list and defaults are used
+   * when values are not configured.
+   * Current operations are "READ", "UPDATE", "INSERT", "SCAN" and "READMODIFYWRITE".
+   *
+   * @param p The properties list to pull weights from.
+   * @return A generator that can be used to determine the next operation to perform.
+   * @throws IllegalArgumentException if the properties object was null.
+   */
+  protected static DiscreteGenerator createOperationGenerator(final Properties p) {
+    if (p == null) {
+      throw new IllegalArgumentException("Properties object cannot be null");
+    }
+    final double readproportion = Double.parseDouble(
+        p.getProperty(READ_PROPORTION_PROPERTY, READ_PROPORTION_PROPERTY_DEFAULT));
+    final double updateproportion = Double.parseDouble(
+        p.getProperty(UPDATE_PROPORTION_PROPERTY, UPDATE_PROPORTION_PROPERTY_DEFAULT));
+    final double insertproportion = Double.parseDouble(
+        p.getProperty(INSERT_PROPORTION_PROPERTY, INSERT_PROPORTION_PROPERTY_DEFAULT));
+    final double searchproportion = Double.parseDouble(
+        p.getProperty(SEARCH_PROPORTION_PROPERTY, SEARCH_PROPORTION_PROPERTY_DEFAULT));
+
+    final DiscreteGenerator operationchooser = new DiscreteGenerator();
+    if (readproportion > 0) {
+      operationchooser.addValue(readproportion, "READ");
+    }
+
+    if (updateproportion > 0) {
+      operationchooser.addValue(updateproportion, "UPDATE");
+    }
+
+    if (insertproportion > 0) {
+      operationchooser.addValue(insertproportion, "INSERT");
+    }
+
+    if (searchproportion > 0) {
+      operationchooser.addValue(searchproportion, "SEARCH");
+    }
+
+    return operationchooser;
+  }
+
+
+  /**
+   * Initialize the scenario.
+   * Called once, in the main client thread, before any operations are started.
+   */
+  @Override
+  public void init(Properties p) throws WorkloadException {
+    ingestDictPos = 0;
+    rand = new Random(12345);
+    faker = new Faker(new Locale("en"), rand);
+    table = p.getProperty(TABLENAME_PROPERTY, TABLENAME_PROPERTY_DEFAULT);
+
+    recordcount =
+        Long.parseLong(p.getProperty(Client.RECORD_COUNT_PROPERTY, Client.DEFAULT_RECORD_COUNT));
+    if (recordcount == 0) {
+      recordcount = Integer.MAX_VALUE;
+    }
+    String requestdistrib =
+        p.getProperty(REQUEST_DISTRIBUTION_PROPERTY, REQUEST_DISTRIBUTION_PROPERTY_DEFAULT);
+
+    long insertstart =
+        Long.parseLong(p.getProperty(INSERT_START_PROPERTY, INSERT_START_PROPERTY_DEFAULT));
+    long insertcount =
+        Integer.parseInt(p.getProperty(INSERT_COUNT_PROPERTY, String.valueOf(recordcount - insertstart)));
+    // Confirm valid values for insertstart and insertcount in relation to recordcount
+    if (recordcount < (insertstart + insertcount)) {
+      System.err.println("Invalid combination of insertstart, insertcount and recordcount.");
+      System.err.println("recordcount must be bigger than insertstart + insertcount.");
+      System.exit(-1);
+    }
+    zeropadding =
+        Integer.parseInt(p.getProperty(ZERO_PADDING_PROPERTY, ZERO_PADDING_PROPERTY_DEFAULT));
+
+    orderedinserts = p.getProperty(INSERT_ORDER_PROPERTY, INSERT_ORDER_PROPERTY_DEFAULT).compareTo("hashed") != 0;
+
+    keysequence = new CounterGenerator(insertstart);
+    operationchooser = createOperationGenerator(p);
+
+    transactioninsertkeysequence = new AcknowledgedCounterGenerator(recordcount);
+    if (requestdistrib.compareTo("uniform") == 0) {
+      keychooser = new UniformLongGenerator(insertstart, insertstart + insertcount - 1);
+    } else if (requestdistrib.compareTo("exponential") == 0) {
+      double percentile = Double.parseDouble(p.getProperty(
+          ExponentialGenerator.EXPONENTIAL_PERCENTILE_PROPERTY,
+          ExponentialGenerator.EXPONENTIAL_PERCENTILE_DEFAULT));
+      double frac = Double.parseDouble(p.getProperty(
+          ExponentialGenerator.EXPONENTIAL_FRAC_PROPERTY,
+          ExponentialGenerator.EXPONENTIAL_FRAC_DEFAULT));
+      keychooser = new ExponentialGenerator(percentile, recordcount * frac);
+    } else if (requestdistrib.compareTo("sequential") == 0) {
+      keychooser = new SequentialGenerator(insertstart, insertstart + insertcount - 1);
+    } else if (requestdistrib.compareTo("zipfian") == 0) {
+      // it does this by generating a random "next key" in part by taking the modulus over the
+      // number of keys.
+      // If the number of keys changes, this would shift the modulus, and we don't want that to
+      // change which keys are popular so we'll actually construct the scrambled zipfian generator
+      // with a keyspace that is larger than exists at the beginning of the test. that is, we'll predict
+      // the number of inserts, and tell the scrambled zipfian generator the number of existing keys
+      // plus the number of predicted keys as the total keyspace. then, if the generator picks a key
+      // that hasn't been inserted yet, will just ignore it and pick another key. this way, the size of
+      // the keyspace doesn't change from the perspective of the scrambled zipfian generator
+      final double insertproportion = Double.parseDouble(
+          p.getProperty(INSERT_PROPORTION_PROPERTY, INSERT_PROPORTION_PROPERTY_DEFAULT));
+      int opcount = Integer.parseInt(p.getProperty(Client.OPERATION_COUNT_PROPERTY));
+      int expectednewkeys = (int) ((opcount) * insertproportion * 2.0); // 2 is fudge factor
+
+      keychooser = new ScrambledZipfianGenerator(insertstart, insertstart + insertcount + expectednewkeys);
+    } else if (requestdistrib.compareTo("latest") == 0) {
+      keychooser = new SkewedLatestGenerator(transactioninsertkeysequence);
+    } else if (requestdistrib.equals("hotspot")) {
+      double hotsetfraction =
+          Double.parseDouble(p.getProperty(HOTSPOT_DATA_FRACTION, HOTSPOT_DATA_FRACTION_DEFAULT));
+      double hotopnfraction =
+          Double.parseDouble(p.getProperty(HOTSPOT_OPN_FRACTION, HOTSPOT_OPN_FRACTION_DEFAULT));
+      keychooser = new HotspotIntegerGenerator(insertstart, insertstart + insertcount - 1,
+          hotsetfraction, hotopnfraction);
+    } else {
+      throw new WorkloadException("Unknown request distribution \"" + requestdistrib + "\"");
+    }
+
+    insertionRetryLimit = Integer.parseInt(p.getProperty(
+        INSERTION_RETRY_LIMIT, INSERTION_RETRY_LIMIT_DEFAULT));
+    insertionRetryInterval = Integer.parseInt(p.getProperty(
+        INSERTION_RETRY_INTERVAL, INSERTION_RETRY_INTERVAL_DEFAULT));
+
+    int minsearchlength =
+        Integer.parseInt(p.getProperty(MIN_SEARCH_LENGTH_PROPERTY, MIN_SEARCH_LENGTH_PROPERTY_DEFAULT));
+    int maxsearchlength =
+        Integer.parseInt(p.getProperty(MAX_SEARCH_LENGTH_PROPERTY, MAX_SEARCH_LENGTH_PROPERTY_DEFAULT));
+    String searchlengthdistrib =
+        p.getProperty(SEARCH_LENGTH_DISTRIBUTION_PROPERTY, SEARCH_LENGTH_DISTRIBUTION_PROPERTY_DEFAULT);
+
+    if (searchlengthdistrib.compareTo("uniform") == 0) {
+      searchlength = new UniformLongGenerator(minsearchlength, maxsearchlength);
+    } else if (searchlengthdistrib.compareTo("zipfian") == 0) {
+      searchlength = new ZipfianGenerator(minsearchlength, maxsearchlength);
+    } else {
+      throw new WorkloadException(
+          "Distribution \"" + searchlengthdistrib + "\" not allowed for search length");
+    }
+
+    indexedFields = p.getProperty(SEARCH_FIELDS_PROPERTY,
+        SEARCH_FIELDS_PROPERTY_DEFAULT).split(",");
+    String[] indexedFieldsProportionStr = p.getProperty(SEARCH_FIELDS_PROPORTION_PROPERTY,
+        SEARCH_FIELDS_PROPORTION_PROPERTY_DEFAULT).split(",");
+    indexedFieldsProportionPDF = new ArrayList<Double>();
+    double currentPDF = 0.0;
+    for (String indexedFieldProportion : indexedFieldsProportionStr) {
+      currentPDF += Double.parseDouble(indexedFieldProportion);
+      indexedFieldsProportionPDF.add(currentPDF);
+    }
+
+    BufferedReader reader;
+    String filename = p.getProperty(SEARCH_WORDS_DICT_PROPERTY,
+        SEARCH_WORDS_DICT_DEFAULT);
+    System.err.println("Loading search dictionary from: " + filename);
+    searchDict = new ArrayList<String>();
+    try {
+
+      reader = new BufferedReader(new FileReader(
+          filename));
+      String line = reader.readLine();
+      while (line != null) {
+        line = reader.readLine();
+        if (line != null){
+          line = line.replaceAll("[^\\p{L} \\p{Nd}]+", "");
+          searchDict.add(line);
+          if(searchDict.size()%100000==0){
+            System.err.println("Read " + searchDict.size());
+          }
+        }
+      }
+      reader.close();
+      System.err.println("using a dictionary of " + searchDict.size() + " to generate productName and search terms");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+  }
+
+  /**
+   * Do one insert operation. Because it will be called concurrently from multiple client threads, this
+   * function must be thread safe. However, avoid synchronized, or the threads will block waiting for each
+   * other, and it will be difficult to reach the target throughput. Ideally, this function would have no side
+   * effects other than DB operations and mutations on threadstate. Mutations to threadstate do not need to be
+   * synchronized, since each thread has its own threadstate instance.
+   *
+   * @param db
+   * @param threadstate
+   */
+  @Override
+  public boolean doInsert(DB db, Object threadstate) {
+    int keynum = keysequence.nextValue().intValue();
+    String dbkey = buildKeyName(keynum, zeropadding, orderedinserts);
+    HashMap<String, ByteIterator> values = buildValues(dbkey);
+
+    Status status;
+    int numOfRetries = 0;
+    do {
+      status = db.insert(table, dbkey, values);
+      if (null != status && status.isOk()) {
+        break;
+      }
+      // Retry if configured. Without retrying, the load process will fail
+      // even if one single insertion fails. User can optionally configure
+      // an insertion retry limit (default is 0) to enable retry.
+      if (++numOfRetries <= insertionRetryLimit) {
+        System.err.println("Retrying insertion, retry count: " + numOfRetries);
+        try {
+          // Sleep for a random number between [0.8, 1.2)*insertionRetryInterval.
+          int sleepTime = (int) (1000 * insertionRetryInterval * (0.8 + 0.4 * Math.random()));
+          Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+          break;
+        }
+
+      } else {
+        System.err.println("Error inserting, not retrying any more. number of attempts: " + numOfRetries +
+            "Insertion Retry Limit: " + insertionRetryLimit);
+        break;
+
+      }
+    } while (true);
+
+    return null != status && status.isOk();
+  }
+
+  public boolean doTransaction(DB db, Object threadstate) {
+    String operation = operationchooser.nextString();
+    if (operation == null) {
+      return false;
+    }
+    switch (operation) {
+    case "READ":
+      doTransactionRead(db);
+      break;
+    case "UPDATE":
+      doTransactionUpdate(db);
+      break;
+    case "INSERT":
+      doTransactionInsert(db);
+      break;
+    case "SEARCH":
+      doTransactionSearch(db);
+      break;
+    default:
+      return false;
+    }
+
+    return true;
+  }
+
+
+  long nextKeynum() {
+    long keynum;
+    if (keychooser instanceof ExponentialGenerator) {
+      do {
+        keynum = transactioninsertkeysequence.lastValue() - keychooser.nextValue().intValue();
+      } while (keynum < 0);
+    } else {
+      do {
+        keynum = keychooser.nextValue().intValue();
+      } while (keynum > transactioninsertkeysequence.lastValue());
+    }
+    return keynum;
+  }
+
+  public void doTransactionRead(DB db) {
+    // choose a random key
+    long keynum = nextKeynum();
+    String keyname = buildKeyName(keynum, zeropadding, orderedinserts);
+    HashSet<String> fields = null;
+
+    HashMap<String, ByteIterator> cells = new HashMap<String, ByteIterator>();
+    db.read(table, keyname, fields, cells);
+  }
+
+  public void doTransactionUpdate(DB db) {
+    // choose a random key
+    long keynum = nextKeynum();
+    String keyname = buildKeyName(keynum, zeropadding, orderedinserts);
+
+    HashMap<String, ByteIterator> values;
+
+    if (writeallfields) {
+      // new data for all the fields
+      values = buildValues(keyname);
+    } else {
+      // update a random field
+      values = buildSingleValue(keyname);
+    }
+
+    db.update(table, keyname, values);
+  }
+
+  public void doTransactionInsert(DB db) {
+    // choose the next key
+    long keynum = transactioninsertkeysequence.nextValue();
+
+    try {
+      String keyname = buildKeyName(keynum, zeropadding, orderedinserts);
+
+      HashMap<String, ByteIterator> values = buildValues(keyname);
+      db.insert(table, keyname, values);
+    } finally {
+      transactioninsertkeysequence.acknowledge(keynum);
+    }
+  }
+
+
+  public void doTransactionSearch(DB db) {
+    // choose a random search length
+    int len = searchlength.nextValue().intValue();
+    int replystartpos = 0;
+
+    HashSet<String> fields = null;
+    String fieldName = randomIndexedFieldName();
+    String textquerytosearch = "*";
+    textquerytosearch = getRandomFieldValue(fieldName, textquerytosearch);
+    boolean onlyinsale = ThreadLocalRandom.current()
+        .nextBoolean();
+    Pair<String, String> queryPair = Pair.with(fieldName, textquerytosearch);
+    Pair<Integer, Integer> pagePair = Pair.with(replystartpos, len);
+    Vector<HashMap<String, ByteIterator>> results = new Vector<HashMap<String, ByteIterator>>();
+    long st = System.nanoTime();
+    db.search(table, queryPair, onlyinsale, pagePair, fields, results);
+    long en = System.nanoTime();
+//    results.size()
+    measurements.measure("SEARCH", (int) ((en - st) / 1000));
+  }
+
+  private String randomIndexedFieldName() {
+    double rnd = ThreadLocalRandom.current()
+        .nextDouble();
+    String fieldName = indexedFields[0];
+    double fieldPDF = indexedFieldsProportionPDF.get(0);
+    for (int pos = 1; rnd < fieldPDF && pos < indexedFieldsProportionPDF.size(); pos++) {
+      fieldPDF = indexedFieldsProportionPDF.get(pos);
+      fieldName = indexedFields[pos];
+    }
+    return fieldName;
+  }
+
+  private String getRandomFieldValue(String fieldName, String textquerytosearch) {
+    switch (fieldName) {
+    case "brand":
+      textquerytosearch = faker.company().name().replaceAll("[^a-zA-Z0-9]", " ");
+      break;
+    case "color":
+      textquerytosearch = faker.color().name().replaceAll("[^a-zA-Z0-9]", " ");
+      break;
+    case "department":
+      textquerytosearch = faker.commerce().department().replaceAll("[^a-zA-Z0-9]", " ");
+      break;
+    case "productName":
+      textquerytosearch = searchDict.get(rand.nextInt(searchDict.size()));
+      while (textquerytosearch.split(" ").length < 2){
+        textquerytosearch = searchDict.get(rand.nextInt(searchDict.size()));
+      }
+      break;
+    case "productDescription":
+      textquerytosearch = faker.company().catchPhrase().split(" ")[0];
+      break;
+    default:
+      break;
+    }
+    return textquerytosearch;
+  }
+
+  /**
+   * Builds values for all fields.
+   */
+  protected HashMap<String, ByteIterator> buildValues(String key) {
+    if (ingestDictPos>=searchDict.size()){
+      ingestDictPos=0;
+    }
+    HashMap<String, ByteIterator> values = new HashMap<>();
+    String productName = searchDict.get(ingestDictPos);
+    values.put("productName", new StringByteIterator(productName));
+    values.put("productScore", new StringByteIterator(String.valueOf(1.0 - ThreadLocalRandom.current()
+        .nextDouble())));
+    values.put("code", new StringByteIterator(faker.code().ean13()));
+    values.put("productDescription", new StringByteIterator(faker.company().catchPhrase()));
+    values.put("department", new StringByteIterator(faker.commerce().department()
+        .replaceAll("[^a-zA-Z0-9]", " ")));
+    // 0 for out-of-stock
+    // 1 for in-stock
+    values.put("inStock", new StringByteIterator(String.valueOf(ThreadLocalRandom.current()
+        .nextInt(2))));
+    // 0 for standardPrice
+    // 1 for inSale
+    values.put("inSale", new StringByteIterator(String.valueOf(ThreadLocalRandom.current()
+        .nextInt(2))));
+    values.put("color", new StringByteIterator(faker.commerce().color().
+        replaceAll("[^a-zA-Z0-9]", " ")));
+    values.put("image", new StringByteIterator(faker.company().logo()));
+    values.put("material", new StringByteIterator(faker.commerce().material()
+        .replaceAll("[^a-zA-Z0-9]", " ")));
+    values.put("price", new StringByteIterator(faker.commerce().price()));
+    values.put("currencyCode", new StringByteIterator(faker.currency().code()));
+    values.put("brand", new StringByteIterator(faker.company().name()
+        .replaceAll("[^a-zA-Z0-9]", " ")));
+    values.put("stockCount", new StringByteIterator(String.valueOf(ThreadLocalRandom.current()
+        .nextInt(501))));
+    values.put("creator", new StringByteIterator(faker.artist().name()
+        .replaceAll("[^a-zA-Z0-9]", " ")));
+    values.put("shipsFrom", new StringByteIterator(faker.country().countryCode3()));
+    ingestDictPos++;
+    return values;
+  }
+
+  /**
+   * Builds a value for a randomly chosen indexed field.
+   */
+  private HashMap<String, ByteIterator> buildSingleValue(String key) {
+    HashMap<String, ByteIterator> value = new HashMap<>();
+    String fieldName = randomIndexedFieldName();
+    String fieldValue = getRandomFieldValue(fieldName, "");
+    value.put(fieldName, new StringByteIterator(fieldValue));
+    return value;
+  }
+
+}

--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -369,7 +369,7 @@ public class CoreWorkload extends Workload {
   protected int insertionRetryLimit;
   protected int insertionRetryInterval;
 
-  private Measurements measurements = Measurements.getMeasurements();
+  protected Measurements measurements = Measurements.getMeasurements();
 
   public static String buildKeyName(long keynum, int zeropadding, boolean orderedinserts) {
     if (!orderedinserts) {

--- a/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
@@ -33,7 +33,6 @@ import site.ycsb.Client;
 import site.ycsb.DB;
 import site.ycsb.NumericByteIterator;
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 import site.ycsb.StringByteIterator;
 import site.ycsb.Utils;

--- a/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/TimeSeriesWorkload.java
@@ -33,6 +33,8 @@ import site.ycsb.Client;
 import site.ycsb.DB;
 import site.ycsb.NumericByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.Utils;
 import site.ycsb.Workload;

--- a/core/src/test/java/site/ycsb/workloads/TestTimeSeriesWorkload.java
+++ b/core/src/test/java/site/ycsb/workloads/TestTimeSeriesWorkload.java
@@ -22,17 +22,10 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.Vector;
-
+import org.javatuples.Pair;
 import site.ycsb.ByteIterator;
 import site.ycsb.Client;
 import site.ycsb.DB;
@@ -46,7 +39,6 @@ import site.ycsb.measurements.Measurements;
 import org.testng.annotations.Test;
 
 public class TestTimeSeriesWorkload {
-  
   @Test
   public void twoThreads() throws Exception {
     final Properties p = getUTProperties();
@@ -518,7 +510,16 @@ public class TestTimeSeriesWorkload {
     final List<String> keys = new ArrayList<String>();
     final List<Map<String, ByteIterator>> values = 
         new ArrayList<Map<String, ByteIterator>>();
-    
+
+    @Override
+    public Status search(String table,
+                         Pair<String, String> queryPair, boolean onlyinsale,
+                         Pair<Integer, Integer> pagePair,
+                         HashSet<String> fields,
+                         Vector<HashMap<String, ByteIterator>> hashMaps) {
+      return Status.OK;
+    }
+
     @Override
     public Status read(String table, String key, Set<String> fields,
                        Map<String, ByteIterator> result) {

--- a/core/src/test/java/site/ycsb/workloads/TestTimeSeriesWorkload.java
+++ b/core/src/test/java/site/ycsb/workloads/TestTimeSeriesWorkload.java
@@ -31,6 +31,8 @@ import site.ycsb.Client;
 import site.ycsb.DB;
 import site.ycsb.NumericByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.Utils;
 import site.ycsb.WorkloadException;

--- a/couchbase/src/main/java/site/ycsb/db/CouchbaseClient.java
+++ b/couchbase/src/main/java/site/ycsb/db/CouchbaseClient.java
@@ -363,7 +363,9 @@ public class CouchbaseClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/couchbase/src/main/java/site/ycsb/db/CouchbaseClient.java
+++ b/couchbase/src/main/java/site/ycsb/db/CouchbaseClient.java
@@ -27,6 +27,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import net.spy.memcached.PersistTo;
@@ -39,13 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * A class that wraps the CouchbaseClient to allow it to be interfaced with YCSB.
@@ -353,5 +349,21 @@ public class CouchbaseClient extends DB {
       throw new RuntimeException("Could not encode JSON value");
     }
     return writer.toString();
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/couchbase2/src/main/java/site/ycsb/db/couchbase2/Couchbase2Client.java
+++ b/couchbase2/src/main/java/site/ycsb/db/couchbase2/Couchbase2Client.java
@@ -717,7 +717,9 @@ public class Couchbase2Client extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/couchbase2/src/main/java/site/ycsb/db/couchbase2/Couchbase2Client.java
+++ b/couchbase2/src/main/java/site/ycsb/db/couchbase2/Couchbase2Client.java
@@ -56,6 +56,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import rx.Observable;
 import rx.Subscriber;
@@ -701,6 +703,22 @@ public class Couchbase2Client extends DB {
       result.add(tuple);
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   /**

--- a/crail/src/main/java/site/ycsb/db/crail/CrailClient.java
+++ b/crail/src/main/java/site/ycsb/db/crail/CrailClient.java
@@ -17,11 +17,9 @@
 
 package site.ycsb.db.crail;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.Vector;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +36,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 /**
  * Crail binding for <a href="http://crail.apache.org/">Crail</a>.
@@ -171,5 +171,21 @@ public class CrailClient extends DB {
       return Status.ERROR;
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/crail/src/main/java/site/ycsb/db/crail/CrailClient.java
+++ b/crail/src/main/java/site/ycsb/db/crail/CrailClient.java
@@ -185,7 +185,9 @@ public class CrailClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/distribution/src/main/assembly/distribution.xml
+++ b/distribution/src/main/assembly/distribution.xml
@@ -36,6 +36,14 @@ LICENSE file.
     <fileSet>
       <directory>../bin</directory>
       <outputDirectory>bin</outputDirectory>
+      <fileMode>0644</fileMode>
+      <includes>
+        <include>uci_online_retail.csv</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>../bin</directory>
+      <outputDirectory>bin</outputDirectory>
       <fileMode>0755</fileMode>
       <includes>
         <include>ycsb*</include>

--- a/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
@@ -365,7 +365,9 @@ public class DynamoDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
+++ b/dynamodb/src/main/java/site/ycsb/db/DynamoDBClient.java
@@ -27,14 +27,12 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.model.*;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.javatuples.Pair;
 import site.ycsb.*;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.Vector;
 
 /**
  * DynamoDB client for YCSB.
@@ -353,5 +351,21 @@ public class DynamoDBClient extends DB {
       throw new RuntimeException("Assertion Error: impossible primary key type");
     }
     return k;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/elasticsearch/src/main/java/site/ycsb/db/ElasticsearchClient.java
+++ b/elasticsearch/src/main/java/site/ycsb/db/ElasticsearchClient.java
@@ -378,7 +378,9 @@ public class ElasticsearchClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/elasticsearch/src/main/java/site/ycsb/db/ElasticsearchClient.java
+++ b/elasticsearch/src/main/java/site/ycsb/db/ElasticsearchClient.java
@@ -26,6 +26,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -45,12 +47,8 @@ import org.elasticsearch.search.SearchHit;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
 
 /**
  * Elasticsearch client for YCSB framework.
@@ -366,5 +364,21 @@ public class ElasticsearchClient extends DB {
       e.printStackTrace();
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/elasticsearch/src/test/java/site/ycsb/db/ElasticsearchClientTest.java
+++ b/elasticsearch/src/test/java/site/ycsb/db/ElasticsearchClientTest.java
@@ -24,6 +24,8 @@ package site.ycsb.db;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 import org.junit.After;

--- a/elasticsearch5/src/main/java/site/ycsb/db/elasticsearch5/ElasticsearchClient.java
+++ b/elasticsearch5/src/main/java/site/ycsb/db/elasticsearch5/ElasticsearchClient.java
@@ -38,7 +38,8 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
-
+import java.util.*;
+import org.javatuples.Pair;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
@@ -328,6 +329,24 @@ public class ElasticsearchClient extends DB {
   private SearchResponse search(final String table, final String key) {
     refreshIfNeeded();
     return client.prepareSearch(indexKey).setTypes(table).setQuery(new TermQueryBuilder(KEY, key)).get();
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/elasticsearch5/src/main/java/site/ycsb/db/elasticsearch5/ElasticsearchRestClient.java
+++ b/elasticsearch5/src/main/java/site/ycsb/db/elasticsearch5/ElasticsearchRestClient.java
@@ -45,6 +45,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
+import java.util.*;
+import java.util.Map.Entry;
+import org.javatuples.Pair;
 
 import static site.ycsb.db.elasticsearch5.Elasticsearch5.KEY;
 import static site.ycsb.db.elasticsearch5.Elasticsearch5.parseIntegerProperty;
@@ -439,6 +442,24 @@ public class ElasticsearchRestClient extends DB {
       @SuppressWarnings("unchecked") final Map<String, Object> map = mapper.readValue(is, Map.class);
       return map;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/elasticsearch7/README.md
+++ b/elasticsearch7/README.md
@@ -1,0 +1,113 @@
+<!--
+Copyright (c) 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Elasticsearch 7.x running locally. 
+
+### 1. Install and Start Elasticsearch
+
+[Download and install Elasticsearch][1]. When starting Elasticsearch, you should
+[configure][2] the cluster name to be `es.ycsb.cluster` (see below).
+
+### 2. Set Up YCSB
+
+Clone the YCSB git repository and compile:
+
+    git clone git://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
+    mvn clean package
+
+### 3. Run YCSB
+    
+Now you are ready to run! First, load the data:
+
+    ./bin/ycsb load elasticsearch7 -s -P workloads/workloada
+
+Then, run the workload:
+
+    ./bin/ycsb run elasticsearch7 -s -P workloads/workloada
+
+The Elasticsearch 7 binding requires a standalone instance of Elasticsearch.
+You must specify a hosts list for the transport client to connect to via
+`-p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`:
+
+    ./bin/ycsb run elasticsearch5 -s -P workloads/workloada \
+    -p es.hosts.list=<hostname1:port1>,...,<hostnamen:portn>`
+
+Note that `es.hosts.list` defaults to `localhost:9300`. For further
+configuration see below:
+
+### Defaults Configuration
+The default setting for the Elasticsearch node that is created is as follows:
+
+    es.setting.cluster.name=es.ycsb.cluster
+    es.index.key=es.ycsb
+    es.number_of_shards=1
+    es.number_of_replicas=0
+    es.new_index=false
+    es.hosts.list=localhost:9300
+
+### Custom Configuration
+If you wish to customize the settings used to create the Elasticsearch node
+you can created a new property file that contains your desired Elasticsearch 
+node settings and pass it in via the parameter to 'bin/ycsb' script. Note that 
+the default properties will be kept if you don't explicitly overwrite them.
+
+Assuming that we have a properties file named "myproperties.data" that contains 
+custom Elasticsearch node configuration you can execute the following to
+pass it into the Elasticsearch client:
+
+    ./bin/ycsb run elasticsearch7 -P workloads/workloada -P myproperties.data -s
+
+If you wish to change the default index name you can set the following property:
+
+    es.index.key=my_index_key
+
+By default this will use localhost:9300 as a seed node to discover the cluster.
+You can also specify
+
+    es.hosts.list=(\w+:\d+)+
+
+(a comma-separated list of host/port pairs) to change this.
+
+### Configuring the transport client
+
+The `elasticsearch7` binding starts a transport client to connect to
+Elasticsearch using the transport protocol. You can pass arbitrary settings to
+this instance by using properties with the prefix `es.setting.` followed by any
+valid Elasticsearch setting. For example, assuming that you started your
+Elasticsearch node with the cluster name `my-elasticsearch-cluster`, you would
+need to configure the transport client to use the same cluster name via
+
+    ./bin/ycsb run elasticsearch7 -P <workload> \
+    -p es.setting.cluster.name=my-elasticsearch-cluster
+    
+### Using the Elasticsearch low-level REST client
+
+The Elasticsearch 7 bindings also ship with an implementation that uses the
+low-level Elasticsearch REST client. The name of this binding is
+`elasticsearch-rest`. For example:
+
+    ./bin/ycsb load elasticsearch7-rest -P workloads/workloada
+    
+You can configure the hosts to connect to via the same `es.hosts.list` property
+used to configure the transport client in the `elasticsearch7` binding (note
+that by default you should use port 9200)
+
+[1]: https://www.elastic.co/guide/en/elasticsearch/reference/7.2/install-elasticsearch.html
+[2]: https://www.elastic.co/guide/en/elasticsearch/reference/7.2/setup.html

--- a/elasticsearch7/pom.xml
+++ b/elasticsearch7/pom.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2017 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+
+  <properties>
+    <!-- Skip tests by default. will be activated by jdk8 profile -->
+    <skipTests>true</skipTests>
+    <elasticsearch.groupid>org.elasticsearch.distribution.zip</elasticsearch.groupid>
+
+    <!-- For integration tests using ANT -->
+    <integ.http.port>9400</integ.http.port>
+    <integ.transport.port>9500</integ.transport.port>
+
+    <!-- If tests are skipped, skip ES spin up -->
+    <es.skip>${skipTests}</es.skip>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>integ-setup-dependencies</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${elasticsearch.groupid}</groupId>
+                  <artifactId>elasticsearch</artifactId>
+                  <version>${elasticsearch7-version}</version>
+                  <type>zip</type>
+                </artifactItem>
+              </artifactItems>
+              <useBaseVersion>true</useBaseVersion>
+              <outputDirectory>${project.build.directory}/integration-tests/binaries</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.19</version>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.carrotsearch.randomizedtesting</groupId>
+        <artifactId>junit4-maven-plugin</artifactId>
+        <version>2.3.3</version>
+
+        <configuration>
+          <assertions enableSystemAssertions="false">
+            <enable/>
+          </assertions>
+
+          <listeners>
+            <report-text />
+          </listeners>
+        </configuration>
+
+        <executions>
+          <execution>
+            <id>unit-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>junit4</goal>
+            </goals>
+            <inherited>true</inherited>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*Test.class</include>
+              </includes>
+              <excludes>
+                <exclude>**/*$*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-tests</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>junit4</goal>
+            </goals>
+            <inherited>true</inherited>
+            <configuration>
+              <skipTests>${skipTests}</skipTests>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+              <excludes>
+                <exclude>**/*$*</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <artifactId>elasticsearch7-binding</artifactId>
+  <name>Elasticsearch 7.x Binding</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <!-- jna is supported in ES and will be used when provided
+           otherwise a fallback is used -->
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>jna</artifactId>
+      <version>4.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>transport</artifactId>
+      <version>${elasticsearch7-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>${elasticsearch7-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>2.4.0</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <!-- Requires JDK8 to run, so none of our tests
+         will work unless we're using jdk8.
+      -->
+    <profile>
+      <id>jdk8-tests</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.alexcojocaru</groupId>
+            <artifactId>elasticsearch-maven-plugin</artifactId>
+            <version>5.9</version>
+            <configuration>
+              <version>${elasticsearch7-version}</version>
+              <clusterName>test</clusterName>
+              <httpPort>9200</httpPort>
+              <transportPort>9300</transportPort>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-elasticsearch</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>runforked</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-elasticsearch</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/Elasticsearch7.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/Elasticsearch7.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import java.util.Properties;
+
+final class Elasticsearch7 {
+
+  static final String KEY = "key";
+
+  private Elasticsearch7() {
+
+  }
+
+  static int parseIntegerProperty(final Properties properties, final String key, final int defaultValue) {
+    final String value = properties.getProperty(key);
+    return value == null ? defaultValue : Integer.parseInt(value);
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchClient.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchClient.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.javatuples.Pair;
+import site.ycsb.*;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static org.elasticsearch.common.settings.Settings.Builder;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.KEY;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.parseIntegerProperty;
+
+/**
+ * Elasticsearch client for YCSB framework.
+ */
+public class ElasticsearchClient extends DB {
+
+  private static final String DEFAULT_CLUSTER_NAME = "es.ycsb.cluster";
+  private static final String DEFAULT_INDEX_KEY = "es.ycsb";
+  private static final String DEFAULT_REMOTE_HOST = "localhost:9300";
+  private static final int NUMBER_OF_SHARDS = 1;
+  private static final int NUMBER_OF_REPLICAS = 0;
+  private TransportClient client;
+  private String indexKey;
+  private volatile boolean isRefreshNeeded = false;
+
+  /**
+   * Initialize any state for this DB. Called once per DB instance; there is one
+   * DB instance per client thread.
+   */
+  @Override
+  public void init() throws DBException {
+    final Properties props = getProperties();
+
+    this.indexKey = props.getProperty("es.index.key", DEFAULT_INDEX_KEY);
+
+    final int numberOfShards = parseIntegerProperty(props, "es.number_of_shards", NUMBER_OF_SHARDS);
+    final int numberOfReplicas = parseIntegerProperty(props, "es.number_of_replicas", NUMBER_OF_REPLICAS);
+
+    final Boolean newIndex = Boolean.parseBoolean(props.getProperty("es.new_index", "false"));
+    final Builder settings = Settings.builder().put("cluster.name", DEFAULT_CLUSTER_NAME);
+
+    // if properties file contains elasticsearch user defined properties
+    // add it to the settings file (will overwrite the defaults).
+    for (final Entry<Object, Object> e : props.entrySet()) {
+      if (e.getKey() instanceof String) {
+        final String key = (String) e.getKey();
+        if (key.startsWith("es.setting.")) {
+          settings.put(key.substring("es.setting.".length()), (Boolean) e.getValue());
+        }
+      }
+    }
+
+    settings.put("client.transport.sniff", true)
+        .put("client.transport.ignore_cluster_name", false)
+        .put("client.transport.ping_timeout", "30s")
+        .put("client.transport.nodes_sampler_interval", "30s");
+    // Default it to localhost:9300
+    final String[] nodeList = props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST).split(",");
+    client = new PreBuiltTransportClient(settings.build());
+    for (String h : nodeList) {
+      String[] nodes = h.split(":");
+
+      final InetAddress address;
+      try {
+        address = InetAddress.getByName(nodes[0]);
+      } catch (UnknownHostException e) {
+        throw new IllegalArgumentException("unable to identity host [" + nodes[0] + "]", e);
+      }
+      final int port;
+      try {
+        port = Integer.parseInt(nodes[1]);
+      } catch (final NumberFormatException e) {
+        throw new IllegalArgumentException("unable to parse port [" + nodes[1] + "]", e);
+      }
+      client.addTransportAddress(new InetSocketTransportAddress(address, port));
+    }
+
+    final boolean exists =
+        client.admin().indices()
+            .exists(Requests.indicesExistsRequest(indexKey)).actionGet()
+            .isExists();
+    if (exists && newIndex) {
+      client.admin().indices().prepareDelete(indexKey).get();
+    }
+    if (!exists || newIndex) {
+      client.admin().indices().create(
+          new CreateIndexRequest(indexKey)
+              .settings(
+                  Settings.builder()
+                      .put("index.number_of_shards", numberOfShards)
+                      .put("index.number_of_replicas", numberOfReplicas)
+              )).actionGet();
+    }
+    client.admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet();
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+    if (client != null) {
+      client.close();
+      client = null;
+    }
+  }
+
+  @Override
+  public Status insert(String table, String key, Map<String, ByteIterator> values) {
+    try (XContentBuilder doc = jsonBuilder()) {
+
+      doc.startObject();
+      for (final Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        doc.field(entry.getKey(), entry.getValue());
+      }
+      doc.field(KEY, key);
+      doc.endObject();
+
+      final IndexResponse indexResponse = client.prepareIndex(indexKey, table).setSource(doc).get();
+      if (indexResponse.isCreated()) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(final String table, final String key) {
+    try {
+      final SearchResponse searchResponse = search(table, key);
+      if (searchResponse.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final String id = searchResponse.getHits().getAt(0).getId();
+
+      final DeleteResponse deleteResponse = client.prepareDelete(indexKey, table, id).get();
+      if (!deleteResponse.isFound()) {
+        return Status.NOT_FOUND;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status read(
+      final String table,
+      final String key,
+      final Set<String> fields,
+      final Map<String, ByteIterator> result) {
+    try {
+      final SearchResponse searchResponse = search(table, key);
+      if (searchResponse.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final SearchHit hit = searchResponse.getHits().getAt(0);
+      if (fields != null) {
+        for (final String field : fields) {
+          result.put(field, new StringByteIterator((String) hit.getSource().get(field)));
+        }
+      } else {
+        for (final Map.Entry<String, Object> e : hit.getSource().entrySet()) {
+          if (KEY.equals(e.getKey())) {
+            continue;
+          }
+          result.put(e.getKey(), new StringByteIterator((String) e.getValue()));
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final SearchResponse response = search(table, key);
+      if (response.getHits().getTotalHits() == 0) {
+        return Status.NOT_FOUND;
+      }
+
+      final SearchHit hit = response.getHits().getAt(0);
+      for (final Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        hit.getSource().put(entry.getKey(), entry.getValue());
+      }
+
+      final IndexResponse indexResponse =
+          client.prepareIndex(indexKey, table, hit.getId()).setSource(hit.getSource()).get();
+
+      if (!indexResponse.isCreated()) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status scan(
+      final String table,
+      final String startkey,
+      final int recordcount,
+      final Set<String> fields,
+      final Vector<HashMap<String, ByteIterator>> result) {
+    try {
+      refreshIfNeeded();
+      final RangeQueryBuilder query = new RangeQueryBuilder(KEY).gte(startkey);
+      final SearchResponse response = client.prepareSearch(indexKey).setQuery(query).setSize(recordcount).get();
+
+      for (final SearchHit hit : response.getHits()) {
+        final HashMap<String, ByteIterator> entry;
+        if (fields != null) {
+          entry = new HashMap<>(fields.size());
+          for (final String field : fields) {
+            entry.put(field, new StringByteIterator((String) hit.getSource().get(field)));
+          }
+        } else {
+          entry = new HashMap<>(hit.getSource().size());
+          for (final Map.Entry<String, Object> field : hit.getSource().entrySet()) {
+            if (KEY.equals(field.getKey())) {
+              continue;
+            }
+            entry.put(field.getKey(), new StringByteIterator((String) field.getValue()));
+          }
+        }
+        result.add(entry);
+      }
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> result) {
+
+    return Status.OK;
+  }
+
+  private void refreshIfNeeded() {
+    if (isRefreshNeeded) {
+      final boolean refresh;
+      synchronized (this) {
+        if (isRefreshNeeded) {
+          refresh = true;
+          isRefreshNeeded = false;
+        } else {
+          refresh = false;
+        }
+      }
+      if (refresh) {
+        client.admin().indices().refresh(new RefreshRequest()).actionGet();
+      }
+    }
+  }
+
+  private SearchResponse search(final String table, final String key) {
+    refreshIfNeeded();
+    return client.prepareSearch(indexKey).setTypes(table).setQuery(new TermQueryBuilder(KEY, key)).get();
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchRestClient.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/ElasticsearchRestClient.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.nio.entity.NStringEntity;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.javatuples.Pair;
+import site.ycsb.*;
+import site.ycsb.workloads.CommerceWorkload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.KEY;
+import static site.ycsb.db.elasticsearch7.Elasticsearch7.parseIntegerProperty;
+
+/**
+ * Elasticsearch REST client for YCSB framework.
+ */
+public class ElasticsearchRestClient extends DB {
+
+  private static final String DEFAULT_INDEX_KEY = "es.ycsb";
+  private static final String DEFAULT_REMOTE_HOST = "localhost:9200";
+  private static final String DEFAULT_HOST_SCHEMA = "http";
+  private static final String CRED_USER_PROPERTY = "es.user";
+  private static final String DEFAULT_CRED_USER = "";
+  private static final String CRED_PASS_PROPERTY = "es.password";
+  private static final String DEFAULT_CRED_PASS = "";
+  private static final int NUMBER_OF_SHARDS = 1;
+  private static final int NUMBER_OF_REPLICAS = 0;
+  private static final boolean INDEX_QUERY_CACHE_ENABLED_DEFAULT = true;
+  private static final String INDEX_QUERY_CACHE_ENABLED_PROPERTY = "es.queries.cache.enabled";
+  private static final String CONTENT_TYPE_APPLICATION_JSON = ContentType.APPLICATION_JSON.toString();
+  private RestClient restClient;
+  private String indexKey;
+  private volatile boolean isRefreshNeeded = false;
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint) throws DBException {
+    final Map<String, String> params = emptyMap();
+    return performRequest(restClient, method, endpoint, params);
+  }
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint,
+      final Map<String, String> params) throws DBException {
+    return performRequest(restClient, method, endpoint, params, null, null);
+  }
+
+  private static Response performRequest(
+      final RestClient restClient,
+      final String method,
+      final String endpoint,
+      final Map<String, String> params,
+      final HttpEntity entity, NStringEntity contentTypeEntity) throws DBException {
+    try {
+      Request request = new Request(method,
+          endpoint);
+      request.addParameters(params);
+      if (entity != null) {
+        request.setEntity(entity);
+      }
+      return restClient.performRequest(request);
+    } catch (final IOException e) {
+      e.printStackTrace();
+      throw new DBException(e);
+    }
+  }
+
+  /**
+   * Initialize any state for this DB. Called once per DB instance; there is one
+   * DB instance per client thread.
+   */
+  @Override
+  public void init() throws DBException {
+    final Properties props = getProperties();
+
+    this.indexKey = props.getProperty("es.index.key", DEFAULT_INDEX_KEY);
+
+    final int numberOfShards = parseIntegerProperty(props, "es.number_of_shards", NUMBER_OF_SHARDS);
+    final int numberOfReplicas = parseIntegerProperty(props, "es.number_of_replicas", NUMBER_OF_REPLICAS);
+    final boolean queryCacheEnabled = Boolean.parseBoolean(props.getProperty(INDEX_QUERY_CACHE_ENABLED_PROPERTY,
+        String.valueOf(INDEX_QUERY_CACHE_ENABLED_DEFAULT)));
+
+    final Boolean newIndex = Boolean.parseBoolean(props.getProperty("es.new_index", "false"));
+
+    final String[] nodeList = props.getProperty("es.hosts.list", DEFAULT_REMOTE_HOST).split(",");
+    final String hostSchema = props.getProperty("es.hosts.schema", DEFAULT_HOST_SCHEMA);
+    final String user = props.getProperty(CRED_USER_PROPERTY, DEFAULT_CRED_USER);
+    final String pass = props.getProperty(CRED_PASS_PROPERTY, DEFAULT_CRED_PASS);
+    final CredentialsProvider credentialsProvider =
+        new BasicCredentialsProvider();
+    if (user!=DEFAULT_CRED_USER && pass != DEFAULT_CRED_PASS) {
+      credentialsProvider.setCredentials(AuthScope.ANY,
+          new UsernamePasswordCredentials(user, pass));
+    }
+
+
+    final List<HttpHost> esHttpHosts = new ArrayList<>(nodeList.length);
+    for (String h : nodeList) {
+      String[] nodes = h.split(":");
+      HttpHost httpHost = new HttpHost(nodes[0], Integer.valueOf(nodes[1]), hostSchema);
+      esHttpHosts.add(httpHost);
+    }
+
+    RestClientBuilder restClientBuilder = RestClient.builder(esHttpHosts.toArray(new HttpHost[esHttpHosts.size()]));
+    // Based uppon https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_basic_authentication.html
+    if (user!=DEFAULT_CRED_USER && pass != DEFAULT_CRED_PASS) {
+      restClientBuilder.setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder
+          .setDefaultCredentialsProvider(credentialsProvider));
+    }
+    restClient = restClientBuilder.build();
+
+    final Response existsResponse = performRequest(restClient,
+        "HEAD", "/" + indexKey);
+    final boolean exists = existsResponse.getStatusLine().getStatusCode() == HttpStatus.SC_OK;
+
+    if (exists && newIndex) {
+      final Response deleteResponse = performRequest(restClient, "DELETE", "/" + indexKey);
+      final int statusCode = deleteResponse.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        throw new DBException("delete [" + indexKey + "] failed with status [" + statusCode + "]");
+      }
+    }
+
+    if (!exists || newIndex) {
+      try (XContentBuilder builder = jsonBuilder()) {
+        builder.startObject();
+        // {
+        builder.startObject("mappings");
+        //   {
+        builder.startObject("properties");
+        //     {
+        builder.startObject("productName");
+        //       {
+        builder.field("type", "text");
+        //       }
+        builder.endObject();
+        builder.startObject("productScore");
+        //       {
+        builder.field("type", "double");
+        //       }
+        builder.endObject();
+        for (String fieldName :
+            props.getProperty(CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY,
+                CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY_DEFAULT).split(",")
+        ) {
+          builder.startObject(fieldName);
+          //       {
+          builder.field("index", "false");
+          builder.field("type", "text");
+          //       }
+          builder.endObject();
+        }
+        //     }
+        builder.endObject();
+        //   }
+        builder.endObject();
+        builder.startObject("settings");
+        //   {
+        builder.field("index.number_of_shards", numberOfShards);
+        builder.field("index.number_of_replicas", numberOfReplicas);
+        builder.field("index.refresh_interval", "-1");
+        builder.field("index.queries.cache.enabled", queryCacheEnabled);
+        //   }
+        builder.endObject();
+        // }
+        builder.endObject();
+        final Map<String, String> params = emptyMap();
+        final StringEntity entity = new StringEntity(builder.string());
+        entity.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+        final Response createResponse = performRequest(restClient, "PUT", "/" + indexKey,
+            params, entity, null);
+        final int statusCode = createResponse.getStatusLine().getStatusCode();
+        if (statusCode != HttpStatus.SC_OK) {
+          throw new DBException("create [" + indexKey + "] failed with status [" + statusCode + "]");
+        }
+      } catch (final IOException e) {
+        throw new DBException(e);
+      }
+    }
+
+    final Map<String, String> params = Collections.singletonMap("wait_for_status", "green");
+    final Response healthResponse = performRequest(restClient, "GET", "/_cluster/health/" + indexKey,
+        params, null, null);
+    final int healthStatusCode = healthResponse.getStatusLine().getStatusCode();
+    if (healthStatusCode != HttpStatus.SC_OK) {
+      throw new DBException("cluster health [" + indexKey + "] failed with status [" + healthStatusCode + "]");
+    }
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+    if (restClient != null) {
+      try {
+        restClient.close();
+        restClient = null;
+      } catch (final IOException e) {
+        throw new DBException(e);
+      }
+    }
+  }
+
+  @Override
+  public Status insert(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final Map<String, String> data = StringByteIterator.getStringMap(values);
+      data.put(KEY, key);
+      NStringEntity payload = new NStringEntity(new ObjectMapper().writeValueAsString(data));
+      payload.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+      // Reason why we use auto-generated ids and not the specific key id
+      // https://www.elastic.co/guide/en/elasticsearch/reference/master/tune-for-indexing-speed.html
+      // When indexing a document that has an explicit id, Elasticsearch needs to check whether a document with the
+      // same id already exists within the same shard, which is a costly operation and gets even more costly as
+      // the index grows. By using auto-generated ids, Elasticsearch can skip this check, which makes indexing faster.
+      final Response response = performRequest(restClient, "POST",
+          "/" + indexKey + "/_doc",
+          Collections.emptyMap(),
+          payload,
+          null
+      );
+
+      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_CREATED) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(final String table, final String key) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == HttpStatus.SC_NOT_FOUND) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      String hitIdStr = (String) hit.get("_id");
+      final Response deleteResponse = performRequest(restClient, "DELETE",
+          "/" + indexKey + "/" + hitIdStr);
+      if (deleteResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status read(
+      final String table,
+      final String key,
+      final Set<String> fields,
+      final Map<String, ByteIterator> result) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == 404) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      if (fields != null) {
+        for (final String field : fields) {
+          result.put(field, new StringByteIterator((String) source.get(field)));
+        }
+      } else {
+        for (final Map.Entry<String, Object> e : source.entrySet()) {
+          if (KEY.equals(e.getKey())) {
+            continue;
+          }
+          result.put(e.getKey(), new StringByteIterator((String) e.getValue()));
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private int getTotalHits(Map<String, Object> hits) {
+    @SuppressWarnings("unchecked") final Map<String, Object> hitsTotal = (Map<String, Object>) hits.get("total");
+    final int total = (int) hitsTotal.get("value");
+    return total;
+  }
+
+  @Override
+  public Status update(final String table, final String key, final Map<String, ByteIterator> values) {
+    try {
+      final Response searchResponse = search(table, key);
+      final int statusCode = searchResponse.getStatusLine().getStatusCode();
+      if (statusCode == 404) {
+        return Status.NOT_FOUND;
+      } else if (statusCode != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      final Map<String, Object> map = map(searchResponse);
+      @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+      final int total = getTotalHits(hits);
+      if (total == 0) {
+        return Status.NOT_FOUND;
+      }
+      @SuppressWarnings("unchecked") final Map<String, Object> hit =
+          (Map<String, Object>) ((List<Object>) hits.get("hits")).get(0);
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      for (final Map.Entry<String, String> entry : StringByteIterator.getStringMap(values).entrySet()) {
+        source.put(entry.getKey(), entry.getValue());
+      }
+      final Map<String, String> params = emptyMap();
+      NStringEntity payload = new NStringEntity(new ObjectMapper().writeValueAsString(source));
+      payload.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+      final Response response = performRequest(restClient, "PUT",
+          "/" + indexKey + "/_doc/" + hit.get("_id"),
+          params,
+          payload, null
+      );
+      if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+        return Status.ERROR;
+      }
+
+      if (!isRefreshNeeded) {
+        synchronized (this) {
+          isRefreshNeeded = true;
+        }
+      }
+
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status scan(
+      final String table,
+      final String startkey,
+      final int recordcount,
+      final Set<String> fields,
+      final Vector<HashMap<String, ByteIterator>> result) {
+    try {
+      final Response response;
+      try (XContentBuilder builder = jsonBuilder()) {
+        builder.startObject();
+        builder.startObject("query");
+        builder.startObject("range");
+        builder.startObject(KEY);
+        builder.field("gte", startkey);
+        builder.endObject();
+        builder.endObject();
+        builder.endObject();
+        builder.field("size", recordcount);
+        builder.endObject();
+        response = search(table, builder);
+        processSearchReply(fields, result, response);
+      }
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private void processSearchReply(Set<String> fields, Vector<HashMap<String, ByteIterator>> result, Response response)
+      throws IOException {
+    @SuppressWarnings("unchecked") final Map<String, Object> map = map(response);
+    @SuppressWarnings("unchecked") final Map<String, Object> hits = (Map<String, Object>) map.get("hits");
+    @SuppressWarnings("unchecked") final List<Map<String, Object>> list =
+        (List<Map<String, Object>>) hits.get("hits");
+
+    for (final Map<String, Object> hit : list) {
+      @SuppressWarnings("unchecked") final Map<String, Object> source = (Map<String, Object>) hit.get("_source");
+      final HashMap<String, ByteIterator> entry;
+      if (fields != null) {
+        entry = new HashMap<>(fields.size());
+        for (final String field : fields) {
+          entry.put(field, new StringByteIterator((String) source.get(field)));
+        }
+      } else {
+        entry = new HashMap<>(hit.size());
+        for (final Map.Entry<String, Object> field : source.entrySet()) {
+          if (KEY.equals(field.getKey())) {
+            continue;
+          }
+          entry.put(field.getKey(), new StringByteIterator((String) field.getValue()));
+        }
+      }
+      result.add(entry);
+    }
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> result) {
+    try {
+      final Response response;
+//     {
+//  "query": {
+//    "bool": {
+//      "must": [{"term":{"productName":"feltcraft"} }, {"term":{"productName":"blue"} }]    }
+//  },
+//  "sort": [ {"productScore":{}} ],"size": 0,  "track_total_hits": true
+//}
+
+      try (XContentBuilder builder = jsonBuilder()) {
+        builder.startObject();
+        builder.startObject("query");
+        builder.startObject("bool");
+        builder.startArray("must");
+        builder.startObject();
+        builder.startObject("term");
+        builder.field("productName", queryPair.getValue1().split(" ")[0]);
+        builder.endObject();
+        builder.endObject();
+        builder.startObject();
+        builder.startObject("term");
+        builder.field("productName", queryPair.getValue1().split(" ")[1]);
+        builder.endObject();
+        builder.endObject();
+        builder.endArray();
+        builder.endObject();
+        builder.endObject();
+        // sorting
+        builder.startArray("sort");
+        builder.startObject();
+        builder.startObject("productScore");
+        builder.field("order", "asc");
+        builder.endObject();
+        builder.endObject();
+        builder.endArray();
+        builder.field("size", pagePair.getValue1());
+        builder.field("track_total_hits", true);
+        builder.endObject();
+        response = search(table, builder);
+        processSearchReply(fields, result, response);
+      }
+      return Status.OK;
+    } catch (final Exception e) {
+      e.printStackTrace();
+      return Status.ERROR;
+    }
+  }
+
+  private void refreshIfNeeded() throws IOException, DBException {
+    if (isRefreshNeeded) {
+      final boolean refresh;
+      synchronized (this) {
+        if (isRefreshNeeded) {
+          refresh = true;
+          isRefreshNeeded = false;
+        } else {
+          refresh = false;
+        }
+      }
+      if (refresh) {
+        performRequest(restClient, "POST", "/" + indexKey + "/_refresh");
+      }
+    }
+  }
+
+  private Response search(final String table, final String key) throws IOException, DBException {
+    try (XContentBuilder builder = jsonBuilder()) {
+      builder.startObject();
+      builder.startObject("query");
+      builder.startObject("term");
+      builder.field(KEY, key);
+      builder.endObject();
+      builder.endObject();
+      builder.endObject();
+      return search(table, builder);
+    }
+  }
+
+  private Response search(final String table, final XContentBuilder builder) throws IOException, DBException {
+    refreshIfNeeded();
+    final Map<String, String> params = emptyMap();
+    final StringEntity entity = new StringEntity(builder.string());
+    entity.setContentType(CONTENT_TYPE_APPLICATION_JSON);
+    return performRequest(restClient, "GET", "/" + indexKey + "/_search?request_cache=false",
+        params, entity, null);
+  }
+
+  private Map<String, Object> map(final Response response) throws IOException {
+    try (InputStream is = response.getEntity().getContent()) {
+      final ObjectMapper mapper = new ObjectMapper();
+      @SuppressWarnings("unchecked") final Map<String, Object> map = mapper.readValue(is, Map.class);
+      return map;
+    }
+  }
+
+}

--- a/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/package-info.java
+++ b/elasticsearch7/src/main/java/site/ycsb/db/elasticsearch7/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017 YCSB Contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for
+ * <a href="https://www.elastic.co/products/elasticsearch">Elasticsearch</a>.
+ */
+package site.ycsb.db.elasticsearch7;
+

--- a/elasticsearch7/src/main/resources/log4j2.properties
+++ b/elasticsearch7/src/main/resources/log4j2.properties
@@ -1,0 +1,23 @@
+# Copyright (c) 2017 YCSB contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you
+# may not use this file except in compliance with the License. You
+# may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the License. See accompanying
+# LICENSE file.
+#
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.targetStr = SYSTEM_ERR
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchClientIT.java
+++ b/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchClientIT.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import site.ycsb.DB;
+
+public class ElasticsearchClientIT extends ElasticsearchIntegTestBase {
+
+    @Override
+    DB newDB() {
+        return new ElasticsearchClient();
+    }
+
+}

--- a/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchIntegTestBase.java
+++ b/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchIntegTestBase.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+package site.ycsb.db.elasticsearch7;
+
+import site.ycsb.ByteIterator;
+import site.ycsb.Client;
+import site.ycsb.DB;
+import site.ycsb.DBException;
+import site.ycsb.Status;
+import site.ycsb.StringByteIterator;
+import site.ycsb.workloads.CoreWorkload;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Vector;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class ElasticsearchIntegTestBase {
+
+    private DB db;
+
+    abstract DB newDB();
+
+    private final static HashMap<String, ByteIterator> MOCK_DATA;
+    private final static String MOCK_TABLE = "MOCK_TABLE";
+    private final static String FIELD_PREFIX = CoreWorkload.FIELD_NAME_PREFIX_DEFAULT;
+
+    static {
+        MOCK_DATA = new HashMap<>(10);
+        for (int i = 1; i <= 10; i++) {
+            MOCK_DATA.put(FIELD_PREFIX + i, new StringByteIterator("value" + i));
+        }
+    }
+
+    @Before
+    public void setUp() throws DBException {
+        final Properties props = new Properties();
+        props.put("es.new_index", "true");
+        props.put("es.setting.cluster.name", "test");
+        db = newDB();
+        db.setProperties(props);
+        db.init();
+        for (int i = 0; i < 16; i++) {
+            db.insert(MOCK_TABLE, Integer.toString(i), MOCK_DATA);
+        }
+    }
+
+    @After
+    public void tearDown() throws DBException {
+        db.cleanup();
+    }
+
+    @Test
+    public void testInsert() {
+        final Status result = db.insert(MOCK_TABLE, "0", MOCK_DATA);
+        assertEquals(Status.OK, result);
+    }
+
+    /**
+     * Test of delete method, of class ElasticsearchClient.
+     */
+    @Test
+    public void testDelete() {
+        final Status result = db.delete(MOCK_TABLE, "1");
+        assertEquals(Status.OK, result);
+    }
+
+    /**
+     * Test of read method, of class ElasticsearchClient.
+     */
+    @Test
+    public void testRead() {
+        final Set<String> fields = MOCK_DATA.keySet();
+        final HashMap<String, ByteIterator> resultParam = new HashMap<>(10);
+        final Status result = db.read(MOCK_TABLE, "1", fields, resultParam);
+        assertEquals(Status.OK, result);
+    }
+
+    /**
+     * Test of update method, of class ElasticsearchClient.
+     */
+    @Test
+    public void testUpdate() {
+        final HashMap<String, ByteIterator> newValues = new HashMap<>(10);
+
+        for (int i = 1; i <= 10; i++) {
+            newValues.put(FIELD_PREFIX + i, new StringByteIterator("newvalue" + i));
+        }
+
+        final Status updateResult = db.update(MOCK_TABLE, "1", newValues);
+        assertEquals(Status.OK, updateResult);
+
+        // validate that the values changed
+        final HashMap<String, ByteIterator> resultParam = new HashMap<>(10);
+        final Status readResult = db.read(MOCK_TABLE, "1", MOCK_DATA.keySet(), resultParam);
+        assertEquals(Status.OK, readResult);
+
+        for (int i = 1; i <= 10; i++) {
+            assertEquals("newvalue" + i, resultParam.get(FIELD_PREFIX + i).toString());
+        }
+
+    }
+
+    /**
+     * Test of scan method, of class ElasticsearchClient.
+     */
+    @Test
+    public void testScan() {
+        final int recordcount = 10;
+        final Set<String> fields = MOCK_DATA.keySet();
+        final Vector<HashMap<String, ByteIterator>> resultParam = new Vector<>(10);
+        final Status result = db.scan(MOCK_TABLE, "1", recordcount, fields, resultParam);
+        assertEquals(Status.OK, result);
+
+        assertEquals(10, resultParam.size());
+    }
+
+}

--- a/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchIntegTestBase.java
+++ b/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchIntegTestBase.java
@@ -21,6 +21,8 @@ import site.ycsb.Client;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 import org.junit.After;

--- a/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchRestClientIT.java
+++ b/elasticsearch7/src/test/java/site/ycsb/db/elasticsearch5/ElasticsearchRestClientIT.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017 YCSB contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+package site.ycsb.db.elasticsearch7;
+
+import site.ycsb.DB;
+
+public class ElasticsearchRestClientIT extends ElasticsearchIntegTestBase {
+
+  @Override
+  DB newDB() {
+    return new ElasticsearchRestClient();
+  }
+
+}

--- a/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
+++ b/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
@@ -21,6 +21,7 @@ import com.apple.foundationdb.*;
 import com.apple.foundationdb.async.AsyncIterable;
 import com.apple.foundationdb.tuple.Tuple;
 
+import org.javatuples.Pair;
 import site.ycsb.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -298,5 +299,21 @@ public class FoundationDBClient extends DB {
       e.printStackTrace();
     }
     return Status.ERROR;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
+++ b/foundationdb/src/main/java/site/ycsb/db/foundationdb/FoundationDBClient.java
@@ -313,7 +313,9 @@ public class FoundationDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/geode/src/main/java/site/ycsb/db/GeodeClient.java
+++ b/geode/src/main/java/site/ycsb/db/GeodeClient.java
@@ -18,11 +18,7 @@
 package site.ycsb.db;
 
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,6 +27,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -233,5 +231,21 @@ public class GeodeClient extends DB {
       }
     }
     return r;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/geode/src/main/java/site/ycsb/db/GeodeClient.java
+++ b/geode/src/main/java/site/ycsb/db/GeodeClient.java
@@ -245,7 +245,9 @@ public class GeodeClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
+++ b/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
@@ -456,7 +456,9 @@ public class GoogleBigtableClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
   

--- a/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
+++ b/googlebigtable/src/main/java/site/ycsb/db/GoogleBigtableClient.java
@@ -18,20 +18,13 @@ package site.ycsb.db;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.util.Bytes;
 
-import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.ExecutionException;
 
 import com.google.bigtable.v2.Column;
@@ -58,6 +51,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 /**
  * Google Bigtable Proto client for YCSB framework.
@@ -447,6 +442,22 @@ public class GoogleBigtableClient extends site.ycsb.DB {
         bulkMutation = session.createBulkMutation(tableName);
       }
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
   
 }

--- a/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
@@ -32,6 +32,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.apache.log4j.Level;
@@ -39,11 +41,8 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.Vector;
 
 import javax.annotation.Nullable;
 
@@ -339,5 +338,21 @@ public class GoogleDatastoreClient extends DB {
     }
 
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
@@ -352,7 +352,9 @@ public class GoogleDatastoreClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/griddb/src/main/java/site/ycsb/db/griddb/GridDBClient.java
+++ b/griddb/src/main/java/site/ycsb/db/griddb/GridDBClient.java
@@ -18,14 +18,7 @@
  
 package site.ycsb.db.griddb;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.logging.Logger;
 
 import com.toshiba.mwcloud.gs.ColumnInfo;
@@ -42,6 +35,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 /**
  * A class representing GridDBClient.
@@ -313,6 +308,22 @@ public class GridDBClient extends site.ycsb.DB {
       return Status.ERROR;
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   protected String makeContainerKey(String key) {

--- a/griddb/src/main/java/site/ycsb/db/griddb/GridDBClient.java
+++ b/griddb/src/main/java/site/ycsb/db/griddb/GridDBClient.java
@@ -322,7 +322,9 @@ public class GridDBClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/griddb/src/test/java/site/ycsb/db/griddb/GridDBClientTest.java
+++ b/griddb/src/test/java/site/ycsb/db/griddb/GridDBClientTest.java
@@ -49,6 +49,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
+++ b/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
@@ -19,6 +19,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.measurements.Measurements;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -44,11 +46,7 @@ import org.apache.hadoop.hbase.filter.PageFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
@@ -517,6 +515,22 @@ public class HBaseClient1 extends site.ycsb.DB {
     }
 
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   // Only non-private for testing.

--- a/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
+++ b/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
@@ -529,7 +529,9 @@ public class HBaseClient1 extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/hbase1/src/test/java/site/ycsb/db/hbase1/HBaseClient1Test.java
+++ b/hbase1/src/test/java/site/ycsb/db/hbase1/HBaseClient1Test.java
@@ -25,6 +25,8 @@ import static org.junit.Assume.assumeTrue;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
+++ b/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
@@ -24,6 +24,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.measurements.Measurements;
 
 import org.apache.hadoop.security.UserGroupInformation;
@@ -49,11 +51,7 @@ import org.apache.hadoop.hbase.filter.PageFilter;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import java.io.IOException;
-import java.util.ConcurrentModificationException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static site.ycsb.workloads.CoreWorkload.TABLENAME_PROPERTY;
@@ -550,6 +548,22 @@ public class HBaseClient2 extends site.ycsb.DB {
     }
 
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   // Only non-private for testing.

--- a/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
+++ b/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
@@ -562,7 +562,9 @@ public class HBaseClient2 extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/hbase2/src/test/java/site/ycsb/db/hbase2/HBaseClient2Test.java
+++ b/hbase2/src/test/java/site/ycsb/db/hbase2/HBaseClient2Test.java
@@ -26,6 +26,8 @@ import static org.junit.Assume.assumeTrue;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/ignite/src/main/java/site/ycsb/db/ignite/IgniteAbstractClient.java
+++ b/ignite/src/main/java/site/ycsb/db/ignite/IgniteAbstractClient.java
@@ -21,11 +21,9 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.Vector;
+import org.javatuples.Pair;
+
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.logger.log4j2.Log4J2Logger;
@@ -170,6 +168,22 @@ public abstract class IgniteAbstractClient extends DB {
   @Override
   public Status scan(String table, String startkey, int recordcount,
                      Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/ignite/src/main/java/site/ycsb/db/ignite/IgniteAbstractClient.java
+++ b/ignite/src/main/java/site/ycsb/db/ignite/IgniteAbstractClient.java
@@ -183,7 +183,9 @@ public abstract class IgniteAbstractClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/ignite/src/test/java/site/ycsb/db/ignite/IgniteClientTest.java
+++ b/ignite/src/test/java/site/ycsb/db/ignite/IgniteClientTest.java
@@ -19,6 +19,8 @@ package site.ycsb.db.ignite;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import org.apache.ignite.IgniteCheckedException;

--- a/ignite/src/test/java/site/ycsb/db/ignite/IgniteClientTestBase.java
+++ b/ignite/src/test/java/site/ycsb/db/ignite/IgniteClientTestBase.java
@@ -20,6 +20,8 @@ package site.ycsb.db.ignite;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import org.apache.ignite.Ignite;
 import org.junit.After;

--- a/ignite/src/test/java/site/ycsb/db/ignite/IgniteSqlClientTest.java
+++ b/ignite/src/test/java/site/ycsb/db/ignite/IgniteSqlClientTest.java
@@ -19,6 +19,8 @@ package site.ycsb.db.ignite;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import org.apache.ignite.IgniteCheckedException;

--- a/infinispan/src/main/java/site/ycsb/db/InfinispanClient.java
+++ b/infinispan/src/main/java/site/ycsb/db/InfinispanClient.java
@@ -21,6 +21,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.infinispan.Cache;
@@ -32,10 +34,7 @@ import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * This is a client implementation for Infinispan 5.x.
@@ -149,5 +148,21 @@ public class InfinispanClient extends DB {
       LOGGER.error(e);
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/infinispan/src/main/java/site/ycsb/db/InfinispanClient.java
+++ b/infinispan/src/main/java/site/ycsb/db/InfinispanClient.java
@@ -162,7 +162,9 @@ public class InfinispanClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/infinispan/src/main/java/site/ycsb/db/InfinispanRemoteClient.java
+++ b/infinispan/src/main/java/site/ycsb/db/InfinispanRemoteClient.java
@@ -17,16 +17,14 @@
 
 package site.ycsb.db;
 
+import org.javatuples.Pair;
 import site.ycsb.*;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.util.logging.Log;
 import org.infinispan.util.logging.LogFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 /**
  * This is a client implementation for Infinispan 5.x in client-server mode.
@@ -123,6 +121,22 @@ public class InfinispanRemoteClient extends DB {
       LOGGER.error(e);
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private RemoteCache<String, Map<String, String>> cache() {

--- a/infinispan/src/main/java/site/ycsb/db/InfinispanRemoteClient.java
+++ b/infinispan/src/main/java/site/ycsb/db/InfinispanRemoteClient.java
@@ -135,7 +135,9 @@ public class InfinispanRemoteClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -546,7 +546,9 @@ public class JdbcDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
+++ b/jdbc/src/main/java/site/ycsb/db/JdbcDBClient.java
@@ -20,6 +20,8 @@ import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import java.sql.*;
@@ -530,5 +532,21 @@ public class JdbcDBClient extends DB {
     }
 
     return new OrderedFieldInfo(fieldKeys, fieldValues);
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
@@ -426,7 +426,9 @@ public class KuduYCSBClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
+++ b/kudu/src/main/java/site/ycsb/db/KuduYCSBClient.java
@@ -21,6 +21,8 @@ import com.stumbleupon.async.TimeoutException;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 import org.slf4j.Logger;
@@ -30,13 +32,7 @@ import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Schema;
 import org.apache.kudu.client.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import static site.ycsb.Client.DEFAULT_RECORD_COUNT;
 import static site.ycsb.Client.RECORD_COUNT_PROPERTY;
@@ -416,5 +412,21 @@ public class KuduYCSBClient extends site.ycsb.DB {
     } catch (KuduException ex) {
       LOG.warn("Write operation failed", ex);
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/maprjsondb/src/main/java/site/ycsb/db/mapr/MapRJSONDBClient.java
+++ b/maprjsondb/src/main/java/site/ycsb/db/mapr/MapRJSONDBClient.java
@@ -233,7 +233,9 @@ public class MapRJSONDBClient extends site.ycsb.DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/maprjsondb/src/main/java/site/ycsb/db/mapr/MapRJSONDBClient.java
+++ b/maprjsondb/src/main/java/site/ycsb/db/mapr/MapRJSONDBClient.java
@@ -16,10 +16,7 @@
 package site.ycsb.db.mapr;
 
 import java.nio.ByteBuffer;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import org.ojai.Document;
 import org.ojai.DocumentConstants;
@@ -36,6 +33,8 @@ import org.ojai.store.QueryCondition.Op;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 /**
  * MapR-DB(json) client for YCSB framework.
@@ -220,5 +219,21 @@ public class MapRJSONDBClient extends site.ycsb.DB {
       }
     }
     return (HashMap<String, ByteIterator>)result;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/memcached/src/main/java/site/ycsb/db/MemcachedClient.java
+++ b/memcached/src/main/java/site/ycsb/db/MemcachedClient.java
@@ -309,7 +309,9 @@ public class MemcachedClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/memcached/src/main/java/site/ycsb/db/MemcachedClient.java
+++ b/memcached/src/main/java/site/ycsb/db/MemcachedClient.java
@@ -21,6 +21,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import java.io.IOException;
@@ -28,13 +30,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.FailureMode;
@@ -299,5 +295,21 @@ public class MemcachedClient extends DB {
     JsonGenerator jsonGenerator = jsonFactory.createJsonGenerator(writer);
     MAPPER.writeTree(jsonGenerator, node);
     return writer.toString();
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
@@ -38,17 +38,14 @@ import com.allanbank.mongodb.builder.BatchedWrite;
 import com.allanbank.mongodb.builder.BatchedWriteMode;
 import com.allanbank.mongodb.builder.Find;
 import com.allanbank.mongodb.builder.Sort;
+import com.mongodb.client.MongoCursor;
+import org.javatuples.Pair;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -546,5 +543,16 @@ public class AsyncMongoDbClient extends DB {
 
       return value;
     }
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> result) {
+
+    MongoCursor<org.bson.Document> cursor = null;
+    return Status.ERROR;
   }
 }

--- a/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
@@ -44,7 +44,6 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 
 import java.util.*;

--- a/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
+++ b/mongodb/src/main/java/site/ycsb/db/AsyncMongoDbClient.java
@@ -44,6 +44,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/mongodb/src/test/java/site/ycsb/db/AbstractDBTestCases.java
+++ b/mongodb/src/test/java/site/ycsb/db/AbstractDBTestCases.java
@@ -28,6 +28,8 @@ import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/nosqldb/src/main/java/site/ycsb/db/NoSqlDbClient.java
+++ b/nosqldb/src/main/java/site/ycsb/db/NoSqlDbClient.java
@@ -17,14 +17,7 @@
 
 package site.ycsb.db;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import oracle.kv.Consistency;
@@ -43,6 +36,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 /**
  * A database interface layer for Oracle NoSQL Database.
@@ -242,6 +237,22 @@ public class NoSqlDbClient extends DB {
     }
 
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/nosqldb/src/main/java/site/ycsb/db/NoSqlDbClient.java
+++ b/nosqldb/src/main/java/site/ycsb/db/NoSqlDbClient.java
@@ -251,7 +251,9 @@ public class NoSqlDbClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/orientdb/src/main/java/site/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/site/ycsb/db/OrientDBClient.java
@@ -26,16 +26,13 @@ import com.orientechnologies.orient.core.exception.OConcurrentModificationExcept
 import com.orientechnologies.orient.core.index.OIndexCursor;
 import com.orientechnologies.orient.core.record.ORecord;
 import com.orientechnologies.orient.core.record.impl.ODocument;
+import org.javatuples.Pair;
 import site.ycsb.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -319,5 +316,21 @@ public class OrientDBClient extends DB {
       e.printStackTrace();
     }
     return Status.ERROR;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/orientdb/src/main/java/site/ycsb/db/OrientDBClient.java
+++ b/orientdb/src/main/java/site/ycsb/db/OrientDBClient.java
@@ -330,7 +330,9 @@ public class OrientDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@ LICENSE file.
         <artifactId>slf4j-api</artifactId>
         <version>1.7.25</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.javafaker</groupId>
+        <artifactId>javafaker</artifactId>
+        <version>1.0.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -123,6 +128,7 @@ LICENSE file.
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>
     <elasticsearch5-version>5.5.1</elasticsearch5-version>
+    <elasticsearch7-version>7.12.0</elasticsearch7-version>
     <foundationdb.version>5.2.5</foundationdb.version>
     <geode.version>1.2.0</geode.version>
     <googlebigtable.version>1.4.0</googlebigtable.version>
@@ -133,12 +139,13 @@ LICENSE file.
     <infinispan.version>7.2.2.Final</infinispan.version>
     <kudu.version>1.11.1</kudu.version>
     <maprhbase.version>1.1.8-mapr-1710</maprhbase.version>
-    <mongodb.version>3.11.0</mongodb.version>
+    <mongodb.version>3.12.8</mongodb.version>
     <mongodb.async.version>2.0.1</mongodb.async.version>
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <redis.version>2.9.0</redis.version>
+    <jedis.redisearch.version>3.5.2</jedis.redisearch.version>
+    <redis.version>3.5.1</redis.version>
     <riak.version>2.0.5</riak.version>
     <rocksdb.version>6.2.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>
@@ -172,6 +179,7 @@ LICENSE file.
     <module>dynamodb</module>
     <module>elasticsearch</module>
     <module>elasticsearch5</module>
+    <module>elasticsearch7</module>
     <module>foundationdb</module>
     <module>geode</module>
     <module>googlebigtable</module>
@@ -192,6 +200,8 @@ LICENSE file.
     <module>postgrenosql</module>
     <module>rados</module>
     <module>redis</module>
+    <module>redisearch</module>
+    <module>redisjson2</module>
     <module>rest</module>
     <module>riak</module>
     <module>rocksdb</module>

--- a/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
+++ b/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
@@ -420,7 +420,9 @@ public class PostgreNoSQLDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
+++ b/postgrenosql/src/main/java/site/ycsb/postgrenosql/PostgreNoSQLDBClient.java
@@ -18,6 +18,7 @@
  */
 package site.ycsb.postgrenosql;
 
+import org.javatuples.Pair;
 import site.ycsb.*;
 import org.json.simple.JSONObject;
 import org.postgresql.Driver;
@@ -405,5 +406,21 @@ public class PostgreNoSQLDBClient extends DB {
     delete.append(PRIMARY_KEY);
     delete.append(" = ?");
     return delete.toString();
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/rados/src/main/java/site/ycsb/db/RadosClient.java
+++ b/rados/src/main/java/site/ycsb/db/RadosClient.java
@@ -187,7 +187,9 @@ public class RadosClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/rados/src/main/java/site/ycsb/db/RadosClient.java
+++ b/rados/src/main/java/site/ycsb/db/RadosClient.java
@@ -28,15 +28,13 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
 
 import org.json.JSONObject;
 
@@ -174,6 +172,22 @@ public class RadosClient extends DB {
   @Override
   public Status scan(String table, String startkey, int recordcount, Set<String> fields,
       Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/rados/src/test/java/site/ycsb/db/RadosClientTest.java
+++ b/rados/src/test/java/site/ycsb/db/RadosClientTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assume.assumeNoException;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.junit.AfterClass;

--- a/redis/README.md
+++ b/redis/README.md
@@ -45,15 +45,14 @@ Set host, port, password, and cluster mode in the workload you plan to run.
 
 Or, you can set configs with the shell command, EG:
 
-    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" > outputLoad.txt
+    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
 
 ### 5. Load data and run tests
 
 Load the data:
+    ./bin/ycsb load redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputLoad.txt
 
-    ./bin/ycsb load redis -s -P workloads/workloada > outputLoad.txt
 
 Run the workload test:
-
-    ./bin/ycsb run redis -s -P workloads/workloada > outputRun.txt
+    ./bin/ycsb run redis -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" -p "threadcount=8" > outputRun.txt
 

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -34,6 +34,17 @@ LICENSE file.
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>${redis.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>

--- a/redis/src/main/java/site/ycsb/db/RedisClient.java
+++ b/redis/src/main/java/site/ycsb/db/RedisClient.java
@@ -271,7 +271,9 @@ public class RedisClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/redis/src/main/java/site/ycsb/db/RedisClient.java
+++ b/redis/src/main/java/site/ycsb/db/RedisClient.java
@@ -31,7 +31,6 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
-import org.javatuples.Pair;
 
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;

--- a/redis/src/main/java/site/ycsb/db/RedisClient.java
+++ b/redis/src/main/java/site/ycsb/db/RedisClient.java
@@ -26,10 +26,13 @@ package site.ycsb.db;
 
 import redis.clients.jedis.*;
 import redis.clients.jedis.util.JedisClusterCRC16;
+import org.javatuples.Pair;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 
@@ -254,5 +257,21 @@ public class RedisClient extends DB {
     } finally {
       j.close();
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/redisearch/README.md
+++ b/redisearch/README.md
@@ -1,0 +1,254 @@
+<!--
+Copyright (c) 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Redis with RediSearch[https://github.com/RediSearch/RediSearch] module enabled. 
+
+### 1. Start Redis with RediSearch 
+
+```
+(...)
+```
+
+### 2. Install Java and Maven
+
+### 3. Set Up YCSB
+
+Git clone YCSB and compile:
+
+    git clone http://github.com/RediSearch/YCSB.git --branch redisearch2.support
+    cd YCSB
+    mvn -pl site.ycsb:redisearch-binding -am clean package
+
+### 4. Provide Redis Connection Parameters
+    
+Set host, port, password, and cluster mode in the workload you plan to run. 
+
+- `redisearch.host`
+- `redisearch.port`
+- `redisearch.password`
+  * Don't set the password if redis auth is disabled.
+- `redisearch.cluster`
+  * Set the cluster parameter to `true` if redis cluster mode is enabled.
+  * Default is `false`.
+
+Or, you can set configs with the shell command, EG:
+
+    ./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+
+### 5. Load data and run the tests
+
+All six workloads have a data set that is similar. Workloads D and E insert records during the test run. Thus, to keep the database size consistent, we recommend the following sequence:
+
+Load the database, using workload A’s parameter file (workloads/workloada) and the “-load” switch to the client.
+
+- Run workload A (using workloads/workloada and “-t”) for a variety of throughputs.
+
+- Run workload B (using workloads/workloadb and “-t”) for a variety of throughputs.
+
+- Run workload C (using workloads/workloadc and “-t”) for a variety of throughputs.
+
+- Run workload F (using workloads/workloadf and “-t”) for a variety of throughputs.
+
+- Run workload D (using workloads/workloadd and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+- Delete the data in the database.
+
+- Reload the database, using workload E’s parameter file (workloads/workloade) and the "-load switch to the client.
+
+- Run workload E (using workloads/workloade and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+
+```bash
+# load, run A, B, C, F, D, (flushdb), load, E
+./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+./bin/ycsb run redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunA.txt
+./bin/ycsb run redisearch -s -P workloads/workloadb -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunB.txt
+./bin/ycsb run redisearch -s -P workloads/workloadc -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunC.txt
+./bin/ycsb run redisearch -s -P workloads/workloadf -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunF.txt
+./bin/ycsb run redisearch -s -P workloads/workloadd -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunD.txt
+
+redis-cli flushall
+
+./bin/ycsb load redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=32" -p "recordcount=30000000" -p "operationcount=30000000" > outputLoad.txt
+./bin/ycsb run redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=32" -p "recordcount=30000000" -p "operationcount=30000000" > outputRunE.txt
+```
+
+
+## An overall picture, and the RediSearch use-case
+
+### Default workloads
+
+By default, there are 6 default independent workloads, in the core package. Prior to describing the workloads, we will describe the dataset that is similar across all six.
+
+#### RediSearch default workloads dataset representation
+
+All six workloads have a data set that is similar, composed for N distinct records.
+
+Each record is identified by a primary key, which is a string like “user234123”.
+
+
+Within each record, by default, we have 10 fields, named field0, field1 and so on. The values of each field are a random string of ASCII characters of length L.
+By default, we construct 1,000-byte records by using F = 10 fields, each of L = 100 bytes.
+
+Specifically, within Redis, we model each record as a HASH, as showcased below.
+
+Apart from the default fields, within each document we add a numeric `__score__` field, used within the `scan()` workloads for sorting. 
+The value of the `__score__` field is given by computing a hash of the key name.
+
+
+```bash
+127.0.0.1:6379> hgetall user6873002678636213555
+ 1) "field6"
+ 2) "1;x.H{=8`73<+H71+t6W=99\"8(f>Tm*;<4K16?r#?:'<d.!<7\"6!I#'_=(M3!-(-6n>Q99:>8)< P+ 1x2\\%/M\x7f'W%%Sy\"^u%?n+"
+ 3) "field1"
+ 4) ")C3,U!6@-(G!:V5<<d9)j#\\+9&:5S#\":d;&v?>h;<&3)|&\".2< <O{%(:<R90\">4[s-Y'84 '!61%.=(.9R{9Aw*Cc-H=$H'*!,,"
+ 5) "field7"
+ 6) ".(v#Uq'2>=@5%E),*`9]',V->1.9'*&@s6L7:>>,Js:V)17:$Y58^-(Qk?Aq6 r\"Zm Ee&Ag%S=)I%6),)Jy ),=9r5O+%Ug)=x+"
+ 7) "field9"
+ 8) " &f2R).A;43f>Vq;3,<W/9$d#G=,\"4*H%)-(>30 7&4 p;)(=/<<Ny(6~670,(*4N''Ze&&2:P5$Vm728<Ks0 4!C?3;:48>'R}*"
+ 9) "field4"
+10) "4)t&S+08$) f V1)Qm,>,,;6&2`\"!n=Wu#V)4-.=I;5@q+U+$Gq.Ou1H{3Ma<[k.X} .:![\x7f,..8C;\"Ns:Vy<8t6B1<Uq\"E)\" 0$"
+11) "field8"
+12) "8H+ 9d\"^/%968!|;2|+Q-=;f9?`&T%%Sc;>06Bk*]%=U',)8&W5-D+)-*=B)9&p2T}-^'5Kq%(8-K5634 *$)E=1.`+]{?Vi##l+"
+13) "field5"
+14) "\"Sa/W\x7f5&j6C1:5j:R-$8: =(5)&94b(,r6L')+h+G=!8b7T95#>$=:=%t;U?;]+-%(+Yu7P'7#:9<>=Zi?Ok&%<()p&.&-M5<Ow>"
+15) "field3"
+16) "+H9-8t>5|;]}22|&>x$T38,4#\"f3#00\\30R71.*!8n,_i'>:,-f\"Sk:Q9% $?Fa:Q%:E',S;0.h3[);J-$G\x7f-8x\"]'?V!$50>,f6"
+17) "field0"
+18) "23,!Za?Uq?T5-9<=<. B)!2$?$4</h=?$$2`:$x7T%'':<L%+, -]e3^m?\"`16.!I{1.j6R}\"/:<\"4;Dm\"/$>.`6Vs;W7(>l/7z#"
+19) "field2"
+20) "5Dk'Qw==04$*9,b;B+!])$7h44(-8~?H'1!t>D9%?$>5x3Z/%Ek6Kg<H+()6,\".8\"~7W!(F=&7 (Vc4]q#Im7?\"50 ,Qk6Zs4#n:"
+21) "__score__"
+22) "1.770379916E9"
+```
+
+#### Scanning based on RediSearch secondary index…
+
+As you will see below, there is the need to model a scan operation within different records, in which we scan records in order, starting at a randomly chosen record key. 
+The number of records to scan is randomly chosen. 
+
+ To model the scan operation within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
+for the search query, and set +inf as the upper limit of the search result.
+
+ The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.
+
+ Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly chosen starting key, with
+ variadic record count replies.
+ 
+Example FT.SEARCH command that a scan operation would generate.
+
+```bash
+127.0.0.1:6379> "FT.SEARCH" "index" "@__score__:[7.39074446E8 inf]" "LIMIT" "0" "13" "RETURN" "10" "field0" "field1" "field2" "field3" "field4" "field5" "field6" "field7" "field8" "field9"
+ 1) (integer) 350
+ 2) "user3232700585171816769"
+ 3)  1) "field0"
+     2) "6;l+P=;R'8F/:Vi77:,S+-5j&8|?,,,0(%,x9_#%?z5+l/4*?1 -'&)@!$8n=^w+Js*)t;S/,<(4J#4=:=8x$[w;X) J#4 r9T90"
+     3) "field1"
+     4) "<4.5]u'Gm/!\"3Bs#%d!U%(Z)1Z-, h3?r'/6 581%x3A55Qs*B34%~ ) )^w-O=0Ok=D=1?4?%v+5(9]+(T=!-b\" x#@o\">6\"$p7"
+     (...)
+     (...)
+    19) "field9"
+    20) "8\"d2Dw7Z)8L?(D75820V?4;h*-*8,4:V+8!8:+>9,(05r3F!=(r2I#)D+)Xm5!*-Xa:O7-987Ti?Ce(8(=]' Mm+Y)*S%5K#7(00"
+ 4) "user1000385178204227360"
+ 5)  1) "field0"
+     2) "'1r;A+(Sc#&:4-x:7|6D-(Z}2<0%66>$ 85v(/84Wo3'\"=3.!0p*+2%#,<-f9+|?7p#Y{/60*5|\"R1/Qk\">z##68F/-*<)*`+Xe*"
+     (...)
+     (...)
+(...)
+(...)
+```
+  
+
+### Workload operation details
+
+#### Workload A: Update heavy workload
+
+- read/scan/update/insert ratio: 50/0/50/0
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+- Application example: Session store recording recent actions
+
+#### Workload B: Read mostly workload
+
+- read/scan/update/insert ratio: 95/0/5/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: photo tagging; add a tag is an update, but most operations are to read tags
+
+#### Workload C: Read only
+
+- read/scan/update/insert ratio: 100/0/0/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload D: Read latest workload
+
+- read/scan/update/insert ratio: 95/0/0/5
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: latest -- new records are inserted, and the most recently inserted records are the most popular.
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload E: Short ranges
+
+- read/scan/update/insert ratio: 0/95/0/5
+
+- maxscanlength=100
+
+- scanlengthdistribution=uniform
+
+- This is a 95% read workload, in which short ranges of records are queried, instead of individual records.
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: threaded conversations, where each scan is for the posts in a given thread (assumed to be clustered by thread id)
+
+#### Workload F: Read-modify-write workload
+
+- read/scan/update/insert/readmodifywrite ratio: 50/0/0/0/50
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user database, where user records are read and modified by the user or to record user activity.

--- a/redisearch/pom.xml
+++ b/redisearch/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+  
+  <artifactId>redisearch-binding</artifactId>
+  <name>RediSearch DB Binding</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>${jedis.redisearch.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.11.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>2.11.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-log4j2</artifactId>
+      <version>${ignite.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/redisearch/src/main/java/site/ycsb/db/RediSearchClient.java
+++ b/redisearch/src/main/java/site/ycsb/db/RediSearchClient.java
@@ -1,0 +1,490 @@
+/**
+ * Copyright (c) 2021 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ * <p>
+ * RediSearch client binding for YCSB.
+ * <p>
+ * All YCSB records are mapped to a Redis *hash field*.
+ * For scanning we use RediSearch's secondary index capabilities.
+ */
+
+package site.ycsb.db;
+
+import org.javatuples.Pair;
+import redis.clients.jedis.*;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+import site.ycsb.*;
+import site.ycsb.workloads.CommerceWorkload;
+import site.ycsb.workloads.CoreWorkload;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * YCSB binding for <a href="https://github.com/RediSearch/RediSearch/">RediSearch</a>.
+ * <p>
+ * See {@code redisearch/README.md} for details.
+ */
+public class RediSearchClient extends DB {
+  public static final String HOST_PROPERTY = "redis.host";
+  public static final String PORT_PROPERTY = "redis.port";
+  public static final String PASSWORD_PROPERTY = "redis.password";
+  public static final String CLUSTER_PROPERTY = "redis.cluster";
+  public static final String CLUSTER_PROPERTY_DEFAULT = "false";
+  public static final String TIMEOUT_PROPERTY = "redis.timeout";
+  public static final String CLIENT_POOL_MAX_PROPERTY = "redis.client.poolmaxsize";
+  public static final String CLIENT_POOL_MAX_PROPERTY_DEFAULT = "1";
+  public static final String INDEX_NAME_PROPERTY = "redisearch.indexname";
+  public static final String INDEX_NAME_PROPERTY_DEFAULT = "index";
+  public static final String RANGE_FIELD_NAME_PROPERTY = "redisearch.scorefield";
+  public static final String RANGE_FIELD_NAME_PROPERTY_DEFAULT = "__doc_hash__";
+  public static final String INDEXED_TAG_FIELDS_PROPERTY = "redisearch.indexedtagfields";
+  //  public static final String INDEXED_TAG_FIELDS_PROPERTY_DEFAULT = "brand,department,color,inSale,inStock";
+  public static final String INDEXED_TAG_FIELDS_PROPERTY_DEFAULT = "";
+  public static final String INDEXED_TEXT_FIELDS_PROPERTY = "redisearch.indexedtextfields";
+  //  public static final String INDEXED_TEXT_FIELDS_PROPERTY_DEFAULT = "productName,productDescription";
+  public static final String INDEXED_TEXT_FIELDS_PROPERTY_DEFAULT = "productName";
+  public static final String RESULT_PROCESS_PROPERTY = "redisearch.enable.resultprocess";
+  public static final String RESULT_PROCESS_PROPERTY_DEFAULT = "true";
+  private static final boolean INDEX_HASHES_ENABLED_PROPERTY_DEFAULT = true;
+  private static final String INDEX_HASHES_ENABLED_PROPERTY = "redisearch.indexdocs";
+  private JedisCluster jedisCluster;
+  private JedisPool jedisPool;
+  private Boolean clusterEnabled;
+  private int fieldCount;
+  private String fieldPrefix;
+  private String indexName;
+  private String rangeField;
+  private boolean orderedinserts;
+  private boolean coreWorkload;
+  private String keyprefix;
+  private Set<String> commerceTagFields;
+  private Set<String> commerceTextFields;
+  private Set<String> nonIndexFields;
+  private boolean resultProcessing;
+
+  @Override
+  public void init() throws DBException {
+    Properties props = getProperties();
+    int port = Protocol.DEFAULT_PORT;
+    String host = Protocol.DEFAULT_HOST;
+    int timeout = Protocol.DEFAULT_TIMEOUT;
+
+    final boolean indexingHashesEnabled = Boolean.parseBoolean(props.getProperty(INDEX_HASHES_ENABLED_PROPERTY,
+        String.valueOf(INDEX_HASHES_ENABLED_PROPERTY_DEFAULT)));
+
+    String redisTimeoutStr = props.getProperty(TIMEOUT_PROPERTY);
+    String password = props.getProperty(PASSWORD_PROPERTY);
+    clusterEnabled = Boolean.parseBoolean(props.getProperty(CLUSTER_PROPERTY, CLUSTER_PROPERTY_DEFAULT));
+    resultProcessing = Boolean.parseBoolean(props.getProperty(RESULT_PROCESS_PROPERTY,
+        RESULT_PROCESS_PROPERTY_DEFAULT));
+    String portString = props.getProperty(PORT_PROPERTY);
+    indexName = props.getProperty(INDEX_NAME_PROPERTY, INDEX_NAME_PROPERTY_DEFAULT);
+    rangeField = props.getProperty(RANGE_FIELD_NAME_PROPERTY, RANGE_FIELD_NAME_PROPERTY_DEFAULT);
+    keyprefix = "user";
+    if (portString != null) {
+      port = Integer.parseInt(portString);
+    }
+    orderedinserts = props.getProperty(CoreWorkload.INSERT_ORDER_PROPERTY,
+        CommerceWorkload.INSERT_ORDER_PROPERTY_DEFAULT).compareTo("ordered") == 0;
+    if (props.getProperty(HOST_PROPERTY) != null) {
+      host = props.getProperty(HOST_PROPERTY);
+    }
+    if (redisTimeoutStr != null) {
+      timeout = Integer.parseInt(redisTimeoutStr);
+    }
+
+    JedisPoolConfig poolConfig = new JedisPoolConfig();
+    int poolMaxTotal = Integer.parseInt(props.getProperty(CLIENT_POOL_MAX_PROPERTY, CLIENT_POOL_MAX_PROPERTY_DEFAULT));
+    poolConfig.setMaxTotal(poolMaxTotal);
+    if (clusterEnabled) {
+      Set<HostAndPort> startNodes = new HashSet<>();
+      jedisPool = new JedisPool(poolConfig, host, port, timeout, password);
+      List<Object> clusterNodes = jedisPool.getResource().clusterSlots();
+      for (Object slotDetail : clusterNodes
+      ) {
+        List<Object> nodeDetail = (List<Object>) ((List<Object>) slotDetail).get(2);
+        String h = new String((byte[]) nodeDetail.get(0));
+        long p = (long) nodeDetail.get(1);
+        System.err.println(h + " : " + p);
+        startNodes.add(new HostAndPort(h, (int) p));
+      }
+      jedisCluster = new JedisCluster(startNodes, timeout, timeout, 5, password, poolConfig);
+    } else {
+      jedisPool = new JedisPool(poolConfig, host, port, timeout, password);
+    }
+
+    fieldCount = Integer.parseInt(props.getProperty(
+        CoreWorkload.FIELD_COUNT_PROPERTY, CoreWorkload.FIELD_COUNT_PROPERTY_DEFAULT));
+    fieldPrefix = props.getProperty(
+        CoreWorkload.FIELD_NAME_PREFIX, CoreWorkload.FIELD_NAME_PREFIX_DEFAULT);
+
+    if (indexingHashesEnabled) {
+      try (Jedis setupPoolConn = getResource()) {
+        coreWorkload = props.getProperty("workload").compareTo("site.ycsb.workloads.CoreWorkload") == 0;
+        if (coreWorkload) {
+          setupPoolConn.sendCommand(RediSearchCommands.CREATE,
+              coreWorkloadIndexCreateCmdArgs(indexName).toArray(String[]::new));
+        } else {
+          commerceTagFields = new TreeSet<>();
+          commerceTextFields = new TreeSet<>();
+          nonIndexFields = new TreeSet<>();
+          String[] tagFields = props.getProperty(INDEXED_TAG_FIELDS_PROPERTY,
+              INDEXED_TAG_FIELDS_PROPERTY_DEFAULT).split(",");
+          if (tagFields.length > 0) {
+            for (String tagFieldName : tagFields
+            ) {
+              commerceTagFields.add(tagFieldName);
+            }
+          }
+          for (String textFieldName :
+              props.getProperty(INDEXED_TEXT_FIELDS_PROPERTY, INDEXED_TEXT_FIELDS_PROPERTY_DEFAULT).split(",")
+          ) {
+            commerceTextFields.add(textFieldName);
+          }
+          for (String fieldName :
+              props.getProperty(CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY,
+                  CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY_DEFAULT).split(",")
+          ) {
+            nonIndexFields.add(fieldName);
+          }
+          setupPoolConn.sendCommand(RediSearchCommands.CREATE,
+              commerceWorkloadIndexCreateCmdArgs(indexName).toArray(String[]::new));
+        }
+      } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+        if (!e.getMessage().contains("Index already exists")) {
+          throw new DBException(e.getMessage());
+        }
+      }
+    }
+  }
+
+  private List<String> commerceWorkloadIndexCreateCmdArgs(String iName) {
+    List<String> args = new ArrayList<>(Arrays.asList(iName, "ON", "HASH",
+        "NOFIELDS", "NOFREQS", "NOOFFSETS",
+        "SCHEMA", "productScore", "NUMERIC", "SORTABLE", "NOINDEX"));
+    Iterator iterator = commerceTagFields.iterator();
+//    while (iterator.hasNext()) {
+//      args.addAll(new ArrayList<>(Arrays.asList(iterator.next().toString(), "TAG")));
+//    }
+    iterator = commerceTextFields.iterator();
+    while (iterator.hasNext()) {
+      args.addAll(new ArrayList<>(Arrays.asList(iterator.next().toString(), "TEXT", "NOSTEM", "SORTABLE")));
+    }
+//    iterator = nonIndexFields.iterator();
+//    while (iterator.hasNext()) {
+//      args.addAll(new ArrayList<>(Arrays.asList(iterator.next().toString(), "TEXT", "NOINDEX")));
+//    }
+    return args;
+  }
+
+  private Jedis getResource() {
+    if (clusterEnabled) {
+      return jedisCluster.getConnectionFromSlot(ThreadLocalRandom.current()
+          .nextInt(JedisCluster.HASHSLOTS));
+    } else {
+      return jedisPool.getResource();
+    }
+  }
+
+  private Jedis getResource(String key) {
+    if (clusterEnabled) {
+      return jedisCluster.getConnectionFromSlot(JedisClusterCRC16.getSlot(key));
+    } else {
+      return jedisPool.getResource();
+    }
+  }
+
+  /**
+   * Helper method to create the FT.CREATE command arguments, used to add a secondary index definition to Redis.
+   *
+   * @param iName Index name
+   * @return
+   */
+  private List<String> coreWorkloadIndexCreateCmdArgs(String iName) {
+    List<String> args = new ArrayList<>(Arrays.asList(iName, "ON", "HASH",
+        "SCHEMA", rangeField, "NUMERIC", "SORTABLE"));
+    return args;
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+    try {
+      if (clusterEnabled) {
+        jedisCluster.close();
+      } else {
+        jedisPool.close();
+      }
+    } catch (Exception e) {
+      throw new DBException("Closing connection failed.", e);
+    }
+  }
+
+  /*
+   * Calculate a hash for a key to store it in an index. The actual return value
+   * of this function is not interesting -- it primarily needs to be fast and
+   * scattered along the whole space of int's. In a real world scenario one
+   * would probably use the ASCII values of the keys.
+   */
+  private int hash(String key) {
+    if (orderedinserts) {
+      return Integer.parseInt(key.replaceAll(keyprefix, ""));
+    } else {
+      return key.hashCode();
+    }
+  }
+
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+                     Map<String, ByteIterator> result) {
+    Status res = Status.OK;
+    try (Jedis j = getResource(key)) {
+      if (fields == null) {
+        Map<String, String> reply = j.hgetAll(key);
+        extractHGetAllResults(result, reply);
+      } else {
+        List<String> reply = j.hmget(key, fields.toArray(new String[fields.size()]));
+        if (resultProcessing) {
+          extractHmGetResults(fields, result, reply);
+          res = result.isEmpty() ? Status.NOT_FOUND : Status.OK;
+        }
+      }
+    } catch (Exception e) {
+      res = Status.ERROR;
+    }
+    return res;
+  }
+
+  private void extractHGetAllResults(Map<String, ByteIterator> result, Map<String, String> reply) {
+    StringByteIterator.putAllAsByteIterators(result, reply);
+  }
+
+  private void extractHmGetResults(Set<String> fields, Map<String, ByteIterator> result, List<String> values) {
+    Iterator<String> fieldIterator = fields.iterator();
+    Iterator<String> valueIterator = values.iterator();
+
+    while (fieldIterator.hasNext() && valueIterator.hasNext()) {
+      result.put(fieldIterator.next(),
+          new StringByteIterator(valueIterator.next()));
+    }
+  }
+
+  @Override
+  public Status insert(String table, String key,
+                       Map<String, ByteIterator> values) {
+    if (coreWorkload) {
+      values.put(rangeField, new StringByteIterator(String.valueOf(hash(key))));
+    }
+    try (Jedis j = getResource(key)) {
+      j.hset(key, StringByteIterator.getStringMap(values));
+      return Status.OK;
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(String table, String key) {
+    try (Jedis j = getResource(key)) {
+      j.del(key);
+      return Status.OK;
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status update(String table, String key,
+                       Map<String, ByteIterator> values) {
+    try (Jedis j = getResource(key)) {
+      j.hset(key, StringByteIterator.getStringMap(values));
+      return Status.OK;
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> result) {
+
+    List<Object> resp;
+    try (Jedis j = getResource()) {
+      resp = (List<Object>) j.sendCommand(RediSearchCommands.SEARCH,
+          searchCommandArgs(indexName, queryPair, onlyinsale, pagePair, fields));
+      if (resultProcessing) {
+        processFTSearchReply(result, resp);
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return Status.OK;
+  }
+
+  private void processFTSearchReply(Vector<HashMap<String, ByteIterator>> result, List<Object> resp) {
+    for (int i = 1; i < resp.size(); i += 2) {
+      List<byte[]> docFields = (List<byte[]>) resp.get(i + 1);
+      HashMap<String, ByteIterator> values = new HashMap<>();
+      for (int k = 2; k < docFields.size(); k += 2) {
+        values.put(SafeEncoder.encode(docFields.get(k)),
+            new StringByteIterator(SafeEncoder.encode(docFields.get(k + 1))));
+        result.add(values);
+      }
+    }
+  }
+
+  private String[] searchCommandArgs(String idxName, Pair<String, String> queryPair, boolean onlyinsale,
+                                     Pair<Integer, Integer> pagePair, HashSet<String> rFields) {
+    int returnFieldsCount = fieldCount;
+    if (rFields != null) {
+      returnFieldsCount = rFields.size();
+    }
+    String fieldName = queryPair.getValue0();
+    String query;
+    if (commerceTextFields.contains(fieldName)) {
+      String[] words = queryPair.getValue1().split(" ");
+      query = words[0] + " " + words[1];
+    } else {
+      String tagValue = queryPair.getValue1().replaceAll(" ", "\\\\ ");
+      query = String.format("@%s:{%s}", fieldName, tagValue);
+    }
+
+    ArrayList<String> searchCommandArgs = new ArrayList<>(Arrays.asList(idxName,
+        query,
+        "VERBATIM",
+        "SORTBY", "productScore",
+        "LIMIT", String.valueOf(pagePair.getValue0()),
+        String.valueOf(pagePair.getValue0() + pagePair.getValue1() - 1)));
+    if (rFields != null) {
+      searchCommandArgs.addAll(Arrays.asList("RETURN", String.valueOf(returnFieldsCount)));
+      for (String field : rFields) {
+        searchCommandArgs.add(field);
+      }
+    }
+    return searchCommandArgs.toArray(String[]::new);
+  }
+
+  /**
+   * As you will see below, there is the need to model a scan operation within different records,
+   * in which we scan records in order, starting at a randomly chosen record key.
+   * The number of records to scan is randomly chosen.
+   * <p>
+   * To model this within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
+   * for the search query, and set +inf as the upper limit of the search result.
+   * The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.
+   * <p>
+   * Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly chosen starting key, with
+   * variadic record count replies.
+   * <p>
+   * Example FT.SEARCH command that a scan operation would generate.
+   * "FT.SEARCH" "index" "*" \
+   * "FILTER" __score__ "-6.17979116E8" +inf \
+   * "LIMIT" "0" "54" \
+   * "RETURN" "10" \
+   * "field0" "field1" "field2" "field3" "field4" \
+   * "field5" "field6" "field7" "field8" "field9"
+   *
+   * @param table       The name of the table
+   * @param startkey    The record key of the first record to read.
+   * @param recordcount The number of records to read
+   * @param fields      The list of fields to read, or null for all of them
+   * @param result      A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
+   * @return
+   */
+  @Override
+  public Status scan(String table, String startkey, int recordcount,
+                     Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    try (Jedis j = getResource(startkey)) {
+      int rangeStart = hash(startkey);
+      int rangeEnd = Integer.MAX_VALUE;
+      List<Object> resp = (List<Object>) j.sendCommand(RediSearchCommands.AGGREGATE,
+          scanCommandArgs(indexName, recordcount, rangeStart, rangeEnd, fields));
+      if (resultProcessing) {
+        long totalResult = (long) resp.get(0);
+        for (int i = 1; i < resp.size(); i++) {
+          List<byte[]> docFields = (List<byte[]>) resp.get(i);
+          HashMap<String, ByteIterator> values = new HashMap<>();
+          for (int k = 2; k < docFields.size(); k += 2) {
+            values.put(SafeEncoder.encode(docFields.get(k)),
+                new StringByteIterator(SafeEncoder.encode(docFields.get(k + 1))));
+            result.add(values);
+          }
+        }
+      }
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+    return Status.OK;
+  }
+
+  /**
+   * Helpher method to create the FT.SEARCH args used for the scan() operation.
+   *
+   * @param iName      RediSearch index name
+   * @param rCount     return count
+   * @param rangeStart numeric range start
+   * @param rangeEnd   numeric range end
+   * @param rFields    fields to retrieve
+   * @return
+   */
+  private String[] scanCommandArgs(String iName, int rCount, int rangeStart, int rangeEnd, Set<String> rFields) {
+    int returnFieldsCount = fieldCount;
+    if (rFields != null) {
+      returnFieldsCount = rFields.size();
+    }
+    ArrayList<String> scanSearchArgs = new ArrayList<>(Arrays.asList(iName,
+        String.format("@%s:[%d +inf]", rangeField, rangeStart),
+        "LIMIT", "0", String.valueOf(rCount - 1), "FIRST"));
+    scanSearchArgs.addAll(Arrays.asList("SORTBY", "2", String.format("@%s", rangeField), "DESC"));
+    scanSearchArgs.addAll(Arrays.asList("LOAD", String.valueOf(returnFieldsCount)));
+
+    if (rFields == null) {
+      for (int i = 0; i < returnFieldsCount; i++) {
+        scanSearchArgs.add(String.format("%s%d", fieldPrefix, i));
+      }
+    } else {
+      for (String field : rFields) {
+        scanSearchArgs.add(field);
+      }
+    }
+    return scanSearchArgs.toArray(String[]::new);
+  }
+
+  /**
+   * RediSearch Protocol commands.
+   */
+  public enum RediSearchCommands implements ProtocolCommand {
+
+    CREATE,
+    AGGREGATE,
+    SEARCH;
+
+    private final byte[] raw;
+
+    RediSearchCommands() {
+      this.raw = SafeEncoder.encode("FT." + name());
+    }
+
+    @Override
+    public byte[] getRaw() {
+      return this.raw;
+    }
+  }
+}

--- a/redisearch/src/main/java/site/ycsb/db/package-info.java
+++ b/redisearch/src/main/java/site/ycsb/db/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://redis.io/">Redis</a>.
+ */
+package site.ycsb.db;
+

--- a/redisjson2/README.md
+++ b/redisjson2/README.md
@@ -1,0 +1,254 @@
+<!--
+Copyright (c) 2021 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Redis with RediSearch[https://github.com/RediSearch/RediSearch] module enabled. 
+
+### 1. Start Redis with RediSearch 
+
+```
+(...)
+```
+
+### 2. Install Java and Maven
+
+### 3. Set Up YCSB
+
+Git clone YCSB and compile:
+
+    git clone http://github.com/RediSearch/YCSB.git --branch redisearch2.support
+    cd YCSB
+    mvn -pl site.ycsb:redisearch-binding -am clean package
+
+### 4. Provide Redis Connection Parameters
+    
+Set host, port, password, and cluster mode in the workload you plan to run. 
+
+- `redisearch.host`
+- `redisearch.port`
+- `redisearch.password`
+  * Don't set the password if redis auth is disabled.
+- `redisearch.cluster`
+  * Set the cluster parameter to `true` if redis cluster mode is enabled.
+  * Default is `false`.
+
+Or, you can set configs with the shell command, EG:
+
+    ./bin/ycsb load redisjson2 -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+
+### 5. Load data and run the tests
+
+All six workloads have a data set that is similar. Workloads D and E insert records during the test run. Thus, to keep the database size consistent, we recommend the following sequence:
+
+Load the database, using workload A’s parameter file (workloads/workloada) and the “-load” switch to the client.
+
+- Run workload A (using workloads/workloada and “-t”) for a variety of throughputs.
+
+- Run workload B (using workloads/workloadb and “-t”) for a variety of throughputs.
+
+- Run workload C (using workloads/workloadc and “-t”) for a variety of throughputs.
+
+- Run workload F (using workloads/workloadf and “-t”) for a variety of throughputs.
+
+- Run workload D (using workloads/workloadd and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+- Delete the data in the database.
+
+- Reload the database, using workload E’s parameter file (workloads/workloade) and the "-load switch to the client.
+
+- Run workload E (using workloads/workloade and “-t”) for a variety of throughputs. This workload inserts records, increasing the size of the database.
+
+
+```bash
+# load, run A, B, C, F, D, (flushdb), load, E
+./bin/ycsb load redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputLoad.txt
+
+./bin/ycsb run redisearch -s -P workloads/workloada -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunA.txt
+./bin/ycsb run redisearch -s -P workloads/workloadb -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunB.txt
+./bin/ycsb run redisearch -s -P workloads/workloadc -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunC.txt
+./bin/ycsb run redisearch -s -P workloads/workloadf -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunF.txt
+./bin/ycsb run redisearch -s -P workloads/workloadd -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=8" > outputRunD.txt
+
+redis-cli flushall
+
+./bin/ycsb load redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=32" -p "recordcount=30000000" -p "operationcount=30000000" > outputLoad.txt
+./bin/ycsb run redisearch -s -P workloads/workloade -p "redisearch.host=127.0.0.1" -p "redisearch.port=6379" -p "threadcount=32" -p "recordcount=30000000" -p "operationcount=30000000" > outputRunE.txt
+```
+
+
+## An overall picture, and the RediSearch use-case
+
+### Default workloads
+
+By default, there are 6 default independent workloads, in the core package. Prior to describing the workloads, we will describe the dataset that is similar across all six.
+
+#### RediSearch default workloads dataset representation
+
+All six workloads have a data set that is similar, composed for N distinct records.
+
+Each record is identified by a primary key, which is a string like “user234123”.
+
+
+Within each record, by default, we have 10 fields, named field0, field1 and so on. The values of each field are a random string of ASCII characters of length L.
+By default, we construct 1,000-byte records by using F = 10 fields, each of L = 100 bytes.
+
+Specifically, within Redis, we model each record as a HASH, as showcased below.
+
+Apart from the default fields, within each document we add a numeric `__score__` field, used within the `scan()` workloads for sorting. 
+The value of the `__score__` field is given by computing a hash of the key name.
+
+
+```bash
+127.0.0.1:6379> hgetall user6873002678636213555
+ 1) "field6"
+ 2) "1;x.H{=8`73<+H71+t6W=99\"8(f>Tm*;<4K16?r#?:'<d.!<7\"6!I#'_=(M3!-(-6n>Q99:>8)< P+ 1x2\\%/M\x7f'W%%Sy\"^u%?n+"
+ 3) "field1"
+ 4) ")C3,U!6@-(G!:V5<<d9)j#\\+9&:5S#\":d;&v?>h;<&3)|&\".2< <O{%(:<R90\">4[s-Y'84 '!61%.=(.9R{9Aw*Cc-H=$H'*!,,"
+ 5) "field7"
+ 6) ".(v#Uq'2>=@5%E),*`9]',V->1.9'*&@s6L7:>>,Js:V)17:$Y58^-(Qk?Aq6 r\"Zm Ee&Ag%S=)I%6),)Jy ),=9r5O+%Ug)=x+"
+ 7) "field9"
+ 8) " &f2R).A;43f>Vq;3,<W/9$d#G=,\"4*H%)-(>30 7&4 p;)(=/<<Ny(6~670,(*4N''Ze&&2:P5$Vm728<Ks0 4!C?3;:48>'R}*"
+ 9) "field4"
+10) "4)t&S+08$) f V1)Qm,>,,;6&2`\"!n=Wu#V)4-.=I;5@q+U+$Gq.Ou1H{3Ma<[k.X} .:![\x7f,..8C;\"Ns:Vy<8t6B1<Uq\"E)\" 0$"
+11) "field8"
+12) "8H+ 9d\"^/%968!|;2|+Q-=;f9?`&T%%Sc;>06Bk*]%=U',)8&W5-D+)-*=B)9&p2T}-^'5Kq%(8-K5634 *$)E=1.`+]{?Vi##l+"
+13) "field5"
+14) "\"Sa/W\x7f5&j6C1:5j:R-$8: =(5)&94b(,r6L')+h+G=!8b7T95#>$=:=%t;U?;]+-%(+Yu7P'7#:9<>=Zi?Ok&%<()p&.&-M5<Ow>"
+15) "field3"
+16) "+H9-8t>5|;]}22|&>x$T38,4#\"f3#00\\30R71.*!8n,_i'>:,-f\"Sk:Q9% $?Fa:Q%:E',S;0.h3[);J-$G\x7f-8x\"]'?V!$50>,f6"
+17) "field0"
+18) "23,!Za?Uq?T5-9<=<. B)!2$?$4</h=?$$2`:$x7T%'':<L%+, -]e3^m?\"`16.!I{1.j6R}\"/:<\"4;Dm\"/$>.`6Vs;W7(>l/7z#"
+19) "field2"
+20) "5Dk'Qw==04$*9,b;B+!])$7h44(-8~?H'1!t>D9%?$>5x3Z/%Ek6Kg<H+()6,\".8\"~7W!(F=&7 (Vc4]q#Im7?\"50 ,Qk6Zs4#n:"
+21) "__score__"
+22) "1.770379916E9"
+```
+
+#### Scanning based on RediSearch secondary index…
+
+As you will see below, there is the need to model a scan operation within different records, in which we scan records in order, starting at a randomly chosen record key. 
+The number of records to scan is randomly chosen. 
+
+ To model the scan operation within RedisSearch, we use FT.SEARCH and use computed hash score from the key name as the lower limit
+for the search query, and set +inf as the upper limit of the search result.
+
+ The provided record count is passed via the LIMIT 0 <recordcound> FT.SEARCH argument.
+
+ Together, the above FT.SEARCH command arguments fully comply with a sorted, randomly chosen starting key, with
+ variadic record count replies.
+ 
+Example FT.SEARCH command that a scan operation would generate.
+
+```bash
+127.0.0.1:6379> "FT.SEARCH" "index" "@__score__:[7.39074446E8 inf]" "LIMIT" "0" "13" "RETURN" "10" "field0" "field1" "field2" "field3" "field4" "field5" "field6" "field7" "field8" "field9"
+ 1) (integer) 350
+ 2) "user3232700585171816769"
+ 3)  1) "field0"
+     2) "6;l+P=;R'8F/:Vi77:,S+-5j&8|?,,,0(%,x9_#%?z5+l/4*?1 -'&)@!$8n=^w+Js*)t;S/,<(4J#4=:=8x$[w;X) J#4 r9T90"
+     3) "field1"
+     4) "<4.5]u'Gm/!\"3Bs#%d!U%(Z)1Z-, h3?r'/6 581%x3A55Qs*B34%~ ) )^w-O=0Ok=D=1?4?%v+5(9]+(T=!-b\" x#@o\">6\"$p7"
+     (...)
+     (...)
+    19) "field9"
+    20) "8\"d2Dw7Z)8L?(D75820V?4;h*-*8,4:V+8!8:+>9,(05r3F!=(r2I#)D+)Xm5!*-Xa:O7-987Ti?Ce(8(=]' Mm+Y)*S%5K#7(00"
+ 4) "user1000385178204227360"
+ 5)  1) "field0"
+     2) "'1r;A+(Sc#&:4-x:7|6D-(Z}2<0%66>$ 85v(/84Wo3'\"=3.!0p*+2%#,<-f9+|?7p#Y{/60*5|\"R1/Qk\">z##68F/-*<)*`+Xe*"
+     (...)
+     (...)
+(...)
+(...)
+```
+  
+
+### Workload operation details
+
+#### Workload A: Update heavy workload
+
+- read/scan/update/insert ratio: 50/0/50/0
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+- Application example: Session store recording recent actions
+
+#### Workload B: Read mostly workload
+
+- read/scan/update/insert ratio: 95/0/5/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: photo tagging; add a tag is an update, but most operations are to read tags
+
+#### Workload C: Read only
+
+- read/scan/update/insert ratio: 100/0/0/0
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload D: Read latest workload
+
+- read/scan/update/insert ratio: 95/0/0/5
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: latest -- new records are inserted, and the most recently inserted records are the most popular.
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user profile cache, where profiles are constructed elsewhere (e.g., Hadoop)
+
+#### Workload E: Short ranges
+
+- read/scan/update/insert ratio: 0/95/0/5
+
+- maxscanlength=100
+
+- scanlengthdistribution=uniform
+
+- This is a 95% read workload, in which short ranges of records are queried, instead of individual records.
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: threaded conversations, where each scan is for the posts in a given thread (assumed to be clustered by thread id)
+
+#### Workload F: Read-modify-write workload
+
+- read/scan/update/insert/readmodifywrite ratio: 50/0/0/0/50
+
+- Default data size: 1 KB records (10 fields, 100 bytes each, plus key)
+
+- Request distribution: Zipfian (some items are more popular than others, according to a Zipfian distribution)
+
+- Workload: Core ( site.ycsb.workloads.CoreWorkload )
+
+- Application example: user database, where user records are read and modified by the user or to record user activity.

--- a/redisjson2/pom.xml
+++ b/redisjson2/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+  
+  <artifactId>redisjson2-binding</artifactId>
+  <name>RedisJSON v2 DB Binding</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>${jedis.redisearch.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-pool2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-pool2</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.11.2</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>2.11.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ignite</groupId>
+      <artifactId>ignite-log4j2</artifactId>
+      <version>${ignite.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.griddb</groupId>
+      <artifactId>gridstore</artifactId>
+      <version>4.0.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.2.4</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/redisjson2/src/main/java/site/ycsb/db/CommerceDocument.java
+++ b/redisjson2/src/main/java/site/ycsb/db/CommerceDocument.java
@@ -1,0 +1,92 @@
+package site.ycsb.db;
+
+
+//
+//  {
+//    "productScore": 0.06580772031001791,
+//      "image": "https: //pigment.github.io/fake-logos/logos/medium/color/10.png",
+//      "creator": "Raphael",
+//      "code": "1591839259749",
+//      "color": "teal",
+//      "productName": "OF 12 COLOURED PENCILS ALICEBLUE PACK",
+//      "inSale": "0",
+//      "material": "Granite",
+//      "price": "60.41",
+//      "inStock": "1",
+//      "shipsFrom": "nor",
+//      "department": "Baby   Health",
+//      "currencyCode": "UAH",
+//      "brand": "Ryan Group",
+//      "productDescription": "User-friendly discrete concept",
+//      "stockCount": "163"
+//  }
+
+import site.ycsb.ByteIterator;
+import site.ycsb.StringByteIterator;
+
+import java.util.HashMap;
+
+/**
+ * Ecommerce document class for RedisJSON YCSB.
+ */
+public class CommerceDocument {
+  protected String productScore;
+  protected String image;
+  protected String creator;
+  protected String code;
+  protected String color;
+  protected String productName;
+  protected String inSale;
+  protected String material;
+  protected String price;
+  protected String inStock;
+  protected String shipsFrom;
+  protected String department;
+  protected String currencyCode;
+  protected String brand;
+  protected String productDescription;
+  protected String stockCount;
+
+  public HashMap<String, ByteIterator> getFieldMap() {
+    HashMap<String, ByteIterator> values = new HashMap<>();
+    values.put("productScore", new StringByteIterator(this.productScore));
+    values.put("image", new StringByteIterator(this.image));
+    values.put("creator", new StringByteIterator(this.creator));
+    values.put("code", new StringByteIterator(this.code));
+    values.put("color", new StringByteIterator(this.color));
+    values.put("productName", new StringByteIterator(this.productName));
+    values.put("inSale", new StringByteIterator(this.inSale));
+    values.put("material", new StringByteIterator(this.material));
+    values.put("price", new StringByteIterator(this.price));
+    values.put("inStock", new StringByteIterator(this.inStock));
+    values.put("shipsFrom", new StringByteIterator(this.shipsFrom));
+    values.put("department", new StringByteIterator(this.department));
+    values.put("currencyCode", new StringByteIterator(this.currencyCode));
+    values.put("brand", new StringByteIterator(this.brand));
+    values.put("productDescription", new StringByteIterator(this.productDescription));
+    values.put("stockCount", new StringByteIterator(this.stockCount));
+    return values;
+  }
+
+  @Override
+  public String toString() {
+    return "CommerceDocument{" +
+        "productScore='" + productScore + '\'' +
+        ", image='" + image + '\'' +
+        ", creator='" + creator + '\'' +
+        ", code='" + code + '\'' +
+        ", color='" + color + '\'' +
+        ", productName='" + productName + '\'' +
+        ", inSale='" + inSale + '\'' +
+        ", material='" + material + '\'' +
+        ", price='" + price + '\'' +
+        ", inStock='" + inStock + '\'' +
+        ", shipsFrom='" + shipsFrom + '\'' +
+        ", department='" + department + '\'' +
+        ", currencyCode='" + currencyCode + '\'' +
+        ", brand='" + brand + '\'' +
+        ", productDescription='" + productDescription + '\'' +
+        ", stockCount='" + stockCount + '\'' +
+        '}';
+  }
+}

--- a/redisjson2/src/main/java/site/ycsb/db/RedisJSONClient.java
+++ b/redisjson2/src/main/java/site/ycsb/db/RedisJSONClient.java
@@ -1,0 +1,486 @@
+/**
+ * Copyright (c) 2021 YCSB contributors. All rights reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ * <p>
+ * RediSearch client binding for YCSB.
+ * <p>
+ * All YCSB records are mapped to a Redis *hash field*.
+ * For scanning we use RediSearch's secondary index capabilities.
+ */
+
+package site.ycsb.db;
+
+import com.google.gson.Gson;
+import org.javatuples.Pair;
+import redis.clients.jedis.*;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+import site.ycsb.*;
+import site.ycsb.workloads.CommerceWorkload;
+import site.ycsb.workloads.CoreWorkload;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * YCSB binding for <a href="https://github.com/RediSearch/RediSearch/">RediSearch</a>.
+ * <p>
+ * See {@code redisearch/README.md} for details.
+ */
+public class RedisJSONClient extends DB {
+
+  /**
+   * Count the number of times initialized to teardown on the last
+   * {@link #cleanup()}.
+   */
+  private static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
+
+  public static final String HOST_PROPERTY = "redis.host";
+  public static final String PORT_PROPERTY = "redis.port";
+  public static final String PASSWORD_PROPERTY = "redis.password";
+  public static final String CLUSTER_PROPERTY = "redis.cluster";
+  public static final String CREATE_FT_INDEX_PROPERTY = "create.search.index";
+  public static final String CLUSTER_PROPERTY_DEFAULT = "false";
+  public static final String CREATE_FT_INDEX_PROPERTY_DEFAULT = "true";
+  public static final String TIMEOUT_PROPERTY = "redis.timeout";
+  public static final String CLIENT_POOL_MAX_PROPERTY = "redis.client.poolmaxsize";
+  public static final String CLIENT_POOL_MAX_PROPERTY_DEFAULT = "1";
+  public static final String INDEX_NAME_PROPERTY = "redis.indexname";
+  public static final String INDEX_NAME_PROPERTY_DEFAULT = "index";
+  public static final String RANGE_FIELD_NAME_PROPERTY = "redis.scorefield";
+  public static final String RANGE_FIELD_NAME_PROPERTY_DEFAULT = "__doc_hash__";
+  public static final String INDEXED_TAG_FIELDS_PROPERTY = "redis.indexedtagfields";
+  public static final String INDEXED_TAG_FIELDS_PROPERTY_DEFAULT = "";
+  public static final String INDEXED_TEXT_FIELDS_PROPERTY = "redis.indexedtextfields";
+  public static final String INDEXED_TEXT_FIELDS_PROPERTY_DEFAULT = "productName";
+  public static final String RESULT_PROCESS_PROPERTY = "redis.enable.resultprocess";
+  public static final String RESULT_PROCESS_PROPERTY_DEFAULT = "true";
+  public static final String ROOT_PATH_PROPERTY = "json.root";
+  /**
+   * The number of YCSB client threads to run.
+   */
+  public static final String THREAD_COUNT_PROPERTY = "threadcount";
+
+  public static final String ROOT_PATH_PROPERTY_DEFAULT = "$";
+  private static final Gson GSON = new Gson();
+
+  private static final boolean INDEX_JSON_ENABLED_PROPERTY_DEFAULT = true;
+  private static final String INDEX_JSON_ENABLED_PROPERTY = "redisjson.indexdocs";
+
+  private static JedisCluster jedisCluster;
+  private static JedisPool jedisPool;
+  private Boolean clusterEnabled;
+  private Boolean createFTIndex;
+  private int fieldCount;
+  private String indexName;
+  private String rangeField;
+  private String rootPath;
+  private boolean orderedinserts;
+  private boolean coreWorkload;
+  private String keyprefix;
+  private Set<String> commerceTagFields;
+  private Set<String> commerceTextFields;
+  private Set<String> nonIndexFields;
+  private boolean resultProcessing;
+
+  /*
+   * @Description: Method to convert Map to JSON String
+   * @param: map Map<String, String>
+   * @return: json String
+   */
+  public static String convert(Map<String, String> map) {
+    String json = GSON.toJson(map);
+    return json;
+  }
+
+
+  @Override
+  public void init() throws DBException {
+    INIT_COUNT.incrementAndGet();
+    Properties props = getProperties();
+    int port = Protocol.DEFAULT_PORT;
+    String host = Protocol.DEFAULT_HOST;
+    int timeout = Protocol.DEFAULT_TIMEOUT;
+
+    final boolean indexingJsonEnabled = Boolean.parseBoolean(props.getProperty(INDEX_JSON_ENABLED_PROPERTY,
+        String.valueOf(INDEX_JSON_ENABLED_PROPERTY_DEFAULT)));
+
+    String redisTimeoutStr = props.getProperty(TIMEOUT_PROPERTY);
+    String password = props.getProperty(PASSWORD_PROPERTY);
+    clusterEnabled = Boolean.parseBoolean(props.getProperty(CLUSTER_PROPERTY, CLUSTER_PROPERTY_DEFAULT));
+    createFTIndex = Boolean.parseBoolean(props.getProperty(CREATE_FT_INDEX_PROPERTY, CREATE_FT_INDEX_PROPERTY_DEFAULT));
+    resultProcessing = Boolean.parseBoolean(props.getProperty(RESULT_PROCESS_PROPERTY,
+        RESULT_PROCESS_PROPERTY_DEFAULT));
+    String portString = props.getProperty(PORT_PROPERTY);
+    indexName = props.getProperty(INDEX_NAME_PROPERTY, INDEX_NAME_PROPERTY_DEFAULT);
+    rootPath = props.getProperty(ROOT_PATH_PROPERTY, ROOT_PATH_PROPERTY_DEFAULT);
+    rangeField = props.getProperty(RANGE_FIELD_NAME_PROPERTY, RANGE_FIELD_NAME_PROPERTY_DEFAULT);
+
+
+    keyprefix = "user";
+    if (portString != null) {
+      port = Integer.parseInt(portString);
+    }
+    orderedinserts = props.getProperty(CoreWorkload.INSERT_ORDER_PROPERTY,
+        CommerceWorkload.INSERT_ORDER_PROPERTY_DEFAULT).compareTo("ordered") == 0;
+    if (props.getProperty(HOST_PROPERTY) != null) {
+      host = props.getProperty(HOST_PROPERTY);
+    }
+    if (redisTimeoutStr != null) {
+      timeout = Integer.parseInt(redisTimeoutStr);
+    }
+
+    if (jedisPool != null) {
+      return;
+    }
+
+    JedisPoolConfig poolConfig = new JedisPoolConfig();
+
+    //get number of threads, and set it to the pool max size
+    int poolMaxTotal = Integer.parseInt(props.getProperty(THREAD_COUNT_PROPERTY, "1"));
+    poolConfig.setMaxTotal(poolMaxTotal);
+    if (clusterEnabled) {
+      Set<HostAndPort> startNodes = new HashSet<>();
+      jedisPool = new JedisPool(poolConfig, host, port, timeout, password);
+      List<Object> clusterNodes = jedisPool.getResource().clusterSlots();
+      for (Object slotDetail : clusterNodes
+      ) {
+        List<Object> nodeDetail = (List<Object>) ((List<Object>) slotDetail).get(2);
+        String h = new String((byte[]) nodeDetail.get(0));
+        long p = (long) nodeDetail.get(1);
+        System.err.println(h + " : " + p);
+        startNodes.add(new HostAndPort(h, (int) p));
+      }
+      jedisCluster = new JedisCluster(startNodes, timeout, timeout, 5, password, poolConfig);
+    } else {
+      jedisPool = new JedisPool(poolConfig, host, port, timeout, password);
+    }
+
+    fieldCount = Integer.parseInt(props.getProperty(
+        CoreWorkload.FIELD_COUNT_PROPERTY, CoreWorkload.FIELD_COUNT_PROPERTY_DEFAULT));
+    if (indexingJsonEnabled) {
+      try (Jedis setupPoolConn = getResource()) {
+        coreWorkload = props.getProperty("workload").compareTo("site.ycsb.workloads.CoreWorkload") == 0;
+        if (coreWorkload) {
+          setupPoolConn.sendCommand(RediSearchCommands.CREATE,
+              coreWorkloadIndexCreateCmdArgs(indexName).toArray(String[]::new));
+        } else {
+          commerceTagFields = new TreeSet<>();
+          commerceTextFields = new TreeSet<>();
+          nonIndexFields = new TreeSet<>();
+          String[] tagFields = props.getProperty(INDEXED_TAG_FIELDS_PROPERTY,
+              INDEXED_TAG_FIELDS_PROPERTY_DEFAULT).split(",");
+          if (tagFields.length > 0) {
+            for (String tagFieldName : tagFields
+            ) {
+              commerceTagFields.add(tagFieldName);
+            }
+          }
+          for (String textFieldName :
+              props.getProperty(INDEXED_TEXT_FIELDS_PROPERTY, INDEXED_TEXT_FIELDS_PROPERTY_DEFAULT).split(",")
+          ) {
+            commerceTextFields.add(textFieldName);
+          }
+          for (String fieldName :
+              props.getProperty(CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY,
+                  CommerceWorkload.NON_INDEXED_FIELDS_SEARCH_PROPERTY_DEFAULT).split(",")
+          ) {
+            nonIndexFields.add(fieldName);
+          }
+          if (createFTIndex) {
+            setupPoolConn.sendCommand(RediSearchCommands.CREATE,
+                commerceWorkloadIndexCreateCmdArgs(indexName).toArray(String[]::new));
+          }
+        }
+      } catch (redis.clients.jedis.exceptions.JedisDataException e) {
+        if (!e.getMessage().contains("Index already exists")) {
+          throw new DBException(e.getMessage());
+        }
+      }
+    }
+
+  }
+
+  private List<String> commerceWorkloadIndexCreateCmdArgs(String iName) {
+    List<String> args = new ArrayList<>(Arrays.asList(iName,
+        "ON", "JSON",
+        "NOFIELDS", "NOFREQS", "NOOFFSETS",
+        "SCHEMA",
+        "$.productScore", "AS", "productScore", "NUMERIC", "SORTABLE", "NOINDEX",
+        "$.productName", "AS", "productName", "TEXT", "NOSTEM", "SORTABLE"));
+
+    return args;
+  }
+
+  private Jedis getResource() {
+    if (clusterEnabled) {
+      return jedisCluster.getConnectionFromSlot(ThreadLocalRandom.current()
+          .nextInt(JedisCluster.HASHSLOTS));
+    } else {
+      return jedisPool.getResource();
+    }
+  }
+
+  private Jedis getResource(String key) {
+    if (clusterEnabled) {
+      return jedisCluster.getConnectionFromSlot(JedisClusterCRC16.getSlot(key));
+    } else {
+      return jedisPool.getResource();
+    }
+  }
+
+  /**
+   * Helper method to create the FT.CREATE command arguments, used to add a secondary index definition to Redis.
+   *
+   * @param iName Index name
+   * @return
+   */
+  private List<String> coreWorkloadIndexCreateCmdArgs(String iName) {
+    List<String> args = new ArrayList<>(Arrays.asList(iName, "ON", "JSON",
+        "SCHEMA", rangeField, "NUMERIC", "SORTABLE"));
+    return args;
+  }
+
+  @Override
+  public void cleanup() throws DBException {
+//    if (jedisPool != null) {
+//      return;
+//    }
+//    try {
+//      if (clusterEnabled) {
+//        jedisCluster.close();
+//      } else {
+//        jedisPool.close();
+//      }
+//    } catch (Exception e) {
+//      throw new DBException("Closing connection failed.", e);
+//    }
+  }
+
+  /*
+   * Calculate a hash for a key to store it in an index. The actual return value
+   * of this function is not interesting -- it primarily needs to be fast and
+   * scattered along the whole space of int's. In a real world scenario one
+   * would probably use the ASCII values of the keys.
+   */
+  private int hash(String key) {
+    if (orderedinserts) {
+      return Integer.parseInt(key.replaceAll(keyprefix, ""));
+    } else {
+      return key.hashCode();
+    }
+  }
+
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+                     Map<String, ByteIterator> result) {
+    Status res = Status.OK;
+    try (Jedis j = getResource(key)) {
+      if (fields == null) {
+        j.getClient().sendCommand(RedisJSONCommands.GET, key);
+      } else {
+        ArrayList<String> jsonGetCommandArgs = new ArrayList<>(Arrays.asList(key));
+        for (String field : fields) {
+          jsonGetCommandArgs.add("$." + field);
+        }
+        j.getClient().sendCommand(RedisJSONCommands.GET, jsonGetCommandArgs.toArray(String[]::new));
+      }
+      String rep = j.getClient().getBulkReply();
+      CommerceDocument obj = GSON.fromJson(rep, CommerceDocument.class);
+      result = obj.getFieldMap();
+    } catch (Exception e) {
+      res = Status.ERROR;
+    }
+    return res;
+  }
+
+
+  @Override
+  public Status insert(String table, String key,
+                       Map<String, ByteIterator> values) {
+    if (coreWorkload) {
+      values.put(rangeField, new StringByteIterator(String.valueOf(hash(key))));
+    }
+    try (Jedis j = getResource(key)) {
+      String pss = String.valueOf(values.get("productScore"));
+      values.remove("productScore");
+      String partialJson = convert(StringByteIterator.getStringMap(values));
+      partialJson = "{\"productScore\": " + pss + " , " + partialJson.substring(1);
+      j.getClient().sendCommand(RedisJSONCommands.SET, key, rootPath, partialJson);
+      if (j.getClient().getStatusCodeReply().compareTo("OK") == 0) {
+        return Status.OK;
+      } else {
+        return Status.ERROR;
+      }
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status delete(String table, String key) {
+    try (Jedis j = getResource(key)) {
+      j.del(key);
+      return Status.OK;
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status update(String table, String key,
+                       Map<String, ByteIterator> values) {
+    try (Jedis j = getResource(key)) {
+      ArrayList<String> jsonGetCommandArgs = new ArrayList<>(Arrays.asList(key));
+      // using iterators
+      Iterator<Map.Entry<String, ByteIterator>> itr = values.entrySet().iterator();
+      Gson gson = new Gson();
+      while (itr.hasNext()) {
+        Map.Entry<String, ByteIterator> entry = itr.next();
+        jsonGetCommandArgs.add("." + entry.getKey());
+        jsonGetCommandArgs.add("\"" + String.valueOf(entry.getValue()) + "\"");
+      }
+      j.getClient().sendCommand(RedisJSONCommands.SET, jsonGetCommandArgs.toArray(String[]::new));
+      if (j.getClient().getStatusCodeReply().compareTo("OK") == 0) {
+        return Status.OK;
+      } else {
+        return Status.ERROR;
+      }
+    } catch (Exception e) {
+      return Status.ERROR;
+    }
+  }
+
+  @Override
+  public Status search(String table,
+                       Pair<String, String> queryPair, boolean onlyinsale,
+                       Pair<Integer, Integer> pagePair,
+                       HashSet<String> fields,
+                       Vector<HashMap<String, ByteIterator>> result) {
+
+    List<Object> resp;
+    try (Jedis j = getResource()) {
+      resp = (List<Object>) j.sendCommand(RediSearchCommands.SEARCH,
+          searchCommandArgs(indexName, queryPair, onlyinsale, pagePair, fields));
+      if (resultProcessing) {
+//        long totalResult = (long) resp.get(0);
+        for (int i = 1; i < resp.size(); i += 2) {
+          String keyname = SafeEncoder.encode((byte[]) resp.get(i));
+          List<byte[]> docDetails = (List<byte[]>) resp.get(i + 1);
+          // Check if the reply includes score field
+          int docStartPos = 0;
+          if (docDetails.size() >= 4) {
+            docStartPos = 2;
+          }
+          String rep = SafeEncoder.encode(docDetails.get(docStartPos + 1));
+          CommerceDocument obj = GSON.fromJson(rep, CommerceDocument.class);
+          result.add(obj.getFieldMap());
+        }
+      }
+    } catch (Exception e) {
+      throw e;
+    }
+    return Status.OK;
+  }
+
+
+  private String[] searchCommandArgs(String idxName, Pair<String, String> queryPair, boolean onlyinsale,
+                                     Pair<Integer, Integer> pagePair, HashSet<String> rFields) {
+    int returnFieldsCount = fieldCount;
+    if (rFields != null) {
+      returnFieldsCount = rFields.size();
+    }
+    String fieldName = queryPair.getValue0();
+    String query;
+    if (commerceTextFields.contains(fieldName)) {
+      String[] words = queryPair.getValue1().split(" ");
+      query = words[0] + " " + words[1];
+    } else {
+      String tagValue = queryPair.getValue1().replaceAll(" ", "\\\\ ");
+      query = String.format("@%s:{%s}", fieldName, tagValue);
+    }
+
+    ArrayList<String> searchCommandArgs = new ArrayList<>(Arrays.asList(idxName,
+        query,
+        "VERBATIM",
+        "SORTBY", "productScore",
+        "LIMIT", String.valueOf(pagePair.getValue0()),
+        String.valueOf(pagePair.getValue0() + pagePair.getValue1() - 1)));
+    if (rFields != null) {
+      searchCommandArgs.addAll(Arrays.asList("RETURN", String.valueOf(returnFieldsCount)));
+      for (String field : rFields) {
+        searchCommandArgs.add(field);
+      }
+    }
+    return searchCommandArgs.toArray(String[]::new);
+  }
+
+  /**
+   * @param table       The name of the table
+   * @param startkey    The record key of the first record to read.
+   * @param recordcount The number of records to read
+   * @param fields      The list of fields to read, or null for all of them
+   * @param result      A Vector of HashMaps, where each HashMap is a set field/value pairs for one record
+   * @return
+   */
+  @Override
+  public Status scan(String table, String startkey, int recordcount,
+                     Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  /**
+   * RediSearch Protocol commands.
+   */
+  public enum RediSearchCommands implements ProtocolCommand {
+
+    CREATE,
+    SEARCH;
+
+    private final byte[] raw;
+
+    RediSearchCommands() {
+      this.raw = SafeEncoder.encode("FT." + name());
+    }
+
+    @Override
+    public byte[] getRaw() {
+      return this.raw;
+    }
+  }
+
+  /**
+   * RedisJSON Protocol commands.
+   */
+  public enum RedisJSONCommands implements ProtocolCommand {
+
+    SET,
+    GET;
+
+    private final byte[] raw;
+
+    RedisJSONCommands() {
+      this.raw = SafeEncoder.encode("JSON." + name());
+    }
+
+    @Override
+    public byte[] getRaw() {
+      return this.raw;
+    }
+  }
+}

--- a/redisjson2/src/main/java/site/ycsb/db/package-info.java
+++ b/redisjson2/src/main/java/site/ycsb/db/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2014, Yahoo!, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://redis.io/">Redis</a>.
+ */
+package site.ycsb.db;
+

--- a/rest/src/main/java/site/ycsb/webservice/rest/RestClient.java
+++ b/rest/src/main/java/site/ycsb/webservice/rest/RestClient.java
@@ -22,11 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 
 import javax.ws.rs.HttpMethod;
@@ -50,6 +46,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 /**
@@ -164,6 +162,22 @@ public class RestClient extends DB {
   @Override
   public Status scan(String table, String startkey, int recordcount, Set<String> fields,
       Vector<HashMap<String, ByteIterator>> result) {
+    return Status.NOT_IMPLEMENTED;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/rest/src/main/java/site/ycsb/webservice/rest/RestClient.java
+++ b/rest/src/main/java/site/ycsb/webservice/rest/RestClient.java
@@ -177,7 +177,9 @@ public class RestClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/rest/src/test/java/site/ycsb/webservice/rest/RestClientTest.java
+++ b/rest/src/test/java/site/ycsb/webservice/rest/RestClientTest.java
@@ -39,6 +39,8 @@ import org.junit.Test;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 /**

--- a/riak/src/main/java/site/ycsb/db/riak/RiakKVClient.java
+++ b/riak/src/main/java/site/ycsb/db/riak/RiakKVClient.java
@@ -587,7 +587,9 @@ public class RiakKVClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/riak/src/main/java/site/ycsb/db/riak/RiakKVClient.java
+++ b/riak/src/main/java/site/ycsb/db/riak/RiakKVClient.java
@@ -25,6 +25,7 @@ import com.basho.riak.client.core.RiakFuture;
 import com.basho.riak.client.core.query.RiakObject;
 import com.basho.riak.client.core.query.indexes.LongIntIndex;
 import com.basho.riak.client.core.util.BinaryValue;
+import org.javatuples.Pair;
 import site.ycsb.*;
 
 import java.io.IOException;
@@ -572,6 +573,22 @@ public class RiakKVClient extends DB {
       System.err.println("Unable to properly shutdown the cluster. Reason: " + e.toString());
       throw new DBException(e);
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   /**

--- a/riak/src/test/java/site/ycsb/db/riak/RiakKVClientTest.java
+++ b/riak/src/test/java/site/ycsb/db/riak/RiakKVClientTest.java
@@ -22,6 +22,8 @@ import java.util.*;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.junit.AfterClass;

--- a/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
+++ b/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
@@ -336,7 +336,9 @@ public class RocksDBClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
+++ b/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
@@ -19,6 +19,8 @@ package site.ycsb.db.rocksdb;
 
 import site.ycsb.*;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import net.jcip.annotations.GuardedBy;
 import org.rocksdb.*;
 import org.slf4j.Logger;
@@ -320,6 +322,22 @@ public class RocksDBClient extends DB {
       LOGGER.error(e.getMessage(), e);
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private void saveColumnFamilyNames() throws IOException {

--- a/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBClientTest.java
+++ b/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBClientTest.java
@@ -19,6 +19,8 @@ package site.ycsb.db.rocksdb;
 
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 import org.junit.*;

--- a/s3/src/main/java/site/ycsb/db/S3Client.java
+++ b/s3/src/main/java/site/ycsb/db/S3Client.java
@@ -34,6 +34,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.*;
@@ -514,5 +516,21 @@ public class S3Client extends DB {
       result.add(resultTemp);
     }
     return Status.OK;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/s3/src/main/java/site/ycsb/db/S3Client.java
+++ b/s3/src/main/java/site/ycsb/db/S3Client.java
@@ -530,7 +530,9 @@ public class S3Client extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/scylla/src/main/java/site/ycsb/db/scylla/ScyllaCQLClient.java
+++ b/scylla/src/main/java/site/ycsb/db/scylla/ScyllaCQLClient.java
@@ -660,7 +660,9 @@ public class ScyllaCQLClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/scylla/src/main/java/site/ycsb/db/scylla/ScyllaCQLClient.java
+++ b/scylla/src/main/java/site/ycsb/db/scylla/ScyllaCQLClient.java
@@ -25,6 +25,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -646,4 +648,19 @@ public class ScyllaCQLClient extends DB {
     return Status.ERROR;
   }
 
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
+  }
 }

--- a/scylla/src/test/java/site/ycsb/db/scylla/ScyllaCQLClientTest.java
+++ b/scylla/src/test/java/site/ycsb/db/scylla/ScyllaCQLClientTest.java
@@ -34,6 +34,8 @@ import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;

--- a/seaweedfs/src/main/java/site/ycsb/db/seaweed/SeaweedClient.java
+++ b/seaweedfs/src/main/java/site/ycsb/db/seaweed/SeaweedClient.java
@@ -326,7 +326,9 @@ public class SeaweedClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/seaweedfs/src/main/java/site/ycsb/db/seaweed/SeaweedClient.java
+++ b/seaweedfs/src/main/java/site/ycsb/db/seaweed/SeaweedClient.java
@@ -27,18 +27,15 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
@@ -315,6 +312,22 @@ public class SeaweedClient extends DB {
     JsonGenerator jsonGenerator = jsonFactory.createJsonGenerator(writer);
     MAPPER.writeTree(jsonGenerator, node);
     return writer.toString();
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/solr7/src/main/java/site/ycsb/db/solr7/SolrClient.java
+++ b/solr7/src/main/java/site/ycsb/db/solr7/SolrClient.java
@@ -342,7 +342,9 @@ public class SolrClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/solr7/src/main/java/site/ycsb/db/solr7/SolrClient.java
+++ b/solr7/src/main/java/site/ycsb/db/solr7/SolrClient.java
@@ -21,6 +21,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 
 import org.apache.solr.client.solrj.SolrQuery;
@@ -326,6 +328,22 @@ public class SolrClient extends DB {
       break;
     }
     return responseStatus;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/solr7/src/test/java/site/ycsb/db/solr7/SolrClientBaseTest.java
+++ b/solr7/src/test/java/site/ycsb/db/solr7/SolrClientBaseTest.java
@@ -20,6 +20,8 @@ package site.ycsb.db.solr7;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.workloads.CoreWorkload;
 import org.apache.solr.client.solrj.embedded.JettyConfig;

--- a/tablestore/src/main/java/site/ycsb/db/tablestore/TableStoreClient.java
+++ b/tablestore/src/main/java/site/ycsb/db/tablestore/TableStoreClient.java
@@ -20,6 +20,7 @@ package site.ycsb.db.tablestore;
 import java.util.*;
 import java.util.function.*;
 
+import org.javatuples.Pair;
 import site.ycsb.*;
 
 import com.alicloud.openservices.tablestore.*;
@@ -271,6 +272,22 @@ public class TableStoreClient extends DB {
       LOGGER.error(e);
       return Status.ERROR;
     }
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
 }

--- a/tablestore/src/main/java/site/ycsb/db/tablestore/TableStoreClient.java
+++ b/tablestore/src/main/java/site/ycsb/db/tablestore/TableStoreClient.java
@@ -286,7 +286,9 @@ public class TableStoreClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
+++ b/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
@@ -16,6 +16,7 @@
  */
 package site.ycsb.db;
 
+import org.javatuples.Pair;
 import site.ycsb.*;
 import org.tarantool.TarantoolConnection16;
 import org.tarantool.TarantoolConnection16Impl;
@@ -148,5 +149,21 @@ public class TarantoolClient extends DB {
     }
     return Status.OK;
 
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 }

--- a/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
+++ b/tarantool/src/main/java/site/ycsb/db/TarantoolClient.java
@@ -163,7 +163,9 @@ public class TarantoolClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 }

--- a/voltdb/src/main/java/site/ycsb/db/voltdb/VoltClient4.java
+++ b/voltdb/src/main/java/site/ycsb/db/voltdb/VoltClient4.java
@@ -305,7 +305,9 @@ public class VoltClient4 extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
   

--- a/voltdb/src/main/java/site/ycsb/db/voltdb/VoltClient4.java
+++ b/voltdb/src/main/java/site/ycsb/db/voltdb/VoltClient4.java
@@ -26,11 +26,7 @@ package site.ycsb.db.voltdb;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +41,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.db.voltdb.sortedvolttable.VoltDBTableSortedMergeWrangler;
 
 /**
@@ -293,6 +291,22 @@ public class VoltClient4 extends DB {
       buf.position(off + len);
     }
     return result;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
   
   private static class StaticHolder {

--- a/voltdb/src/test/java/site/ycsb/db/voltdb/test/VoltDBClientTest.java
+++ b/voltdb/src/test/java/site/ycsb/db/voltdb/test/VoltDBClientTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assume.assumeNoException;
 import site.ycsb.ByteIterator;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.db.voltdb.ConnectionHelper;
 import site.ycsb.db.voltdb.VoltClient4;

--- a/workloads/workload-ecommerce
+++ b/workloads/workload-ecommerce
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.15
+searchproportion=0.45
+updateproportion=0.40
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-0percent-updates
+++ b/workloads/workload-ecommerce-0percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.35
+searchproportion=0.65
+updateproportion=0.0
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-100percent-insert
+++ b/workloads/workload-ecommerce-100percent-insert
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.0
+searchproportion=0.0
+updateproportion=0.0
+insertproportion=1.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-100percent-reads
+++ b/workloads/workload-ecommerce-100percent-reads
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=1.0
+searchproportion=0.0
+updateproportion=0.0
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-100percent-searches
+++ b/workloads/workload-ecommerce-100percent-searches
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.0
+searchproportion=1.0
+updateproportion=0.0
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-10percent-updates
+++ b/workloads/workload-ecommerce-10percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.30
+searchproportion=0.60
+updateproportion=0.10
+insertproportion=0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-20percent-updates
+++ b/workloads/workload-ecommerce-20percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.25
+searchproportion=0.55
+updateproportion=0.20
+insertproportion=0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-30percent-updates
+++ b/workloads/workload-ecommerce-30percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.20
+searchproportion=0.50
+updateproportion=0.30
+insertproportion=0.00
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-40percent-updates
+++ b/workloads/workload-ecommerce-40percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.15
+searchproportion=0.45
+updateproportion=0.40
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/workloads/workload-ecommerce-50percent-updates
+++ b/workloads/workload-ecommerce-50percent-updates
@@ -1,0 +1,52 @@
+# Copyright (c) 2010 Yahoo! Inc. All rights reserved.                                                                                                                             
+#                                                                                                                                                                                 
+# Licensed under the Apache License, Version 2.0 (the "License"); you                                                                                                             
+# may not use this file except in compliance with the License. You                                                                                                                
+# may obtain a copy of the License at                                                                                                                                             
+#                                                                                                                                                                                 
+# http://www.apache.org/licenses/LICENSE-2.0                                                                                                                                      
+#                                                                                                                                                                                 
+# Unless required by applicable law or agreed to in writing, software                                                                                                             
+# distributed under the License is distributed on an "AS IS" BASIS,                                                                                                               
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or                                                                                                                 
+# implied. See the License for the specific language governing                                                                                                                    
+# permissions and limitations under the License. See accompanying                                                                                                                 
+# LICENSE file.                                                                                                                                                                   
+
+# Yahoo! Cloud System Benchmark
+# Workload Ecommerce: Search and Read heavy workload
+#   Application example: Ecommerce website with:
+#                        - PDP: Product display pages being associated with read queries.
+#                        - PLP: Product listing pages being associated with search queries.
+#                        - Backoffice: Product updates and product inserts being showcase by update/insert queries.
+#
+#                        
+#   Read/Update/Search/Insert ratio: 15/0/85/0
+#   Default data size: 500 B records, plus key
+#   Request distribution: zipfian
+
+# The UCI online retail file contains product names retrieved from the open
+# benchmark https://archive.ics.uci.edu/ml/datasets/Online+Retail+II
+dictfile=./bin/uci_online_retail.csv
+recordcount=1000
+operationcount=1000
+workload=site.ycsb.workloads.CommerceWorkload
+
+nonindexedfields=code,image,price,currencyCode,stockCount,creator,shipsFrom,brand,department,productDescription,inSale,inStock,color,material
+indexedfields=productName
+
+searchfields=productName
+searchfieldsproportion=1.0
+searchlengthdistribution=zipfian
+maxsearchlength=20
+minsearchlength=3
+
+readproportion=0.10
+searchproportion=0.40
+updateproportion=0.50
+insertproportion=0.0
+scanproportion=0
+readmodifywriteproportion=0
+
+requestdistribution=zipfian
+

--- a/zookeeper/src/main/java/site/ycsb/db/zookeeper/ZKClient.java
+++ b/zookeeper/src/main/java/site/ycsb/db/zookeeper/ZKClient.java
@@ -23,12 +23,7 @@ package site.ycsb.db.zookeeper;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.zookeeper.CreateMode;
@@ -44,6 +39,8 @@ import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,6 +202,22 @@ public class ZKClient extends DB {
       }
     }
     return result;
+  }
+
+  @Override
+  /**
+   * Full text search a record from the database.
+   *
+   * @param table The name of the table
+   * @param queryPair   The search query pair of words.
+   * @param pagePair   The paginated pair info.
+   * @param pagePair   The return fields for the search query.
+   * @hashMaps values A HashMap of field/value pairs of the search result
+   * @return Status.NOT_IMPLEMENTED or the search results
+   * in case the operation is supported.
+   */
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+    return Status.NOT_IMPLEMENTED;
   }
 
   private static class SimpleWatcher implements Watcher {

--- a/zookeeper/src/main/java/site/ycsb/db/zookeeper/ZKClient.java
+++ b/zookeeper/src/main/java/site/ycsb/db/zookeeper/ZKClient.java
@@ -216,7 +216,9 @@ public class ZKClient extends DB {
    * @return Status.NOT_IMPLEMENTED or the search results
    * in case the operation is supported.
    */
-  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale, Pair<Integer, Integer> pagePair, HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
+  public Status search(String table, Pair<String, String> queryPair, boolean onlyinsale,
+       Pair<Integer, Integer> pagePair,
+       HashSet<String> fields, Vector<HashMap<String, ByteIterator>> hashMaps) {
     return Status.NOT_IMPLEMENTED;
   }
 

--- a/zookeeper/src/test/java/site/ycsb/db/zookeeper/ZKClientTest.java
+++ b/zookeeper/src/test/java/site/ycsb/db/zookeeper/ZKClientTest.java
@@ -26,6 +26,8 @@ import org.junit.Ignore;
 import org.junit.Test;
 import site.ycsb.ByteIterator;
 import site.ycsb.Status;
+import org.javatuples.Pair;
+
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
 import site.ycsb.workloads.CoreWorkload;


### PR DESCRIPTION
The following PR introduces a new workload with deterministic random english-words data, and a new operation apart from the CRUD YCSB operations.

# Commerce Workload 
The generated documents for the `commerce` workload have an approximate size of 500B, and have the following schema:
```
{
    "productScore": 0.06580772031001791,
    "image": "https: //pigment.github.io/fake-logos/logos/medium/color/10.png",
    "creator": "Raphael",
    "code": "1591839259749",
    "color": "teal",
    "productName": "OF 12 COLOURED PENCILS ALICEBLUE PACK",
    "inSale": "0",
    "material": "Granite",
    "price": "60.41",
    "inStock": "1",
    "shipsFrom": "nor",
    "department": "Baby   Health",
    "currencyCode": "UAH",
    "brand": "Ryan Group",
    "productDescription": "User-friendly discrete concept",
    "stockCount": "163"
}
```

# Introduced search operation
When we talk about “Search Performance”, it can refer to different kinds of searches as e.g. “match-query search”, “faceted search”, “fuzzy search”, and more. The initial addition of the search workload to YCSB that we’ve done focused solely on the “match-query searches” mimicking a paginated two-word query match, sorted by a numeric field. We believe the “match-query search” is ’s are the starting point for the search analysis on any vendor that enables search capabilities, and consequently, that every YCSB supported DB/driver should be able to easily enable this on their benchmark drivers. In this PR we've included support for MongoDB, ElasticSearch, RedisJSON, and RediSearch drivers.


# Introduced workload variations

We've included several presets for the search/read/update/write variations. We believe the "mixed workloads" are the ones that more resemble the current real-time data architectures.

# Further note
The PRs #1575 , #1576 , #1574 , #1573 , and #1554 ar expected to be reviewed ( and possibly merged ) before this one. This should be the last one.
