### PR TITLE
[spanner] chore: updates spanner client lib to 6.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ LICENSE file.
     <azurecosmos.version>4.8.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>2.0.1</cloudspanner.version>
+    <cloudspanner.version>6.23.1</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>


### PR DESCRIPTION
We were using a very old version of the cloud spanner client libraries. This PR updates to the latest version (6.23.1).