### PR TITLE
[cloudspanner] set max sessions

### DIFF
--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -154,6 +154,7 @@ public class CloudSpannerClient extends DB {
     int numThreads = Integer.parseInt(properties.getProperty(Client.THREAD_COUNT_PROPERTY, "1"));
     SpannerOptions.Builder optionsBuilder = SpannerOptions.newBuilder()
         .setSessionPoolOption(SessionPoolOptions.newBuilder()
+            .setMaxSessions(numThreads)
             .setMinSessions(numThreads)
             // Since we have no read-write transactions, we can set the write session fraction to 0.
             .setWriteSessionsFraction(0)


### PR DESCRIPTION
Previously, using the Cloud Spanner client with `threadcount` above 400 would error out with:

```
java.lang.IllegalArgumentException: Min sessions(1024) must be <= max sessions(400)
```

This is because the default max session limit is set to 400. This patch sets the max session limit to the number of threads, to allow using more than 400 threads.