### PR TITLE
upgrade hdrhistogram to support newer jdk versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,7 @@ LICENSE file.
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.4</version>
+      <version>2.1.12</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
fixes #1480

As per https://github.com/HdrHistogram/HdrHistogram/issues/175, versions prior 2.1.10 dont work with newer jdks.