### PR TITLE
Add gRPC as default transport layer for google datastore binding

### DIFF
--- a/googledatastore/README.md
+++ b/googledatastore/README.md
@@ -92,6 +92,10 @@ group of the Google Datastore.
 While in this mode, one can optionally specify a root key name. If not
 specified, a default name will be used.
 
+## Enable grpc transport for benchmarking
+By default, benchmarking tests will use gRPC transport unless `googledatastore.useGrpc` is set to false.
+Additionally, you can specify a channel provider by setting `googledatastore.useChannelProvider` to true.
+
 ## Enable tracing for benchmarking
  To enable publishing traces to Google Cloud Trace while running benchmarking tests, `googledatastore.tracingenabled` must be set.
  Tracing depends on the following external APIs/Services:

--- a/googledatastore/pom.xml
+++ b/googledatastore/pom.xml
@@ -35,12 +35,12 @@ LICENSE file.
     <dependency>
       <groupId>com.google.cloud.datastore</groupId>
       <artifactId>datastore-v1-proto-client</artifactId>
-      <version>2.24.2</version>
+      <version>2.31.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>2.24.2</version>
+      <version>2.31.0</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>

--- a/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
@@ -19,10 +19,16 @@ package site.ycsb.db;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.gax.grpc.ChannelPoolSettings;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.datastore.*;
 import com.google.cloud.datastore.Entity;
+import com.google.cloud.datastore.v1.DatastoreSettings;
+import com.google.cloud.grpc.GrpcTransportOptions;
+import com.google.datastore.v1.*;
 import com.google.datastore.v1.ReadOptions.ReadConsistency;
 import com.google.datastore.v1.client.DatastoreHelper;
+import com.google.datastore.v1.Value;
 import com.google.cloud.datastore.Datastore;
 import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.opentelemetry.trace.TraceExporter;
@@ -133,13 +139,20 @@ public class GoogleDatastoreClient extends DB {
     }
     String datasetId = getProperties().getProperty(
         "googledatastore.datasetId", null);
+
+    boolean usegRPC = Boolean.parseBoolean(getProperties().getProperty(
+        "googledatastore.usegRPC", "true"));
+    logger.info("usegRPC:" + usegRPC);
+    boolean useChannelProvider = Boolean.parseBoolean(getProperties().getProperty(
+        "googledatastore.useChannelProvider", "true"));
+    logger.info("useChannelProvider:" + useChannelProvider);
+
     String privateKeyFile = getProperties().getProperty(
         "googledatastore.privateKeyFile", null);
     String serviceAccountEmail = getProperties().getProperty(
         "googledatastore.serviceAccountEmail", null);
 
     // Below are properties related to benchmarking.
-
     String readConsistencyConfig = getProperties().getProperty(
         "googledatastore.readConsistency", null);
     if (readConsistencyConfig != null) {
@@ -212,6 +225,17 @@ public class GoogleDatastoreClient extends DB {
                   .build());
       if (datasetId != null) {
         datastoreOptionsBuilder.setDatabaseId(datasetId);
+      }
+
+      if (usegRPC) {
+        if (useChannelProvider) {
+          InstantiatingGrpcChannelProvider channelProvider = DatastoreSettings
+              .defaultGrpcTransportProviderBuilder()
+              .setChannelPoolSettings(ChannelPoolSettings.builder()
+                  .build()).build();
+          datastoreOptionsBuilder.setChannelProvider(channelProvider);
+        }
+        datastoreOptionsBuilder.setTransportOptions(GrpcTransportOptions.newBuilder().build());
       }
 
       DatastoreOptions datastoreOptions = datastoreOptionsBuilder.build();
@@ -406,4 +430,3 @@ public class GoogleDatastoreClient extends DB {
     return Status.OK;
   }
 }
- 

--- a/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
+++ b/googledatastore/src/main/java/site/ycsb/db/GoogleDatastoreClient.java
@@ -142,10 +142,10 @@ public class GoogleDatastoreClient extends DB {
 
     boolean usegRPC = Boolean.parseBoolean(getProperties().getProperty(
         "googledatastore.usegRPC", "true"));
-    logger.info("usegRPC:" + usegRPC);
+    logger.info("Using gRPC transport:" + usegRPC);
     boolean useChannelProvider = Boolean.parseBoolean(getProperties().getProperty(
         "googledatastore.useChannelProvider", "true"));
-    logger.info("useChannelProvider:" + useChannelProvider);
+    logger.info("Using gRPC ChannelProvider:" + useChannelProvider);
 
     String privateKeyFile = getProperties().getProperty(
         "googledatastore.privateKeyFile", null);


### PR DESCRIPTION
1. Adding gRPC as default transport layer for benchmarking tests.
2. Update readme for gRPC enablement.