### PR TITLE
change version for Histogram

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,7 @@ LICENSE file.
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.12</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
while using -s parameter running a workload, the low version of Histogram got some errors,  check for the reason is that we using lower verison of Histogram. the newest Histogram has fixed the issue