### PR TITLE
[dynamodb] Allow multiple credentials sources and types

### DIFF
--- a/dynamodb/conf/AWSCredentials.properties
+++ b/dynamodb/conf/AWSCredentials.properties
@@ -17,3 +17,12 @@
 # http://aws.amazon.com/security-credentials
 #accessKey =
 #secretKey =
+
+# The below parameter is optional, it is used for enhanced security, when
+# the machine used for running YCSB can't be trusted with the actual account
+# credentials and temporary credentials were generated using 'aws sts',
+# this parameter should be set to the 'SessionToken' field of the Credentials
+# object returned # from the sts command.
+# for more information:
+# https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html#get-session-token
+#sessionToken =

--- a/dynamodb/conf/dynamodb.properties
+++ b/dynamodb/conf/dynamodb.properties
@@ -18,9 +18,6 @@
 
 ## Mandatory parameters
 
-# AWS credentials associated with your aws account.
-#dynamodb.awsCredentialsFile = <path to AWSCredentials.properties>
-
 # Primarykey of table 'usertable'
 #dynamodb.primaryKey = <firstname>
 
@@ -29,6 +26,11 @@
 #dynamodb.hashKeyName = <hashid>
 
 ## Optional parameters
+
+# AWS credentials associated with your aws account. If it is not provided, the
+# default system credentials will be searched according to the DynamoDB library
+# rules
+#dynamodb.awsCredentialsFile = <path to AWSCredentials.properties>
 
 # The property "primaryKeyType" below specifies the type of primary key
 # you have setup for the test table. There are two choices:


### PR DESCRIPTION
The dynamodb binding was very strict about the credentials, it was mandatory to provide the credentials as a properties files, also, the credentials couldn't be temporary.
This change adds two more options on top of the originally supported credentials:
1. It makes the `dynamodb.awsCredentialsFile` property optional, if this property is not given, the library will search for default credentials according to it's search rules that can be reviewed at: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html
2. It adds one more supported property to the credentials file schema `sessionToken`, this adds the ability to generate and use temporary credentials from `aws sts` command. For more information: https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html#get-session-token

This has been tested against DynamoDB with all 3 methods.

Signed-off-by: Eliran Sinvani <eliransin@scylladb.com>