### PR TITLE
Adding a modern redis module to enable authentication by username and password

### DIFF
--- a/bin/bindings.properties
+++ b/bin/bindings.properties
@@ -65,6 +65,7 @@ orientdb:site.ycsb.db.OrientDBClient
 postgrenosql:site.ycsb.postgrenosql.PostgreNoSQLDBClient
 rados:site.ycsb.db.RadosClient
 redis:site.ycsb.db.RedisClient
+redis5:site.ycsb.db.RedisClient
 rest:site.ycsb.webservice.rest.RestClient
 riak:site.ycsb.db.riak.RiakKVClient
 rocksdb:site.ycsb.db.rocksdb.RocksDBClient

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -97,6 +97,7 @@ DATABASES = {
     "postgrenosql" : "site.ycsb.postgrenosql.PostgreNoSQLDBClient",
     "rados"        : "site.ycsb.db.RadosClient",
     "redis"        : "site.ycsb.db.RedisClient",
+    "redis5"       : "site.ycsb.db.redis5.RedisClient",
     "rest"         : "site.ycsb.webservice.rest.RestClient",
     "riak"         : "site.ycsb.db.riak.RiakKVClient",
     "rocksdb"      : "site.ycsb.db.rocksdb.RocksDBClient",

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -211,6 +211,11 @@ LICENSE file.
     </dependency>
     <dependency>
       <groupId>site.ycsb</groupId>
+      <artifactId>redis5-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
       <artifactId>rest-binding</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@ LICENSE file.
     <module>postgrenosql</module>
     <module>rados</module>
     <module>redis</module>
+    <module>redis5</module>
     <module>rest</module>
     <module>riak</module>
     <module>rocksdb</module>

--- a/redis5/README.md
+++ b/redis5/README.md
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2014 - 2015 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+## Quick Start
+
+This section describes how to run YCSB on Redis. 
+
+### 1. Start Redis
+
+### 2. Install Java and Maven
+
+### 3. Set Up YCSB
+
+Git clone YCSB and compile:
+
+    git clone http://github.com/brianfrankcooper/YCSB.git
+    cd YCSB
+    mvn -pl site.ycsb:redis5-binding -am clean package
+
+### 4. Provide Redis Connection Parameters
+    
+Set host, port, password, and cluster mode in the workload you plan to run. 
+
+- `redis.host`
+- `redis.port`
+- `redis.username`
+  * Dont set the username if redis auth is only password based or disabled.
+- `redis.password`
+  * Don't set the password if redis auth is disabled.
+- `redis.cluster`
+  * Set the cluster parameter to `true` if redis cluster mode is enabled.
+  * Default is `false`.
+
+Or, you can set configs with the shell command, EG:
+
+    ./bin/ycsb load redis5 -s -P workloads/workloada -p "redis.host=127.0.0.1" -p "redis.port=6379" > outputLoad.txt
+
+### 5. Load data and run tests
+
+Load the data:
+
+    ./bin/ycsb load redis5 -s -P workloads/workloada > outputLoad.txt
+
+Run the workload test:
+
+    ./bin/ycsb run redis5 -s -P workloads/workloada > outputRun.txt
+

--- a/redis5/pom.xml
+++ b/redis5/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+Copyright (c) 2012 - 2016 YCSB contributors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you
+may not use this file except in compliance with the License. You
+may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License. See accompanying
+LICENSE file.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>site.ycsb</groupId>
+    <artifactId>binding-parent</artifactId>
+    <version>0.18.0-SNAPSHOT</version>
+    <relativePath>../binding-parent</relativePath>
+  </parent>
+  
+  <artifactId>redis5-binding</artifactId>
+  <name>Redis 5+ DB Binding</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>5.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>site.ycsb</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/redis5/src/main/java/site/ycsb/db/redis5/RedisClient.java
+++ b/redis5/src/main/java/site/ycsb/db/redis5/RedisClient.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2025 YCSB Contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * Redis client binding for YCSB.
+ *
+ * All YCSB records are mapped to a Redis *hash field*.  For scanning
+ * operations, all keys are saved (by an arbitrary hash) in a sorted set.
+ */
+
+package site.ycsb.db.redis5;
+
+import site.ycsb.ByteIterator;
+import site.ycsb.DB;
+import site.ycsb.DBException;
+import site.ycsb.Status;
+import site.ycsb.StringByteIterator;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.commands.JedisCommands;
+import redis.clients.jedis.Protocol;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.Vector;
+
+/**
+ * YCSB binding for a more modern <a href="http://redis.io/">Redis</a>.
+ *
+ * See {@code redis5/README.md} for details.
+ */
+public class RedisClient extends DB {
+
+  private JedisCommands jedis;
+
+  public static final String HOST_PROPERTY = "redis.host";
+  public static final String PORT_PROPERTY = "redis.port";
+  public static final String USERNAME_PROPERTY = "redis.username";
+  public static final String PASSWORD_PROPERTY = "redis.password";
+  public static final String CLUSTER_PROPERTY = "redis.cluster";
+  public static final String TIMEOUT_PROPERTY = "redis.timeout";
+
+  public static final String INDEX_KEY = "_indices";
+
+  public void init() throws DBException {
+    Properties props = getProperties();
+    int port;
+
+    String portString = props.getProperty(PORT_PROPERTY);
+    if (portString != null) {
+      port = Integer.parseInt(portString);
+    } else {
+      port = Protocol.DEFAULT_PORT;
+    }
+    String host = props.getProperty(HOST_PROPERTY);
+    String password = props.getProperty(PASSWORD_PROPERTY);
+    String username = props.getProperty(USERNAME_PROPERTY);
+
+    boolean clusterEnabled = Boolean.parseBoolean(props.getProperty(CLUSTER_PROPERTY));
+    if (clusterEnabled) {
+      Set<HostAndPort> jedisClusterNodes = new HashSet<>();
+      jedisClusterNodes.add(new HostAndPort(host, port));
+      if (username != null && password != null) {
+        jedis = new JedisCluster(jedisClusterNodes, username, password);
+      } else {
+        jedis = new JedisCluster(jedisClusterNodes);
+      }
+    } else {
+      String redisTimeout = props.getProperty(TIMEOUT_PROPERTY);
+      if (redisTimeout != null){
+        jedis = new Jedis(host, port, Integer.parseInt(redisTimeout));
+      } else {
+        jedis = new Jedis(host, port);
+      }
+      ((Jedis) jedis).connect();
+
+      if (username != null && password != null) {
+        ((Jedis) jedis).auth(username, password);
+      } else if (password != null) {
+        ((Jedis) jedis).auth(password);
+      }
+    }
+  }
+
+  public void cleanup() throws DBException {
+    try {
+      ((Closeable) jedis).close();
+    } catch (IOException e) {
+      throw new DBException("Closing connection failed.");
+    }
+  }
+
+  /*
+   * Calculate a hash for a key to store it in an index. The actual return value
+   * of this function is not interesting -- it primarily needs to be fast and
+   * scattered along the whole space of doubles. In a real world scenario one
+   * would probably use the ASCII values of the keys.
+   */
+  private double hash(String key) {
+    return key.hashCode();
+  }
+
+  // XXX jedis.select(int index) to switch to `table`
+
+  @Override
+  public Status read(String table, String key, Set<String> fields,
+      Map<String, ByteIterator> result) {
+    if (fields == null) {
+      StringByteIterator.putAllAsByteIterators(result, jedis.hgetAll(key));
+    } else {
+      String[] fieldArray =
+          (String[]) fields.toArray(new String[fields.size()]);
+      List<String> values = jedis.hmget(key, fieldArray);
+
+      Iterator<String> fieldIterator = fields.iterator();
+      Iterator<String> valueIterator = values.iterator();
+
+      while (fieldIterator.hasNext() && valueIterator.hasNext()) {
+        result.put(fieldIterator.next(),
+            new StringByteIterator(valueIterator.next()));
+      }
+      assert !fieldIterator.hasNext() && !valueIterator.hasNext();
+    }
+    return result.isEmpty() ? Status.ERROR : Status.OK;
+  }
+
+  @Override
+  public Status insert(String table, String key,
+      Map<String, ByteIterator> values) {
+    if (jedis.hmset(key, StringByteIterator.getStringMap(values))
+        .equals("OK")) {
+      jedis.zadd(INDEX_KEY, hash(key), key);
+      return Status.OK;
+    }
+    return Status.ERROR;
+  }
+
+  @Override
+  public Status delete(String table, String key) {
+    return jedis.del(key) == 0 && jedis.zrem(INDEX_KEY, key) == 0 ? Status.ERROR
+        : Status.OK;
+  }
+
+  @Override
+  public Status update(String table, String key,
+      Map<String, ByteIterator> values) {
+    return jedis.hmset(key, StringByteIterator.getStringMap(values))
+        .equals("OK") ? Status.OK : Status.ERROR;
+  }
+
+  @Override
+  public Status scan(String table, String startkey, int recordcount,
+      Set<String> fields, Vector<HashMap<String, ByteIterator>> result) {
+    Set<String> keys = new HashSet<String>(jedis.zrangeByScore(INDEX_KEY, hash(startkey),
+        Double.POSITIVE_INFINITY, 0, recordcount));
+
+    HashMap<String, ByteIterator> values;
+    for (String key : keys) {
+      values = new HashMap<String, ByteIterator>();
+      read(table, key, fields, values);
+      result.add(values);
+    }
+
+    return Status.OK;
+  }
+
+}

--- a/redis5/src/main/java/site/ycsb/db/redis5/package-info.java
+++ b/redis5/src/main/java/site/ycsb/db/redis5/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 YCSB Contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License. See accompanying
+ * LICENSE file.
+ */
+
+/**
+ * The YCSB binding for <a href="http://redis.io/">Redis</a>.
+ */
+package site.ycsb.db.redis5;
+


### PR DESCRIPTION
This pull request is to fix the issue #1750 .

I followed the elasticsearch module example and made a sister module with an upgraded jedis dependency.
I added a username and password authentication support.
It was tested against a local redis container with this authentication enabled.