### PR TITLE
[core] Changed the datatype for keynum from integer to long to allow …

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -611,7 +611,7 @@ public class CoreWorkload extends Workload {
    */
   @Override
   public boolean doInsert(DB db, Object threadstate) {
-    int keynum = keysequence.nextValue().intValue();
+    long keynum = keysequence.nextValue().intValue();
     String dbkey = CoreWorkload.buildKeyName(keynum, zeropadding, orderedinserts);
     HashMap<String, ByteIterator> values = buildValues(dbkey);
 


### PR DESCRIPTION
Changed the datatype for keynum from integer to long to allow ycsb to load a larger dataset. Currently, ycsb restricts the number of rows that can be loaded to 2^32 rows.