### PR TITLE
[core] Fix issue where recordcount in the workload is limited to max …

### DIFF
--- a/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
+++ b/core/src/main/java/site/ycsb/workloads/CoreWorkload.java
@@ -448,7 +448,7 @@ public class CoreWorkload extends Workload {
     long insertstart =
         Long.parseLong(p.getProperty(INSERT_START_PROPERTY, INSERT_START_PROPERTY_DEFAULT));
     long insertcount=
-        Integer.parseInt(p.getProperty(INSERT_COUNT_PROPERTY, String.valueOf(recordcount - insertstart)));
+        Long.parseLong(p.getProperty(INSERT_COUNT_PROPERTY, String.valueOf(recordcount - insertstart)));
     // Confirm valid values for insertstart and insertcount in relation to recordcount
     if (recordcount < (insertstart + insertcount)) {
       System.err.println("Invalid combination of insertstart, insertcount and recordcount.");


### PR DESCRIPTION
recordcount is limited to max integer value because the CoreWorkload.init routine is using Integer.parseInt.  Change the code to use Long.parseLong instead.