### PR TITLE
[Spanner] chore: Updates spanner client lib to 6.71.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ LICENSE file.
     <azurecosmos.version>4.8.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>2.0.1</cloudspanner.version>
+    <cloudspanner.version>6.71.0</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>


### PR DESCRIPTION
Spanner's client library was outdated. This PR updates the spanner client library version to the latest available version at this point.