### PR TITLE
Updating Cosmos DB SDK and changing update api

### DIFF
--- a/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
+++ b/azurecosmos/src/main/java/site/ycsb/db/AzureCosmosClient.java
@@ -75,7 +75,6 @@ public class AzureCosmosClient extends DB {
   private static final int DEFAULT_MAX_DEGREE_OF_PARALLELISM = -1;
   private static final int DEFAULT_MAX_BUFFERED_ITEM_COUNT = 0;
   private static final int DEFAULT_PREFERRED_PAGE_SIZE = -1;
-  public static final int NUM_UPDATE_ATTEMPTS = 4;
   private static final boolean DEFAULT_INCLUDE_EXCEPTION_STACK_IN_LOG = false;
   private static final String DEFAULT_USER_AGENT = "azurecosmos-ycsb";
 
@@ -391,7 +390,6 @@ public class AzureCosmosClient extends DB {
    */
   @Override
   public Status update(String table, String key, Map<String, ByteIterator> values) {
-    for (int attempt = 0; attempt < NUM_UPDATE_ATTEMPTS; attempt++) {
       try {
         CosmosContainer container = AzureCosmosClient.containerCache.get(table);
         if (container == null) {
@@ -412,10 +410,7 @@ public class AzureCosmosClient extends DB {
         if (!AzureCosmosClient.includeExceptionStackInLog) {
           e = null;
         }
-        LOGGER.error("Failed to update key {} to collection {} in database {} on attempt {}", key, table,
-            AzureCosmosClient.databaseName, attempt, e);
       }
-    }
 
     return Status.ERROR;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@ LICENSE file.
     <aerospike.version>3.1.2</aerospike.version>
     <arangodb.version>4.4.1</arangodb.version>
     <asynchbase.version>1.8.2</asynchbase.version>
-    <azurecosmos.version>4.8.0</azurecosmos.version>
+    <azurecosmos.version>4.28.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
     <cloudspanner.version>2.0.1</cloudspanner.version>


### PR DESCRIPTION
This PR contains two changes -
1. Moved to latest cosmos sdk 4.28.0
2. Changed the cosmos ycsb update operation to use patch api, earlier it was inefficiently calling two apis for single operation i.e.  read and then replace.