### PR TITLE
Add gRPC as default transport layer for google datastore binding

### DIFF
--- a/googledatastore/README.md
+++ b/googledatastore/README.md
@@ -92,6 +92,10 @@ group of the Google Datastore.
 While in this mode, one can optionally specify a root key name. If not
 specified, a default name will be used.
 
+## Enable grpc transport for benchmarking
+By default, benchmarking tests will use gRPC transport unless `googledatastore.useGrpc` is set to false.
+Additionally, you can specify a channel provider by setting `googledatastore.useChannelProvider` to true.
+
 ## Enable tracing for benchmarking
  To enable publishing traces to Google Cloud Trace while running benchmarking tests, `googledatastore.tracingenabled` must be set.
  Tracing depends on the following external APIs/Services:

--- a/googledatastore/pom.xml
+++ b/googledatastore/pom.xml
@@ -35,12 +35,12 @@ LICENSE file.
     <dependency>
       <groupId>com.google.cloud.datastore</groupId>
       <artifactId>datastore-v1-proto-client</artifactId>
-      <version>2.24.2</version>
+      <version>2.31.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-datastore</artifactId>
-      <version>2.24.2</version>
+      <version>2.31.0</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
This PR is a copy of https://github.com/brianfrankcooper/YCSB/pull/1766.

Description from https://github.com/brianfrankcooper/YCSB/pull/1766:
1. Adding gRPC as default transport layer for benchmarking tests.
2. Update readme for gRPC enablement.