### PR TITLE
[redis] Adding SSL/TLS support for all Redis environments and password authentication for Redis clusters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright (c) 2012 - 2020 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2023 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -138,7 +138,7 @@ LICENSE file.
     <openjpa.jdbc.version>2.1.1</openjpa.jdbc.version>
     <orientdb.version>2.2.37</orientdb.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <redis.version>2.9.0</redis.version>
+    <jedis.version>4.4.5</jedis.version>
     <riak.version>2.0.5</riak.version>
     <rocksdb.version>6.2.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+Copyright (c) 2012 - 2023 YCSB contributors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you
 may not use this file except in compliance with the License. You
@@ -33,7 +33,7 @@ LICENSE file.
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>${redis.version}</version>
+      <version>${jedis.version}</version>
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>


### PR DESCRIPTION
Hi,

this is Marc from IBM. Not sure where the right place to say "Hello" is, so I will try here. Since I haven't contributed to YCSB yet, let me quickly introduce myself. I am a Java Performance Analyst and work in the IBM Lab in Boeblingen, Germany. Nowadays, I spend most of my time improving the performance of IBM products, but I also have a long history of analyzing and optimizing the performance of customer Java applications. The team that I am currently part of makes heavy use of YCSB for all kinds of benchmarking purposes.

When trying to benchmark Redis on various different server platforms, I noticed that the current version of the Redis binding in YCSB (a) doesn't support **passwords** for Redis clusters and that (b) **SSL/TLS support** is missing for both clustered and non-clustered Redis environments. The patch that I am proposing fixes both (a) and (b).

Please note that I haven't touched the client's data access logic at all. What I mean by this is that all calls into the underlying Jedis library like `hmget()`, `hmset()`, etc. are completely unchanged. I "only" added support for the above mentioned functionality (a) and (b) when initializing the existing `JedisCommands` object called `jedis`, which is used to talk to both clustered and standalone Redis installations.

Since the version numbering of the Redis database and the Jedis client library have diverged quite substantially, I've reflected this in the corresponding `.pom` files: I changed `redis.version` to `jedis.version` in order to make it clear that it's really the Jedis version that is used for building the Redis binding inside of YCSB.

Last but not least, in order to actually connect to an SSL/TLS-enabled Redis cluster, you have to set up a Java keystore and add the following command line arguments to your YCSB command line: `-jvm-args "-Djavax.net.ssl.trustStore=/path/to/your/redis-keystore -Djavax.net.ssl.trustStorePassword=..."`

That's it - looking forward to your comments on this patch!


Cheers,
Marc