### PR TITLE
fix(cloudspanner): fix ProtoLiteUtils ClassNotFound issue at run time

### DIFF
--- a/cloudspanner/pom.xml
+++ b/cloudspanner/pom.xml
@@ -61,4 +61,32 @@ LICENSE file.
     </dependency>
 
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Add shaded maven plugin to resolve conflicts for spanner

<img width="1725" alt="Screenshot 2024-07-17 at 5 08 20 PM" src="https://github.com/user-attachments/assets/92c898e5-538d-4c86-b058-b0b0c9e2cf69">

