### PR TITLE
Refactor Cassandra driver from 3.x to 4.x driver

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -70,8 +70,7 @@ LICENSE file.
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.21</version>
-      <scope>test</scope>
+      <version>1.7.25</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -39,9 +39,20 @@ LICENSE file.
   <dependencies>
     <!-- CQL driver -->
     <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-core</artifactId>
+      <version>${cassandra.cql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-query-builder</artifactId>
+      <version>${cassandra.cql.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
-      <version>${cassandra.cql.version}</version>
+      <version>3.0.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>

--- a/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
+++ b/cassandra/src/main/java/site/ycsb/db/CassandraCQLClient.java
@@ -17,35 +17,34 @@
  */
 package site.ycsb.db;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.ColumnDefinitions;
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.Host;
-import com.datastax.driver.core.HostDistance;
-import com.datastax.driver.core.Metadata;
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Row;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.PreparedStatement;
-import com.datastax.driver.core.BoundStatement;
-import com.datastax.driver.core.querybuilder.Insert;
-import com.datastax.driver.core.querybuilder.QueryBuilder;
-import com.datastax.driver.core.querybuilder.Select;
-import com.datastax.driver.core.querybuilder.Update;
-import com.datastax.driver.core.ExexcutionInfo;
-import com.datastax.driver.core.QueryTrace;
+import com.datastax.oss.driver.api.core.ConsistencyLevel;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.*;
+import com.datastax.oss.driver.api.core.cql.*;
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.querybuilder.delete.Delete;
+import com.datastax.oss.driver.api.querybuilder.insert.InsertInto;
+import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
+import com.datastax.oss.driver.api.querybuilder.relation.Relation;
+import com.datastax.oss.driver.api.querybuilder.select.Select;
+import com.datastax.oss.driver.api.querybuilder.update.Assignment;
+import com.datastax.oss.driver.api.querybuilder.update.Update;
+import com.datastax.oss.driver.api.querybuilder.update.UpdateStart;
 import site.ycsb.ByteArrayByteIterator;
 import site.ycsb.ByteIterator;
 import site.ycsb.DB;
 import site.ycsb.DBException;
 import site.ycsb.Status;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,58 +61,34 @@ public class CassandraCQLClient extends DB {
 
   private static Logger logger = LoggerFactory.getLogger(CassandraCQLClient.class);
 
-  private static Cluster cluster = null;
-  private static Session session = null;
+  private static CqlSession session = null;
+  private static DriverExecutionProfile readProfile = null;
+  private static DriverExecutionProfile scanProfile = null;
+  private static DriverExecutionProfile insertProfile = null;
+  private static DriverExecutionProfile updateProfile = null;
+  private static DriverExecutionProfile deleteProfile = null;
 
-  private static ConcurrentMap<Set<String>, PreparedStatement> readStmts =
-      new ConcurrentHashMap<Set<String>, PreparedStatement>();
-  private static ConcurrentMap<Set<String>, PreparedStatement> scanStmts =
-      new ConcurrentHashMap<Set<String>, PreparedStatement>();
-  private static ConcurrentMap<Set<String>, PreparedStatement> insertStmts =
-      new ConcurrentHashMap<Set<String>, PreparedStatement>();
-  private static ConcurrentMap<Set<String>, PreparedStatement> updateStmts =
-      new ConcurrentHashMap<Set<String>, PreparedStatement>();
-  private static AtomicReference<PreparedStatement> readAllStmt =
-      new AtomicReference<PreparedStatement>();
-  private static AtomicReference<PreparedStatement> scanAllStmt =
-      new AtomicReference<PreparedStatement>();
-  private static AtomicReference<PreparedStatement> deleteStmt =
-      new AtomicReference<PreparedStatement>();
+  private static ConcurrentMap<Set<String>, PreparedStatement> readStmts = new ConcurrentHashMap<>();
+  private static ConcurrentMap<Set<String>, PreparedStatement> scanStmts = new ConcurrentHashMap<>();
+  private static ConcurrentMap<Set<String>, PreparedStatement> insertStmts = new ConcurrentHashMap<>();
+  private static ConcurrentMap<Set<String>, PreparedStatement> updateStmts = new ConcurrentHashMap<>();
+  private static AtomicReference<PreparedStatement> readAllStmt = new AtomicReference<>();
+  private static AtomicReference<PreparedStatement> scanAllStmt = new AtomicReference<>();
+  private static AtomicReference<PreparedStatement> deleteStmt = new AtomicReference<>();
 
   private static ConsistencyLevel readConsistencyLevel = ConsistencyLevel.QUORUM;
   private static ConsistencyLevel writeConsistencyLevel = ConsistencyLevel.QUORUM;
 
   public static final String YCSB_KEY = "y_id";
-  public static final String KEYSPACE_PROPERTY = "cassandra.keyspace";
-  public static final String KEYSPACE_PROPERTY_DEFAULT = "ycsb";
-  public static final String USERNAME_PROPERTY = "cassandra.username";
-  public static final String PASSWORD_PROPERTY = "cassandra.password";
 
-  public static final String HOSTS_PROPERTY = "hosts";
-  public static final String PORT_PROPERTY = "port";
-  public static final String PORT_PROPERTY_DEFAULT = "9042";
-
-  public static final String READ_CONSISTENCY_LEVEL_PROPERTY =
-      "cassandra.readconsistencylevel";
-  public static final String READ_CONSISTENCY_LEVEL_PROPERTY_DEFAULT = readConsistencyLevel.name();
-  public static final String WRITE_CONSISTENCY_LEVEL_PROPERTY =
-      "cassandra.writeconsistencylevel";
-  public static final String WRITE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT = writeConsistencyLevel.name();
-
-  public static final String MAX_CONNECTIONS_PROPERTY =
-      "cassandra.maxconnections";
-  public static final String CORE_CONNECTIONS_PROPERTY =
-      "cassandra.coreconnections";
-  public static final String CONNECT_TIMEOUT_MILLIS_PROPERTY =
-      "cassandra.connecttimeoutmillis";
-  public static final String READ_TIMEOUT_MILLIS_PROPERTY =
-      "cassandra.readtimeoutmillis";
-
+  public static final String DRIVER_CONFIG_PROPERTY = "cassandra.driverconfig";
+  public static final String DRIVER_PROFILE_READ_PROPERTY = "cassandra.driverprofile.read";
+  public static final String DRIVER_PROFILE_INSERT_PROPERTY = "cassandra.driverprofile.insert";
+  public static final String DRIVER_PROFILE_SCAN_PROPERTY = "cassandra.driverprofile.scan";
+  public static final String DRIVER_PROFILE_DELETE_PROPERTY = "cassandra.driverprofile.delete";
+  public static final String DRIVER_PROFILE_UPDATE_PROPERTY = "cassandra.driverprofile.update";
   public static final String TRACING_PROPERTY = "cassandra.tracing";
   public static final String TRACING_PROPERTY_DEFAULT = "false";
-
-  public static final String USE_SSL_CONNECTION = "cassandra.useSSL";
-  private static final String DEFAULT_USE_SSL_CONNECTION = "false";
 
   /**
    * Count the number of times initialized to teardown on the last
@@ -121,8 +96,6 @@ public class CassandraCQLClient extends DB {
    */
   private static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
   private static final AtomicInteger TRACE_COUNT = new AtomicInteger(0);
-  private static boolean debug = false;
-
   private static boolean trace = false;
   
   /**
@@ -131,104 +104,36 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public void init() throws DBException {
-
     // Keep track of number of calls to init (for later cleanup)
     INIT_COUNT.incrementAndGet();
-
     // Synchronized so that we only have a single
     // cluster/session instance for all the threads.
     synchronized (INIT_COUNT) {
-
       // Check if the cluster has already been initialized
-      if (cluster != null) {
+      if (session != null) {
         return;
       }
-
       try {
-
-        debug =
-            Boolean.parseBoolean(getProperties().getProperty("debug", "false"));
-        trace = Boolean.valueOf(getProperties().getProperty(TRACING_PROPERTY, TRACING_PROPERTY_DEFAULT));
-
-        String host = getProperties().getProperty(HOSTS_PROPERTY);
-        if (host == null) {
-          throw new DBException(String.format(
-              "Required property \"%s\" missing for CassandraCQLClient",
-              HOSTS_PROPERTY));
+        trace = Boolean.parseBoolean(getProperties().getProperty(TRACING_PROPERTY, TRACING_PROPERTY_DEFAULT));
+        String driverConfigPath = getProperties().getProperty(DRIVER_CONFIG_PROPERTY);
+        if (driverConfigPath == null) {
+          throw new IllegalArgumentException("Missing required driver config file path set via: '"
+              + DRIVER_CONFIG_PROPERTY + "'");
         }
-        String[] hosts = host.split(",");
-        String port = getProperties().getProperty(PORT_PROPERTY, PORT_PROPERTY_DEFAULT);
-
-        String username = getProperties().getProperty(USERNAME_PROPERTY);
-        String password = getProperties().getProperty(PASSWORD_PROPERTY);
-
-        String keyspace = getProperties().getProperty(KEYSPACE_PROPERTY,
-            KEYSPACE_PROPERTY_DEFAULT);
-
-        readConsistencyLevel = ConsistencyLevel.valueOf(
-            getProperties().getProperty(READ_CONSISTENCY_LEVEL_PROPERTY,
-                READ_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
-        writeConsistencyLevel = ConsistencyLevel.valueOf(
-            getProperties().getProperty(WRITE_CONSISTENCY_LEVEL_PROPERTY,
-                WRITE_CONSISTENCY_LEVEL_PROPERTY_DEFAULT));
-
-        Boolean useSSL = Boolean.parseBoolean(getProperties().getProperty(USE_SSL_CONNECTION,
-            DEFAULT_USE_SSL_CONNECTION));
-
-        if ((username != null) && !username.isEmpty()) {
-          Cluster.Builder clusterBuilder = Cluster.builder().withCredentials(username, password)
-              .withPort(Integer.valueOf(port)).addContactPoints(hosts);
-          if (useSSL) {
-            clusterBuilder = clusterBuilder.withSSL();
-          } 
-          cluster = clusterBuilder.build();
-        } else {
-          cluster = Cluster.builder().withPort(Integer.valueOf(port))
-              .addContactPoints(hosts).build();
-        }
-
-        String maxConnections = getProperties().getProperty(
-            MAX_CONNECTIONS_PROPERTY);
-        if (maxConnections != null) {
-          cluster.getConfiguration().getPoolingOptions()
-              .setMaxConnectionsPerHost(HostDistance.LOCAL,
-              Integer.valueOf(maxConnections));
-        }
-
-        String coreConnections = getProperties().getProperty(
-            CORE_CONNECTIONS_PROPERTY);
-        if (coreConnections != null) {
-          cluster.getConfiguration().getPoolingOptions()
-              .setCoreConnectionsPerHost(HostDistance.LOCAL,
-              Integer.valueOf(coreConnections));
-        }
-
-        String connectTimoutMillis = getProperties().getProperty(
-            CONNECT_TIMEOUT_MILLIS_PROPERTY);
-        if (connectTimoutMillis != null) {
-          cluster.getConfiguration().getSocketOptions()
-              .setConnectTimeoutMillis(Integer.valueOf(connectTimoutMillis));
-        }
-
-        String readTimoutMillis = getProperties().getProperty(
-            READ_TIMEOUT_MILLIS_PROPERTY);
-        if (readTimoutMillis != null) {
-          cluster.getConfiguration().getSocketOptions()
-              .setReadTimeoutMillis(Integer.valueOf(readTimoutMillis));
-        }
-
-        Metadata metadata = cluster.getMetadata();
-        logger.info("Connected to cluster: {}\n",
-            metadata.getClusterName());
-
-        for (Host discoveredHost : metadata.getAllHosts()) {
-          logger.info("Datacenter: {}; Host: {}; Rack: {}\n",
-              discoveredHost.getDatacenter(), discoveredHost.getAddress(),
-              discoveredHost.getRack());
-        }
-
-        session = cluster.connect(keyspace);
-
+        File driverConfigFile = new File(driverConfigPath);
+        DriverConfigLoader configLoader = DriverConfigLoader.fromFile(driverConfigFile);
+        DriverConfig driverConfig = configLoader.getInitialConfig();
+        Function<String, DriverExecutionProfile> profileSupplier = (String profile) -> profile == null
+            ? driverConfig.getDefaultProfile()
+            : driverConfig.getProfile(profile);
+        readProfile = profileSupplier.apply(getProperties().getProperty(DRIVER_PROFILE_READ_PROPERTY));
+        scanProfile = profileSupplier.apply(getProperties().getProperty(DRIVER_PROFILE_SCAN_PROPERTY));
+        insertProfile = profileSupplier.apply(getProperties().getProperty(DRIVER_PROFILE_INSERT_PROPERTY));
+        updateProfile = profileSupplier.apply(getProperties().getProperty(DRIVER_PROFILE_UPDATE_PROPERTY));
+        deleteProfile = profileSupplier.apply(getProperties().getProperty(DRIVER_PROFILE_DELETE_PROPERTY));
+        session = CqlSession.builder()
+            .withConfigLoader(DriverConfigLoader.fromFile(driverConfigFile))
+            .build();
       } catch (Exception e) {
         throw new DBException(e);
       }
@@ -252,8 +157,6 @@ public class CassandraCQLClient extends DB {
         scanAllStmt.set(null);
         deleteStmt.set(null);
         session.close();
-        cluster.close();
-        cluster = null;
         session = null;
       }
       if (curInitCount < 0) {
@@ -283,60 +186,46 @@ public class CassandraCQLClient extends DB {
       Map<String, ByteIterator> result) {
     try {
       PreparedStatement stmt = (fields == null) ? readAllStmt.get() : readStmts.get(fields);
-
       // Prepare statement on demand
       if (stmt == null) {
-        Select.Builder selectBuilder;
-
+        Select select;
         if (fields == null) {
-          selectBuilder = QueryBuilder.select().all();
+          select = QueryBuilder.selectFrom(table).all();
         } else {
-          selectBuilder = QueryBuilder.select();
-          for (String col : fields) {
-            ((Select.Selection) selectBuilder).column(col);
-          }
+          select = QueryBuilder.selectFrom(table).columns(fields);
         }
-
-        stmt = session.prepare(selectBuilder.from(table)
-                               .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker()))
-                               .limit(1));
-        stmt.setConsistencyLevel(readConsistencyLevel);
-        if (trace) {
-          stmt.enableTracing();
-        }
-
+        SimpleStatement simpleStatement = select.where(Relation.column(YCSB_KEY).isEqualTo(QueryBuilder.bindMarker()))
+            .limit(1)
+            .build()
+            .setConsistencyLevel(readConsistencyLevel)
+            .setTracing(trace)
+            .setExecutionProfile(readProfile);
+        stmt = session.prepare(simpleStatement);
         PreparedStatement prevStmt = (fields == null) ?
                                      readAllStmt.getAndSet(stmt) :
-                                     readStmts.putIfAbsent(new HashSet(fields), stmt);
+                                     readStmts.putIfAbsent(new HashSet<>(fields), stmt);
         if (prevStmt != null) {
           stmt = prevStmt;
         }
       }
-
-      logger.debug(stmt.getQueryString());
+      logger.debug(stmt.getQuery());
       logger.debug("key = {}", key);
-
       ResultSet rs = session.execute(stmt.bind(key));
-
-      if (rs.isExhausted()) {
-        return Status.NOT_FOUND;
-      }
-
       // Should be only 1 row
       Row row = rs.one();
+      if (row == null) {
+        return Status.NOT_FOUND;
+      }
       ColumnDefinitions cd = row.getColumnDefinitions();
-
-      for (ColumnDefinitions.Definition def : cd) {
-        ByteBuffer val = row.getBytesUnsafe(def.getName());
+      for (final ColumnDefinition def : cd) {
+        ByteBuffer val = row.getBytesUnsafe(def.getName().toString());
         if (val != null) {
-          result.put(def.getName(), new ByteArrayByteIterator(val.array()));
+          result.put(def.getName().toString(), new ByteArrayByteIterator(val.array()));
         } else {
-          result.put(def.getName(), null);
+          result.put(def.getName().toString(), null);
         }
       }
-
       return Status.OK;
-
     } catch (Exception e) {
       logger.error(MessageFormatter.format("Error reading key: {}", key).getMessage(), e);
       return Status.ERROR;
@@ -370,99 +259,75 @@ public class CassandraCQLClient extends DB {
 
     try {
       PreparedStatement stmt = (fields == null) ? scanAllStmt.get() : scanStmts.get(fields);
-
       // Prepare statement on demand
       if (stmt == null) {
-        Select.Builder selectBuilder;
-
+        Select select;
         if (fields == null) {
-          selectBuilder = QueryBuilder.select().all();
+          select = QueryBuilder.selectFrom(table).all();
         } else {
-          selectBuilder = QueryBuilder.select();
-          for (String col : fields) {
-            ((Select.Selection) selectBuilder).column(col);
-          }
+          select = QueryBuilder.selectFrom(table).columns(fields);
         }
-
-        Select selectStmt = selectBuilder.from(table);
-
-        // The statement builder is not setup right for tokens.
-        // So, we need to build it manually.
-        String initialStmt = selectStmt.toString();
-        StringBuilder scanStmt = new StringBuilder();
-        scanStmt.append(initialStmt.substring(0, initialStmt.length() - 1));
-        scanStmt.append(" WHERE ");
-        scanStmt.append(QueryBuilder.token(YCSB_KEY));
-        scanStmt.append(" >= ");
-        scanStmt.append("token(");
-        scanStmt.append(QueryBuilder.bindMarker());
-        scanStmt.append(")");
-        scanStmt.append(" LIMIT ");
-        scanStmt.append(QueryBuilder.bindMarker());
-
-        stmt = session.prepare(scanStmt.toString());
-        stmt.setConsistencyLevel(readConsistencyLevel);
-        if (trace) {
-          stmt.enableTracing();
-        }
-
-        PreparedStatement prevStmt = (fields == null) ?
+        SimpleStatement simpleStatement = select.where(Relation.token(YCSB_KEY)
+                .isGreaterThanOrEqualTo(QueryBuilder.function(
+                    "token",
+                    QueryBuilder.bindMarker()
+                ))
+            ).limit(QueryBuilder.bindMarker())
+            .build()
+            .setConsistencyLevel(readConsistencyLevel)
+            .setTracing(trace)
+            .setExecutionProfile(scanProfile);
+        stmt = session.prepare(simpleStatement);
+        final PreparedStatement prevStmt = (fields == null) ?
                                      scanAllStmt.getAndSet(stmt) :
-                                     scanStmts.putIfAbsent(new HashSet(fields), stmt);
+                                     scanStmts.putIfAbsent(new HashSet<>(fields), stmt);
         if (prevStmt != null) {
           stmt = prevStmt;
         }
       }
-
-      logger.debug(stmt.getQueryString());
-      logger.debug("startKey = {}, recordcount = {}", startkey, recordcount);
-
-      ResultSet rs = session.execute(stmt.bind(startkey, Integer.valueOf(recordcount)));
+      logger.debug(stmt.getQuery());
+      logger.debug("startKey = {}, record count = {}", startkey, recordcount);
+      ResultSet rs = session.execute(stmt.bind(startkey, recordcount));
       if (trace) {
-        final int count = TRACE_COUNT.getAndIncrement();
+        int count = TRACE_COUNT.getAndIncrement();
         if (count % 5 == 0) {
-          final ExecutionInfo executionInfo = rs.getExecutionInfo();
-          final UUID tracingId = executionInfo.getTracingId();
-          final QueryTrace qtrace = executionInfo.getQueryTrace();
-          System.out.printf(
-              "[%s] '%s' to %s took %dμs%n",
+          ExecutionInfo executionInfo = rs.getExecutionInfo();
+          UUID tracingId = executionInfo.getTracingId();
+          QueryTrace qtrace = executionInfo.getQueryTrace();
+          logger.info(
+              "[{}] '{}' to {} took {}μs",
               tracingId,
               qtrace.getRequestType(),
-              qtrace.getCoordinator(),
+              qtrace.getCoordinatorAddress(),
               qtrace.getDurationMicros()
           );
           for (final TraceEvent event : qtrace.getEvents()) {
-            System.out.printf(
-                "  %d - %s - %s%n",
+            logger.info(
+                " - [{}] {} :: {}",
                 event.getSourceElapsedMicros(),
-                event.getSource(),
+                event.getThreadName(),
                 event.getActivity()
             );
           }
         }
       }
-
       HashMap<String, ByteIterator> tuple;
-      while (!rs.isExhausted()) {
-        Row row = rs.one();
-        tuple = new HashMap<String, ByteIterator>();
-
+      Row row;
+      while ((row = rs.one()) != null) {
+        tuple = new HashMap<>();
         ColumnDefinitions cd = row.getColumnDefinitions();
-
-        for (ColumnDefinitions.Definition def : cd) {
-          ByteBuffer val = row.getBytesUnsafe(def.getName());
+        for (ColumnDefinition def : cd) {
+          String name = def.getName().toString();
+          ByteBuffer val = row.getBytesUnsafe(name);
           if (val != null) {
-            tuple.put(def.getName(), new ByteArrayByteIterator(val.array()));
+            tuple.put(name, new ByteArrayByteIterator(val.array()));
           } else {
-            tuple.put(def.getName(), null);
+            tuple.put(name, null);
           }
         }
-
         result.add(tuple);
       }
-
       return Status.OK;
-
     } catch (Exception e) {
       logger.error(
           MessageFormatter.format("Error scanning with startkey: {}", startkey).getMessage(), e);
@@ -493,53 +358,51 @@ public class CassandraCQLClient extends DB {
 
       // Prepare statement on demand
       if (stmt == null) {
-        Update updateStmt = QueryBuilder.update(table);
-
+        UpdateStart updateStmt = QueryBuilder.update(table);
         // Add fields
-        for (String field : fields) {
-          updateStmt.with(QueryBuilder.set(field, QueryBuilder.bindMarker()));
-        }
-
-        // Add key
-        updateStmt.where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker()));
-
-        stmt = session.prepare(updateStmt);
-        stmt.setConsistencyLevel(writeConsistencyLevel);
-        if (trace) {
-          stmt.enableTracing();
-        }
-
-        PreparedStatement prevStmt = updateStmts.putIfAbsent(new HashSet(fields), stmt);
+        List<Assignment> assignments = fields.stream()
+            .map((final String field) -> Assignment.setColumn(field, QueryBuilder.bindMarker()))
+            .collect(Collectors.toList());
+        // Add keying
+        Update update = updateStmt.set(assignments)
+            .where(Relation.column(YCSB_KEY).isEqualTo(QueryBuilder.bindMarker()));
+        SimpleStatement simpleStatement = update.build()
+            .setConsistencyLevel(writeConsistencyLevel)
+            .setTracing(trace)
+            .setExecutionProfile(updateProfile);
+        stmt = session.prepare(simpleStatement);
+        PreparedStatement prevStmt = updateStmts.putIfAbsent(new HashSet<>(fields), stmt);
         if (prevStmt != null) {
           stmt = prevStmt;
         }
       }
-
       if (logger.isDebugEnabled()) {
-        logger.debug(stmt.getQueryString());
+        logger.debug(stmt.getQuery());
         logger.debug("key = {}", key);
         for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
           logger.debug("{} = {}", entry.getKey(), entry.getValue());
         }
       }
-
       // Add fields
-      ColumnDefinitions vars = stmt.getVariables();
+      ColumnDefinitions vars = stmt.getVariableDefinitions();
       BoundStatement boundStmt = stmt.bind();
       for (int i = 0; i < vars.size() - 1; i++) {
-        boundStmt.setString(i, values.get(vars.getName(i)).toString());
+        boundStmt = boundStmt.setString(
+            i,
+            values.get(
+                vars.get(i)
+                    .getName()
+                    .toString()
+            ).toString()
+        );
       }
-
       // Add key
-      boundStmt.setString(vars.size() - 1, key);
-
+      boundStmt = boundStmt.setString(vars.size() - 1, key);
       session.execute(boundStmt);
-
       return Status.OK;
     } catch (Exception e) {
       logger.error(MessageFormatter.format("Error updating key: {}", key).getMessage(), e);
     }
-
     return Status.ERROR;
   }
 
@@ -558,59 +421,54 @@ public class CassandraCQLClient extends DB {
    */
   @Override
   public Status insert(String table, String key, Map<String, ByteIterator> values) {
-
     try {
       Set<String> fields = values.keySet();
       PreparedStatement stmt = insertStmts.get(fields);
-
       // Prepare statement on demand
       if (stmt == null) {
-        Insert insertStmt = QueryBuilder.insertInto(table);
-
+        InsertInto insertStmt = QueryBuilder.insertInto(table);
         // Add key
-        insertStmt.value(YCSB_KEY, QueryBuilder.bindMarker());
-
-        // Add fields
-        for (String field : fields) {
-          insertStmt.value(field, QueryBuilder.bindMarker());
-        }
-
-        stmt = session.prepare(insertStmt);
-        stmt.setConsistencyLevel(writeConsistencyLevel);
-        if (trace) {
-          stmt.enableTracing();
-        }
-
-        PreparedStatement prevStmt = insertStmts.putIfAbsent(new HashSet(fields), stmt);
+        RegularInsert regularInsert = insertStmt.value(YCSB_KEY, QueryBuilder.bindMarker())
+            .values(fields.stream().collect(Collectors.toMap(
+                Function.identity(),
+                (String ignored) -> QueryBuilder.bindMarker()
+            )));
+        SimpleStatement simpleStatement = regularInsert.build()
+            .setConsistencyLevel(writeConsistencyLevel)
+            .setTracing(trace)
+            .setExecutionProfile(insertProfile);
+        stmt = session.prepare(simpleStatement);
+        PreparedStatement prevStmt = insertStmts.putIfAbsent(new HashSet<>(fields), stmt);
         if (prevStmt != null) {
           stmt = prevStmt;
         }
       }
-
       if (logger.isDebugEnabled()) {
-        logger.debug(stmt.getQueryString());
+        logger.debug(stmt.getQuery());
         logger.debug("key = {}", key);
         for (Map.Entry<String, ByteIterator> entry : values.entrySet()) {
           logger.debug("{} = {}", entry.getKey(), entry.getValue());
         }
       }
-
       // Add key
       BoundStatement boundStmt = stmt.bind().setString(0, key);
-
       // Add fields
-      ColumnDefinitions vars = stmt.getVariables();
+      ColumnDefinitions vars = stmt.getVariableDefinitions();
       for (int i = 1; i < vars.size(); i++) {
-        boundStmt.setString(i, values.get(vars.getName(i)).toString());
+        boundStmt = boundStmt.setString(
+            i,
+            values.get(
+                vars.get(i)
+                    .getName()
+                    .toString()
+            ).toString()
+        );
       }
-
       session.execute(boundStmt);
-
       return Status.OK;
     } catch (Exception e) {
       logger.error(MessageFormatter.format("Error inserting key: {}", key).getMessage(), e);
     }
-
     return Status.ERROR;
   }
 
@@ -628,32 +486,27 @@ public class CassandraCQLClient extends DB {
 
     try {
       PreparedStatement stmt = deleteStmt.get();
-
       // Prepare statement on demand
       if (stmt == null) {
-        stmt = session.prepare(QueryBuilder.delete().from(table)
-                               .where(QueryBuilder.eq(YCSB_KEY, QueryBuilder.bindMarker())));
-        stmt.setConsistencyLevel(writeConsistencyLevel);
-        if (trace) {
-          stmt.enableTracing();
-        }
-
+        Delete delete = QueryBuilder.deleteFrom(table)
+            .where(Relation.column(YCSB_KEY).isEqualTo(QueryBuilder.bindMarker()));
+        stmt = session.prepare(delete.build()
+            .setConsistencyLevel(writeConsistencyLevel)
+            .setTracing(trace)
+            .setExecutionProfile(deleteProfile)
+        );
         PreparedStatement prevStmt = deleteStmt.getAndSet(stmt);
         if (prevStmt != null) {
           stmt = prevStmt;
         }
       }
-
-      logger.debug(stmt.getQueryString());
+      logger.debug(stmt.getQuery());
       logger.debug("key = {}", key);
-
       session.execute(stmt.bind(key));
-
       return Status.OK;
     } catch (Exception e) {
       logger.error(MessageFormatter.format("Error deleting key: {}", key).getMessage(), e);
     }
-
     return Status.ERROR;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,16 @@ LICENSE file.
     </developer>
   </developers>
 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Maven Repository Switchboard</name>
+      <url>http://repo1.maven.org/maven2</url>
+    </repository>
+  </repositories>
   <scm>
     <connection>scm:git:git://github.com/brianfrankcooper/YCSB.git</connection>
     <tag>master</tag>
@@ -117,7 +127,7 @@ LICENSE file.
     <asynchbase.version>1.8.2</asynchbase.version>
     <azurecosmos.version>4.8.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
-    <cassandra.cql.version>3.0.0</cassandra.cql.version>
+    <cassandra.cql.version>4.17.0</cassandra.cql.version>
     <cloudspanner.version>6.71.0</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>


### PR DESCRIPTION
# Changelog
* Upgraded Datastax driver from 3.0.0 to 4.17 (latest at time of post)
* Added tracing output controls and frequency
* Moved to direct driver config via HOCON config file.
* Removed duplicate configuration parameters that are now covered in the HOCON config
* Added parameters to allow for driver profiles to be used on each operation type
* Removed string based query formatting for token operations instead using query builder with functions

# TODO
* [ ] Rework test suites
* [ ] Support tracing output on all operations not just scans