### PR TITLE
deps: update cloud spanner to 6.17.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ LICENSE file.
     <azurecosmos.version>4.8.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>2.0.1</cloudspanner.version>
+    <cloudspanner.version>6.17.4</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>


### PR DESCRIPTION
Updates to latest cloud spanner library version.

I executed this version against the quickstart (https://github.com/brianfrankcooper/YCSB/tree/master/cloudspanner#running-a-workload) and it worked fine.