### PR TITLE
[rocksdb] update to binding rocksdb v8

### DIFF
--- a/core/src/main/java/site/ycsb/Client.java
+++ b/core/src/main/java/site/ycsb/Client.java
@@ -339,6 +339,7 @@ public final class Client {
       st = System.currentTimeMillis();
 
       for (Thread t : threads.keySet()) {
+        t.setName("rocksdb:Client");
         t.start();
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ LICENSE file.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <redis.version>2.9.0</redis.version>
     <riak.version>2.0.5</riak.version>
-    <rocksdb.version>6.2.2</rocksdb.version>
+    <rocksdb.version>8.3.2</rocksdb.version>
     <s3.version>1.10.20</s3.version>
     <seaweed.client.version>1.4.1</seaweed.client.version>
     <scylla.cql.version>3.10.2-scylla-1</scylla.cql.version>

--- a/rocksdb/build/README.md
+++ b/rocksdb/build/README.md
@@ -1,0 +1,24 @@
+### 1. Set Up YCSB
+
+Build  RocksDB
+
+	make rocksdbjava -j 10 DEBUG_LEVEL=0
+	cp ./java/target/rocksdbjni-8.3.2-linux64.jar ../YCSB/rocksdb/build/
+
+
+Clone the YCSB git repository and compile:
+
+    git clone https://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
+    mvn -pl site.ycsb:rocksdb-binding -am clean package
+
+### 2. Run YCSB
+
+Now you are ready to run! First, load the data:
+
+    ./bin/ycsb load rocksdb -s -P workloads/workloada -p rocksdb.dir=/tmp/ycsb-rocksdb-data
+
+Then, run the workload:
+
+    ./bin/ycsb run rocksdb -s -P workloads/workloada -p rocksdb.dir=/tmp/ycsb-rocksdb-data
+

--- a/rocksdb/build/README.md
+++ b/rocksdb/build/README.md
@@ -8,7 +8,6 @@ Build  RocksDB
 
 Clone the YCSB git repository and compile:
 
-    git clone https://github.com/brianfrankcooper/YCSB.git
     cd YCSB
     mvn -pl site.ycsb:rocksdb-binding -am clean package
 

--- a/rocksdb/pom.xml
+++ b/rocksdb/pom.xml
@@ -60,7 +60,7 @@ LICENSE file.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/rocksdb/pom.xml
+++ b/rocksdb/pom.xml
@@ -34,7 +34,9 @@ LICENSE file.
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
       <version>${rocksdb.version}</version>
-    </dependency>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/build/rocksdbjni-8.3.2-linux64.jar</systemPath>
+  </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>
       <artifactId>core</artifactId>

--- a/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
+++ b/rocksdb/src/main/java/site/ycsb/db/rocksdb/RocksDBClient.java
@@ -102,7 +102,9 @@ public class RocksDBClient extends DB {
     final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
 
     RocksDB.loadLibrary();
-    OptionsUtil.loadOptionsFromFile(optionsFile.toAbsolutePath().toString(), Env.getDefault(), options, cfDescriptors);
+    ConfigOptions configOptions = new ConfigOptions();
+    configOptions.setEnv(Env.getDefault());
+    OptionsUtil.loadOptionsFromFile(configOptions, optionsFile.toAbsolutePath().toString(), options, cfDescriptors);
     dbOptions = options;
 
     final RocksDB db = RocksDB.open(options, rocksDbDir.toAbsolutePath().toString(), cfDescriptors, cfHandles);

--- a/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBOptionsFileTest.java
+++ b/rocksdb/src/test/java/site/ycsb/db/rocksdb/RocksDBOptionsFileTest.java
@@ -58,7 +58,9 @@ public class RocksDBOptionsFileTest {
     final DBOptions dbOptions = new DBOptions();
 
     RocksDB.loadLibrary();
-    OptionsUtil.loadLatestOptions(dbPath, Env.getDefault(), dbOptions, cfDescriptors);
+    ConfigOptions configOptions = new ConfigOptions();
+    configOptions.setEnv(Env.getDefault());
+    OptionsUtil.loadLatestOptions(configOptions, dbPath, dbOptions, cfDescriptors);
 
     try {
       assertEquals(dbOptions.walSizeLimitMB(), 42);


### PR DESCRIPTION
RocksDB was updated to version 8, and as a result, some modifications were made to the Java API. 

Consequently, the existing YCSB code was unable to test RocksDB versions 8.0.0 and above. The following code has been modified to enable testing of RocksDB version 8.0.0 and later.

However, that it is not compatible with versions earlier than 8.0.0. Please be aware of this limitation.