### PR TITLE
googlebigtable2: Update cell version handling

### DIFF
--- a/googlebigtable2/README.md
+++ b/googlebigtable2/README.md
@@ -84,4 +84,4 @@ The following options can be configured using CLI (using the `-p` parameter).
 * `googlebigtable2.use-batching`: (Optional) Whether or not to use client side buffering and batching of write operations. This can significantly improve performance and defaults to true.
 * `googlebigtable2..max-outstanding-bytes`: (Optional) When batching is enabled, override the limit of number of outstanding mutation bytes.
 * `googlebigtable2.reverse-scans`: (Optional) When enabled, scan start keys will be treated as end keys
-* * `googlebigtable2.timestamp`: (Optional) When set, the timestamp will be used for all mutations, avoiding unbounded growth of cell versions.
+* `googlebigtable2.timestamp`: (Optional) When set, the timestamp will be used for all mutations, avoiding unbounded growth of cell versions.

--- a/googlebigtable2/README.md
+++ b/googlebigtable2/README.md
@@ -39,7 +39,7 @@ PROJECT=<PROJECT_ID>
 INSTANCE=<INSTANCE>
 FAMILY=cf
 SPLITS=$(echo 'num_splits = 200; puts (1..num_splits).map {|i| "user#{1000+i*(9999-1000)/num_splits}"}.join(",")' | ruby)
-cbt -project $PROJECT -instance=$INSTANCE createtable usertable families=$FAMILY splits=$SPLITS
+cbt -project $PROJECT -instance=$INSTANCE createtable usertable families=$FAMILY:maxversions=1 splits=$SPLITS
 ```
 
 Make a note of the column family, in this example it's `cf``.

--- a/googlebigtable2/README.md
+++ b/googlebigtable2/README.md
@@ -84,3 +84,4 @@ The following options can be configured using CLI (using the `-p` parameter).
 * `googlebigtable2.use-batching`: (Optional) Whether or not to use client side buffering and batching of write operations. This can significantly improve performance and defaults to true.
 * `googlebigtable2..max-outstanding-bytes`: (Optional) When batching is enabled, override the limit of number of outstanding mutation bytes.
 * `googlebigtable2.reverse-scans`: (Optional) When enabled, scan start keys will be treated as end keys
+* * `googlebigtable2.timestamp`: (Optional) When set, the timestamp will be used for all mutations, avoiding unbounded growth of cell versions.


### PR DESCRIPTION
* update reads to read the latest cell version to align with hbase behavior
* add ability to specify a fixed timestamp to avoid unbounded growth of cell versions