### PR TITLE
CVE-2021-45105: Bumping Log4j to 2.17.0 on elasticsearch5, ignite, and voltdb

### DIFF
--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -165,12 +165,12 @@ LICENSE file.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/ignite/pom.xml
+++ b/ignite/pom.xml
@@ -87,13 +87,13 @@ LICENSE file.
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.11.0</version>
+      <version>2.17.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.11.0</version>
+      <version>2.17.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/voltdb/pom.xml
+++ b/voltdb/pom.xml
@@ -44,17 +44,17 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.7</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.7</version>
+			<version>2.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.7</version>
+			<version>2.17.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.voltdb/voltdbclient -->
 		<dependency>


### PR DESCRIPTION
Following up on Security Vulnerability CVE-2021-45105