### PR TITLE
[hbase] add a property to allow for reverse scans

### DIFF
--- a/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
+++ b/hbase1/src/main/java/site/ycsb/db/hbase1/HBaseClient1.java
@@ -93,6 +93,9 @@ public class HBaseClient1 extends site.ycsb.DB {
   /** Whether or not a page filter should be used to limit scan length. */
   private boolean usePageFilter = true;
 
+  /** If scans should be reversed. */
+  private boolean reverseScans = false;
+
   /**
    * If true, buffer mutations on the client. This is the default behavior for
    * HBaseClient. For measuring insert/update/delete latencies, client side
@@ -169,6 +172,9 @@ public class HBaseClient1 extends site.ycsb.DB {
         .equals(getProperties().getProperty("hbase.usepagefilter", "true"))) {
       usePageFilter = false;
     }
+
+    reverseScans = Boolean.parseBoolean(
+        getProperties().getProperty("hbase.reversescans", "false"));
 
     columnFamily = getProperties().getProperty("columnfamily");
     if (columnFamily == null) {
@@ -335,6 +341,8 @@ public class HBaseClient1 extends site.ycsb.DB {
     if (this.usePageFilter) {
       s.setFilter(new PageFilter(recordcount));
     }
+
+    s.setReversed(reverseScans);
 
     // add specified fields or else all fields
     if (fields == null) {

--- a/hbase1/src/test/java/site/ycsb/db/hbase1/HBaseClient1Test.java
+++ b/hbase1/src/test/java/site/ycsb/db/hbase1/HBaseClient1Test.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import site.ycsb.ByteIterator;
+import site.ycsb.Client;
 import site.ycsb.Status;
 import site.ycsb.StringByteIterator;
 import site.ycsb.measurements.Measurements;
@@ -180,6 +181,51 @@ public class HBaseClient1Test {
       final ByteBuffer buf = ByteBuffer.wrap(bytes);
       final int rowNum = buf.getInt();
       assertEquals(i + 1, rowNum);
+    }
+  }
+
+  @Test
+  public void testScanReversed() throws Exception {
+    // Fill with data
+    final String colStr = "row_number";
+    final byte[] col = Bytes.toBytes(colStr);
+    final int n = 10;
+    final List<Put> puts = new ArrayList<Put>(n);
+    for(int i = 0; i < n; i++) {
+      final byte[] key = Bytes.toBytes(String.format("%05d", i));
+      final byte[] value = java.nio.ByteBuffer.allocate(4).putInt(i).array();
+      final Put p = new Put(key);
+      p.addColumn(Bytes.toBytes(COLUMN_FAMILY), col, value);
+      puts.add(p);
+    }
+    table.put(puts);
+
+    Properties p = new Properties();
+    p.setProperty("columnfamily", COLUMN_FAMILY);
+    p.setProperty("hbase.reversescans", "true");
+    HBaseClient1 reversedClient = new HBaseClient1();
+    reversedClient.setProperties(p);
+    reversedClient.init();
+
+    // Test
+    final Vector<HashMap<String, ByteIterator>> result =
+        new Vector<HashMap<String, ByteIterator>>();
+
+    try {
+      reversedClient.scan(tableName, "00008", 5, null, result);
+    } finally {
+      reversedClient.cleanup();
+    }
+
+    assertEquals(5, result.size());
+    int rowNumber = 8;
+    for (HashMap<String, ByteIterator> row : result) {
+      assertEquals(1, row.size());
+      assertTrue(row.containsKey(colStr));
+      final byte[] bytes = row.get(colStr).toArray();
+      final ByteBuffer buf = ByteBuffer.wrap(bytes);
+      final int rowNum = buf.getInt();
+      assertEquals(rowNumber--, rowNum);
     }
   }
 

--- a/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
+++ b/hbase2/src/main/java/site/ycsb/db/hbase2/HBaseClient2.java
@@ -98,6 +98,9 @@ public class HBaseClient2 extends site.ycsb.DB {
   /** Whether or not a page filter should be used to limit scan length. */
   private boolean usePageFilter = true;
 
+  /** If scans should be reversed. */
+  private boolean reverseScans = false;
+
   /**
    * If true, buffer mutations on the client. This is the default behavior for
    * HBaseClient. For measuring insert/update/delete latencies, client side
@@ -183,6 +186,8 @@ public class HBaseClient2 extends site.ycsb.DB {
 
     usePageFilter = isBooleanParamSet("hbase.usepagefilter", usePageFilter);
 
+    reverseScans = Boolean.parseBoolean(
+        getProperties().getProperty("hbase.reversescans", "false"));
 
     if (isBooleanParamSet("hbase.usescanvaluefiltering", false)) {
       useScanValueFiltering=true;
@@ -361,6 +366,8 @@ public class HBaseClient2 extends site.ycsb.DB {
     if (this.usePageFilter) {
       filterList.addFilter(new PageFilter(recordcount));
     }
+
+    s.setReversed(reverseScans);
 
     // add specified fields or else all fields
     if (fields == null) {


### PR DESCRIPTION
This add the property `hbase.reversescans` for both the hbase1 & hbase2 drivers. This will allow endusers to compare performance between forward and reverse scans