### PR TITLE
Add support for running YCSB with the experimental Host.

### DIFF
--- a/cloudspanner/README.md
+++ b/cloudspanner/README.md
@@ -87,7 +87,7 @@ If you wish to load a large database, you can run YCSB on multiple client VMs in
 * Split the key range evenly between client VMs;
 * Use few threads on each client VM, so that each individual commit request contains keys which are (close to) consecutive, and would thus likely address a single split; this also helps avoid overloading the servers.
 
-The idea is that we have a number of 'write heads' which are all writing to different parts of the database (and thus talking to different servers), but each individual head is writing its own data (more or less) in order. See the [best practices page](https://cloud.google.com/spanner/docs/best-practices#loading_data) for further details.
+The idea is that we have a number of 'write heads' which are all writing to different parts of the database (and thus talking to different servers), but each individual head is writing its own data (more or less) in order. See the [best practices page](https://cloud.google.com/spanner/docs/bulk-loading) for further details.
 
 ### 6. Run a Workload
 

--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -189,11 +189,6 @@ public class CloudSpannerClient extends DB {
       optionsBuilder.setCredentials(NoCredentials.getInstance());
       //Disable build in client native metrics when connecting to experimental host.
       optionsBuilder.setBuiltInMetricsEnabled(false);
-      // Experimental host uses Multiplexed sessions, so dial down the session pool.
-      optionsBuilder.setSessionPoolOption(SessionPoolOptions.newBuilder()
-            .setMinSessions(0)
-            .setMaxSessions(0)
-            .build());
     }
 
     spanner = optionsBuilder.build().getService();

--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -17,6 +17,7 @@
 package site.ycsb.db.cloudspanner;
 
 import com.google.common.base.Joiner;
+import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Key;
@@ -32,6 +33,7 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.StructReader;
 import com.google.cloud.spanner.TimestampBound;
+import io.grpc.ManagedChannelBuilder;
 import site.ycsb.ByteIterator;
 import site.ycsb.Client;
 import site.ycsb.DB;
@@ -100,6 +102,15 @@ public class CloudSpannerClient extends DB {
      * Number of Cloud Spanner client channels to use. It's recommended to leave this to be the default value.
      */
     static final String NUM_CHANNELS = "cloudspanner.channels";
+    /**
+     * Use plain text for communication.
+     */
+    static final String USE_PLAINTEXT = "cloudspanner.useplaintext";
+    
+    /**
+     * Connect to Experimental host instead of cloud spanner API.
+     */
+    static final String EXPERIMENTAL_HOST="cloudspanner.experimentalhost";    
   }
 
   private static int fieldCount;
@@ -167,6 +178,24 @@ public class CloudSpannerClient extends DB {
     if (numChannels != null) {
       optionsBuilder.setNumChannels(Integer.parseInt(numChannels));
     }
+    boolean usePlaintext = Boolean.parseBoolean(properties.getProperty(CloudSpannerProperties.USE_PLAINTEXT));
+    if (usePlaintext) {
+      optionsBuilder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
+    }
+    String experimentalHost = properties.getProperty(CloudSpannerProperties.EXPERIMENTAL_HOST);
+    if (experimentalHost != null) {
+      optionsBuilder.setExperimentalHost(experimentalHost);
+      //Disable IAM credentials for experimental Host.
+      optionsBuilder.setCredentials(NoCredentials.getInstance());
+      //Disable build in client native metrics when connecting to experimental host.
+      optionsBuilder.setBuiltInMetricsEnabled(false);
+      // Experimental host uses Multiplexed sessions, so dial down the session pool.
+      optionsBuilder.setSessionPoolOption(SessionPoolOptions.newBuilder()
+            .setMinSessions(0)
+            .setMaxSessions(0)
+            .build());
+    }
+
     spanner = optionsBuilder.build().getService();
     Runtime.getRuntime().addShutdownHook(new Thread("spannerShutdown") {
         @Override

--- a/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
+++ b/cloudspanner/src/main/java/site/ycsb/db/cloudspanner/CloudSpannerClient.java
@@ -181,14 +181,13 @@ public class CloudSpannerClient extends DB {
     boolean usePlaintext = Boolean.parseBoolean(properties.getProperty(CloudSpannerProperties.USE_PLAINTEXT));
     if (usePlaintext) {
       optionsBuilder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
+      //Disable credentials and built in metrics when plaintext is used.
+      optionsBuilder.setCredentials(NoCredentials.getInstance());
+      optionsBuilder.setBuiltInMetricsEnabled(false);
     }
     String experimentalHost = properties.getProperty(CloudSpannerProperties.EXPERIMENTAL_HOST);
     if (experimentalHost != null) {
       optionsBuilder.setExperimentalHost(experimentalHost);
-      //Disable IAM credentials for experimental Host.
-      optionsBuilder.setCredentials(NoCredentials.getInstance());
-      //Disable build in client native metrics when connecting to experimental host.
-      optionsBuilder.setBuiltInMetricsEnabled(false);
     }
 
     spanner = optionsBuilder.build().getService();

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ LICENSE file.
     <azurecosmos.version>4.8.0</azurecosmos.version>
     <azurestorage.version>4.0.0</azurestorage.version>
     <cassandra.cql.version>3.0.0</cassandra.cql.version>
-    <cloudspanner.version>6.71.0</cloudspanner.version>
+    <cloudspanner.version>6.91.1</cloudspanner.version>
     <couchbase.version>1.4.10</couchbase.version>
 		<couchbase2.version>2.3.1</couchbase2.version>
 		<crail.version>1.1-incubating</crail.version>


### PR DESCRIPTION
It also adds option to use plainText communication. It is useful especially when running with experimental host. 
This change also upgrades YCSB to use latest version of cloud spanner java client.